### PR TITLE
Added a `DeprecatedTags` check

### DIFF
--- a/.changeset/serious-apples-give.md
+++ b/.changeset/serious-apples-give.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+'@shopify/theme-check-browser': minor
+'@shopify/theme-check-docs-updater': minor
+---
+
+Add `DeprecatedTags` check

--- a/packages/theme-check-common/src/checks/deprecated-tags/index.spec.ts
+++ b/packages/theme-check-common/src/checks/deprecated-tags/index.spec.ts
@@ -1,0 +1,68 @@
+import { expect, describe, it } from 'vitest';
+import { highlightedOffenses, runLiquidCheck } from '../../test';
+import { DeprecatedTags } from './index';
+
+describe('Module: DeprecatedTags', () => {
+  it('should report an offense when include tag is used', async () => {
+    const sourceCode = `
+      {% include 'templates/foo.liquid' %}
+    `;
+    const offenses = await runLiquidCheck(DeprecatedTags, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual(`Use the 'render' tag instead of 'include'`);
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual(['include']);
+  });
+
+  it('should not report an offense when render tag is used', async () => {
+    const sourceCode = `
+      {% render 'templates/foo.liquid' %}
+    `;
+    const offenses = await runLiquidCheck(DeprecatedTags, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toHaveLength(0);
+  });
+
+  it('should suggest replacing include tag with render tag', async () => {
+    const sourceCode = `
+      {% include 'foo.liquid' %}
+      {% assign greeting = "hello world" %}
+      {% include 'greeting.liquid' %}
+    `;
+    const offenses = await runLiquidCheck(DeprecatedTags, sourceCode);
+
+    expect(offenses).toHaveLength(2);
+    if (!offenses[0].suggest || !offenses[1].suggest) return;
+
+    expect(offenses[0].suggest[0].message).toEqual(`Replace 'include' with 'render'`);
+    expect(offenses[1].suggest[0].message).toEqual(`Replace 'include' with 'render'`);
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toHaveLength(2);
+    expect(highlights[0]).toBe('include');
+    expect(highlights[1]).toBe('include');
+  });
+
+  it('should report multiple offenses when multiple include tags are used in the same line', async () => {
+    const sourceCode = "{% include 'foo.liquid' %} Some text {% include 'bar.liquid' %}";
+    const offenses = await runLiquidCheck(DeprecatedTags, sourceCode);
+
+    expect(offenses).toHaveLength(2);
+  });
+
+  it('should report offenses when include tags are nested', async () => {
+    const sourceCode = "{% if true %} {% include 'foo.liquid' %} {% endif %}";
+    const offenses = await runLiquidCheck(DeprecatedTags, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual(`Use the 'render' tag instead of 'include'`);
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual(['include']);
+  });
+});

--- a/packages/theme-check-common/src/checks/deprecated-tags/index.ts
+++ b/packages/theme-check-common/src/checks/deprecated-tags/index.ts
@@ -1,0 +1,52 @@
+import {
+  LiquidHtmlNodeTypes as NodeTypes,
+  LiquidHtmlNodeOfType as NodeOfType,
+  Severity,
+  SourceCodeType,
+  LiquidCheckDefinition,
+} from '../../types';
+
+export const DeprecatedTags: LiquidCheckDefinition = {
+  meta: {
+    code: 'DeprecatedTags',
+    name: 'Deprecated Tags',
+    docs: {
+      description: 'This check is aimed at eliminating the use of deprecated tags.',
+      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/deprecated-tags',
+      recommended: true,
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    return {
+      async LiquidTag(node) {
+        if (node.name === 'include') {
+          const start = node.source.substring(node.position.start);
+          const includeStartIndex = start.indexOf('include');
+          const includeEndIndex = includeStartIndex + 'include'.length;
+
+          const includeStart = node.position.start + includeStartIndex;
+          const includeEnd = node.position.start + includeEndIndex;
+
+          context.report({
+            message: `Use the 'render' tag instead of 'include'`,
+            startIndex: includeStart,
+            endIndex: includeEnd,
+            suggest: [
+              {
+                message: `Replace 'include' with 'render'`,
+                fix: (corrector) => {
+                  corrector.replace(includeStart, includeEnd, 'render');
+                },
+              },
+            ],
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -29,6 +29,7 @@ import { ContentForHeaderModification } from './content-for-header-modification'
 import { AssetSizeAppBlockCSS } from './asset-size-app-block-css';
 import { AssetSizeAppBlockJavaScript } from './asset-size-app-block-javascript';
 import { AssetSizeCSS } from './asset-size-css';
+import { DeprecatedTags } from './deprecated-tags';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
@@ -39,6 +40,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AssetUrlFilters,
   CdnPreconnect,
   ContentForHeaderModification,
+  DeprecatedTags,
   DeprecateBgsizes,
   DeprecateLazysizes,
   ImgLazyLoading,

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -36,6 +36,9 @@ DeprecateBgsizes:
 DeprecateLazysizes:
   enabled: true
   severity: 1
+DeprecatedTags:
+  enabled: true
+  severity: 1
 ImgLazyLoading:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -33,6 +33,9 @@ DeprecateBgsizes:
 DeprecateLazysizes:
   enabled: true
   severity: 1
+DeprecatedTags:
+  enabled: true
+  severity: 1
 ImgLazyLoading:
   enabled: true
   severity: 1


### PR DESCRIPTION
Resolves https://github.com/Shopify/theme-check-js/issues/47
# What are you adding in this PR?

This PR is adding a `DeprecatedTags` check (for more context on why I took this approach, please read [this comment](https://github.com/Shopify/theme-check-js/issues/47#issue-1678446693)). Under the deprecated tags check, we can add specific cases to deprecated tags that we would like to check for. This PR adds the `ConvertIncludeToRender` check which essentially converts a liquid tag that uses `include` to use `render` as  `include` is deprecated.

## What's next? Any followup issues?

If we need to check for any other deprecated tags, it should be written under this check as a specific case. 


## TopHat Screenshots
<img width="694" alt="Screenshot 2023-08-29 at 2 29 29 PM" src="https://github.com/Shopify/theme-tools/assets/90271670/4f3afe64-81a2-46aa-8434-140ff8db452d">

<img width="479" alt="Screenshot 2023-08-29 at 2 29 46 PM" src="https://github.com/Shopify/theme-tools/assets/90271670/1c69a90b-c93f-4771-b946-6290cc5ca38c">

<img width="270" alt="Screenshot 2023-08-29 at 2 30 03 PM" src="https://github.com/Shopify/theme-tools/assets/90271670/f69f329f-9dac-4b92-b21d-7be16f26245c">

## Before you deploy

<!-- If a checklist is not applicable, you can delete it. -->

<!-- Include this check when updating anything within packages/theme-check-* -->
- [x] This PR includes a new checks
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn update-configs` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
