### PR TITLE
Completed AssetSizeCss check

### DIFF
--- a/.changeset/plenty-candles-appear.md
+++ b/.changeset/plenty-candles-appear.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+'@shopify/theme-check-browser': minor
+'@shopify/theme-check-docs-updater': minor
+---
+
+Add `AssetSizeCSS` check

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@shopify/prettier-plugin-liquid": "^1.2.1",
+    "cross-fetch": "^4.0.0",
     "json-to-ast": "^2.1.0",
     "line-column": "^1.0.2",
     "lodash.set": "^4.3.2",

--- a/packages/theme-check-common/src/checks/asset-size-css/index.spec.ts
+++ b/packages/theme-check-common/src/checks/asset-size-css/index.spec.ts
@@ -1,0 +1,179 @@
+import { expect, describe, it } from 'vitest';
+import { AssetSizeCSS } from '.';
+import { check, MockTheme } from '../../test';
+import { SchemaProp } from '../../types';
+
+describe('Module: AssetSizeCSS', () => {
+  const extensionFiles: MockTheme = {
+    'assets/theme.css': '* { color: green !important; }',
+    'templates/index.liquid': `
+      <html>
+        <head>
+          <link href="{{ 'theme.css' | asset_url }}" rel="stylesheet">
+        </head>
+      </html>
+    `,
+  };
+
+  const httpTest: MockTheme = {
+    'templates/index.liquid': `
+      <html>
+        <head>
+          <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+        </head>
+      </html>
+    `,
+  };
+
+  it('should not report any offenses if CSS is smaller than threshold', async () => {
+    const offenses = await check(extensionFiles, [AssetSizeCSS]);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should skip the check if context.fileSize is undefined', async () => {
+    const context = {
+      fileSize: undefined,
+    };
+
+    const offenses = await check(extensionFiles, [AssetSizeCSS], context);
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should report an offense if CSS is larger than threshold', async () => {
+    const CustomAssetSizeCSS = {
+      ...AssetSizeCSS,
+      meta: {
+        ...AssetSizeCSS.meta,
+        schema: {
+          thresholdInBytes: SchemaProp.number(1),
+        },
+      },
+    };
+
+    const offenses = await check(extensionFiles, [CustomAssetSizeCSS]);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0]).toMatchObject({
+      message: 'The CSS file size exceeds the threshold of 1 bytes',
+      absolutePath: '/templates/index.liquid',
+      start: { index: 51 },
+      end: { index: 80 },
+    });
+  });
+
+  it('should report an offense if the CSS file does not exist', async () => {
+    const extensionFiles: MockTheme = {
+      'templates/index.liquid': `
+        <html>
+          <head>
+            <link href="{{ 'nonexistent.css' | asset_url }}" rel="stylesheet">
+          </head>
+        </html>
+      `,
+    };
+
+    const offenses = await check(extensionFiles, [AssetSizeCSS]);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0]).toMatchObject({
+      message: `'nonexistent.css' does not exist.`,
+      absolutePath: '/templates/index.liquid',
+      start: { index: 57 },
+      end: { index: 92 },
+    });
+  });
+
+  it('should report a warning when the CSS file size exceeds the threshold', async () => {
+    const CustomAssetSizeCSS = {
+      ...AssetSizeCSS,
+      meta: {
+        ...AssetSizeCSS.meta,
+        schema: {
+          thresholdInBytes: SchemaProp.number(1),
+        },
+      },
+    };
+    const offenses = await check(httpTest, [CustomAssetSizeCSS]);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0]).toMatchObject({
+      message: 'The CSS file size exceeds the threshold of 1 bytes',
+      absolutePath: '/templates/index.liquid',
+      start: { index: 51 },
+      end: { index: 122 },
+    });
+  });
+  it('should not report any offenses if CSS is smaller than threshold', async () => {
+    const extensionFiles: MockTheme = {
+      'assets/theme.css': 'console.log("hello world");',
+      'templates/index.liquid': `
+        <html>
+          <head>
+            {{ 'theme.css' | asset_url | stylesheet_tag }}
+            {{ "https://example.com" | stylesheet_tag }}
+          </head>
+        </html>
+      `,
+    };
+
+    const offenses = await check(extensionFiles, [AssetSizeCSS]);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should report an offense if CSS is larger than threshold', async () => {
+    const extensionFiles: MockTheme = {
+      'assets/theme.css': 'console.log("hello world");',
+      'templates/index.liquid': `
+        <html>
+          <head>
+            {{ 'theme.css' | asset_url | stylesheet_tag }}
+            {{ "https://example.com" | stylesheet_tag }}
+          </head>
+        </html>
+      `,
+    };
+
+    const CustomAssetSizeCSS = {
+      ...AssetSizeCSS,
+      meta: {
+        ...AssetSizeCSS.meta,
+        schema: {
+          thresholdInBytes: SchemaProp.number(2),
+        },
+      },
+    };
+
+    const offenses = await check(extensionFiles, [CustomAssetSizeCSS]);
+
+    expect(offenses).toHaveLength(2);
+    expect(offenses[0]).toMatchObject({
+      message: 'The CSS file size exceeds the threshold of 2 bytes',
+      absolutePath: '/templates/index.liquid',
+      start: { index: 48 },
+      end: { index: 89 },
+    });
+    expect(offenses[1]).toMatchObject({
+      message: 'The CSS file size exceeds the threshold of 2 bytes',
+      absolutePath: '/templates/index.liquid',
+      start: { index: 107 },
+      end: { index: 128 },
+    });
+  });
+
+  it('should not report any offenses if there is no stylesheet', async () => {
+    const extensionFiles: MockTheme = {
+      'templates/index.liquid': `
+        <html>
+          <head>
+          </head>
+        </html>
+      `,
+    };
+
+    const offenses = await check(extensionFiles, [AssetSizeCSS]);
+
+    expect(offenses).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/asset-size-css/index.ts
+++ b/packages/theme-check-common/src/checks/asset-size-css/index.ts
@@ -1,0 +1,177 @@
+import {
+  LiquidHtmlNodeTypes as NodeTypes,
+  LiquidHtmlNodeOfType as NodeOfType,
+  Severity,
+  SourceCodeType,
+  LiquidCheckDefinition,
+  SchemaProp,
+  LiquidHtmlNode,
+} from '../../types';
+import {
+  isAttr,
+  isValuedHtmlAttribute,
+  isNodeOfType,
+  ValuedHtmlAttribute,
+  valueIncludes,
+} from '../utils';
+import { assertFileExists, assertFileSize, getFileSize } from '../../utils/file-utils';
+import { last } from '../../utils';
+import { LiquidDrop, TextNode } from '@shopify/prettier-plugin-liquid/dist/parser/stage-2-ast';
+
+type LiquidVariable = NodeOfType<NodeTypes.LiquidVariable>;
+
+const schema = {
+  thresholdInBytes: SchemaProp.number(100000),
+};
+
+function isTextNode(node: LiquidHtmlNode): node is TextNode {
+  return node.type === NodeTypes.TextNode;
+}
+
+function isLiquidDrop(node: LiquidHtmlNode): node is LiquidDrop {
+  return node.type === NodeTypes.LiquidDrop;
+}
+
+function isLiquidVariable(node: LiquidHtmlNode | string): node is LiquidVariable {
+  return typeof node !== 'string' && node.type === NodeTypes.LiquidVariable;
+}
+
+function isString(node: LiquidHtmlNode): node is NodeOfType<NodeTypes.String> {
+  return node.type === NodeTypes.String;
+}
+
+export const AssetSizeCSS: LiquidCheckDefinition = {
+  meta: {
+    code: 'AssetSizeCSS',
+    name: 'Prevent Large CSS bundles',
+    docs: {
+      description: 'This check is aimed at preventing large CSS bundles for speed.',
+      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/asset-size-css',
+      recommended: true,
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema,
+    targets: [],
+  },
+
+  create(context) {
+    if (!context.fileSize) {
+      return {};
+    }
+
+    const thresholdInBytes = context.settings.thresholdInBytes;
+
+    async function checkRemoteAssetSize(url: string, position: { start: number; end: number }) {
+      const fileSize = await getFileSize(url);
+      if (fileSize && fileSize > thresholdInBytes) {
+        context.report({
+          message: `The CSS file size exceeds the threshold of ${thresholdInBytes} bytes`,
+          startIndex: position.start,
+          endIndex: position.end,
+        });
+        return;
+      }
+    }
+
+    async function checkThemeAssetSize(
+      hrefValue: string,
+      position: { start: number; end: number },
+    ) {
+      const absolutePath = `assets/${hrefValue}`;
+      const fileExists = await assertFileExists(context, absolutePath);
+
+      if (!fileExists) {
+        context.report({
+          message: `'${hrefValue}' does not exist.`,
+          startIndex: position.start,
+          endIndex: position.end,
+        });
+        return;
+      }
+
+      const fileExceedsThreshold = await assertFileSize(context, absolutePath, thresholdInBytes);
+
+      if (fileExceedsThreshold) {
+        context.report({
+          message: `The CSS file size exceeds the threshold of ${thresholdInBytes} bytes`,
+          startIndex: position.start,
+          endIndex: position.end,
+        });
+        return;
+      }
+    }
+
+    return {
+      async HtmlVoidElement(node) {
+        if (node.name !== 'link') return;
+
+        const relIsStylesheet = node.attributes
+          .filter(isValuedHtmlAttribute)
+          .find((attr) => isAttr(attr, 'rel') && valueIncludes(attr, 'stylesheet'));
+        if (!relIsStylesheet) return;
+
+        const href: ValuedHtmlAttribute | undefined = node.attributes
+          .filter(isValuedHtmlAttribute)
+          .find((attr) => isAttr(attr, 'href'));
+        if (!href) return;
+        if (href.value.length !== 1) return;
+
+        /* This ensures that the link entered is a text and not anything else like http//..{} 
+           This also checks if the value starts with 'http://', 'https://' or '//' to ensure its a valid link. */
+        if (isTextNode(href.value[0]) && /(https?:)?\/\//.test(href.value[0].value)) {
+          const url = href.value[0].value;
+          await checkRemoteAssetSize(url, href.attributePosition);
+        }
+
+        /* This code checks if we have a link with a liquid variable
+        and that its a string with one filter, `asset_url`. This is done to ensure our .css link is 
+        entered with a 'asset_url' to produce valid output. */
+        if (
+          isLiquidDrop(href.value[0]) &&
+          isLiquidVariable(href.value[0].markup) &&
+          isString(href.value[0].markup.expression) &&
+          href.value[0].markup.filters.length === 1 &&
+          href.value[0].markup.filters[0].name === 'asset_url'
+        ) {
+          const assetName = href.value[0].markup.expression.value;
+          await checkThemeAssetSize(assetName, href.attributePosition);
+        }
+      },
+
+      async LiquidFilter(node, ancestors) {
+        if (node.name !== 'stylesheet_tag') return;
+
+        const liquidVariableParent = last(ancestors);
+
+        if (!liquidVariableParent || !isNodeOfType(NodeTypes.LiquidVariable, liquidVariableParent))
+          return;
+
+        if (liquidVariableParent.expression.type !== NodeTypes.String) return;
+
+        /* This code ensures we have a liquid variable with 1 expression, 1 filter, and that it is a valid http link.
+           This is done to ensure a valid http link is entered with 1 filter being the `stylesheet_tag` for valid output. */
+        if (
+          liquidVariableParent.expression.value[0].length == 1 &&
+          liquidVariableParent.filters.length == 1 &&
+          /(https?:)?\/\//.test(liquidVariableParent.expression.value)
+        ) {
+          const url = liquidVariableParent.expression.value;
+          await checkRemoteAssetSize(url, liquidVariableParent.expression.position);
+        }
+
+        /* This code ensures we have a liquid variable with 1 expression, 2 filters being asset_url and stylesheet_tag
+           This is done to ensure a .css file has the 'asset_url' and 'stylesheet_tag' to produce the appropriate output. */
+        if (
+          liquidVariableParent.expression.value[0].length == 1 &&
+          liquidVariableParent.filters.length == 2 &&
+          liquidVariableParent.filters[0].name === 'asset_url' &&
+          liquidVariableParent.filters[1].name === 'stylesheet_tag'
+        ) {
+          const css = liquidVariableParent.expression.value;
+          await checkThemeAssetSize(css, liquidVariableParent.position);
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -28,12 +28,14 @@ import { ValidSchema } from './valid-schema';
 import { ContentForHeaderModification } from './content-for-header-modification';
 import { AssetSizeAppBlockCSS } from './asset-size-app-block-css';
 import { AssetSizeAppBlockJavaScript } from './asset-size-app-block-javascript';
+import { AssetSizeCSS } from './asset-size-css';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
   AssetPreload,
   AssetSizeAppBlockCSS,
   AssetSizeAppBlockJavaScript,
+  AssetSizeCSS,
   AssetUrlFilters,
   CdnPreconnect,
   ContentForHeaderModification,

--- a/packages/theme-check-common/src/utils/file-utils.ts
+++ b/packages/theme-check-common/src/utils/file-utils.ts
@@ -1,4 +1,5 @@
 import { Context, SourceCodeType, Schema, RelativePath } from '../types';
+import { fetch } from 'cross-fetch';
 
 export async function assertFileExists<T extends SourceCodeType, S extends Schema>(
   context: Context<T, S>,
@@ -17,4 +18,20 @@ export async function assertFileSize<T extends SourceCodeType, S extends Schema>
   const fileSize = await context.fileSize!(absolutePath);
   if (fileSize <= thresholdInBytes) return false;
   return true;
+}
+
+export async function getFileSize(url: string): Promise<number> {
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const fileSize = response.headers.get('Content-Length');
+    if (fileSize === null) return 0;
+    return parseFloat(fileSize);
+  } catch (error) {
+    return 0;
+  }
 }

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -17,6 +17,10 @@ AssetSizeAppBlockJavaScript:
   enabled: true
   severity: 1
   thresholdInBytes: 10000
+AssetSizeCSS:
+  enabled: true
+  severity: 1
+  thresholdInBytes: 100000
 AssetUrlFilters:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -14,6 +14,10 @@ AssetSizeAppBlockJavaScript:
   enabled: true
   severity: 1
   thresholdInBytes: 10000
+AssetSizeCSS:
+  enabled: true
+  severity: 1
+  thresholdInBytes: 100000
 AssetUrlFilters:
   enabled: true
   severity: 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,6 +1847,13 @@ cross-env@^7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
+cross-fetch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
+  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3833,6 +3840,13 @@ node-fetch@^2.6.11:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
   integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
Resolves: https://github.com/Shopify/theme-check-js/issues/41
# What are you adding in this PR?

This PR 

This PR is adding 2 checks. The first being the `asset_size_css_stylesheet_tag` check and the second `asset_size_css`. We decided to merge them two together, as in the ruby implementation they required two separate parsers, but for theme check we can just have different function calls to act as separate parsers in the same file. 

<!-- Outline follow up tasks with links to issues so they're tracked. -->

Next I am working on [`assetSizeJavascript`](https://github.com/Shopify/theme-check-js/issues/44). This check will use similar function calls to the assetSizeCss check, so I will move those functions in their own stand alone file. I did not include that check in this PR as it would've been too long.

# TopHat Screenshots:
I changed the threshold in bytes to 1 to tophat. This is not included in final implementation.

### TopHat of local fileSize check.
<img width="827" alt="Screenshot 2023-08-31 at 10 40 34 AM" src="https://github.com/Shopify/theme-tools/assets/90271670/9549cacb-dd99-4b5f-9242-09c512f776dd">


### TopHat of url fileSize check using `fetch`.
<img width="840" alt="Screenshot 2023-08-31 at 10 53 28 AM" src="https://github.com/Shopify/theme-tools/assets/90271670/ab5e47c8-b0d8-464f-8e26-9b04d3baac21">


<!-- If a checklist is not applicable, you can delete it. -->

<!-- Include this check when updating anything within packages/theme-check-* -->


- [x] This PR includes a new checks
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn update-configs` and committed the updated configuration files
