### PR TITLE
Implemented `fileSize` dependency to enable asset size checks

### DIFF
--- a/.changeset/few-rabbits-love.md
+++ b/.changeset/few-rabbits-love.md
@@ -1,0 +1,6 @@
+---
+'@shopify/liquid-language-server-common': minor
+'@shopify/liquid-language-server-node': minor
+---
+
+Implemented `fileSize` dependency to enable asset size checks

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.spec.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.spec.ts
@@ -54,6 +54,7 @@ describe('Module: runChecks', () => {
     runChecks = makeRunChecks(documentManager, diagnosticsManager, {
       findRootURI: async () => 'browser:///',
       fileExists: async () => true,
+      fileSize: async () => 420,
       getDefaultTranslationsFactory: () => async () => ({}),
       getDefaultLocaleFactory: () => async () => 'en',
       loadConfig: async () => ({
@@ -206,6 +207,7 @@ describe('Module: runChecks', () => {
     runChecks = makeRunChecks(documentManager, diagnosticsManager, {
       findRootURI: async () => 'browser:///',
       fileExists: async () => true,
+      fileSize: async () => 420,
       getDefaultTranslationsFactory: () => async () => JSON.parse(files[defaultURI]),
       getDefaultLocaleFactory: () => async () => 'en',
       loadConfig: async () => ({

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -11,6 +11,7 @@ export function makeRunChecks(
   {
     loadConfig,
     findRootURI,
+    fileSize,
     fileExists,
     getDefaultTranslationsFactory,
     getDefaultLocaleFactory,
@@ -21,6 +22,7 @@ export function makeRunChecks(
     | 'loadConfig'
     | 'findRootURI'
     | 'fileExists'
+    | 'fileSize'
     | 'getDefaultTranslationsFactory'
     | 'getDefaultLocaleFactory'
     | 'themeDocset'
@@ -53,9 +55,10 @@ export function makeRunChecks(
       );
 
       const offenses = await check(theme, config, {
-        getDefaultTranslations: async () => defaultTranslations,
-        getDefaultLocale: getDefaultLocaleFactory(rootURI),
         fileExists,
+        fileSize,
+        getDefaultLocale: getDefaultLocaleFactory(rootURI),
+        getDefaultTranslations: async () => defaultTranslations,
         themeDocset,
         schemaValidators,
       });

--- a/packages/theme-language-server-common/src/server/startServer.spec.ts
+++ b/packages/theme-language-server-common/src/server/startServer.spec.ts
@@ -226,6 +226,7 @@ describe('Module: server', () => {
       fileExists: vi
         .fn()
         .mockImplementation(async (absolutePath: string) => fileTree.has(absolutePath)),
+      fileSize: vi.fn().mockResolvedValue(420),
       getDefaultTranslationsFactory: () => async () => ({}),
       getDefaultLocaleFactory: () => async () => 'en',
       loadConfig: async () => ({

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -35,13 +35,14 @@ export function startServer(
   connection: Connection,
   {
     fileExists,
+    fileSize,
     findRootURI,
     getDefaultLocaleFactory,
     getDefaultTranslationsFactory,
     loadConfig,
-    themeDocset: remoteThemeDocset,
-    schemaValidators,
     log = defaultLogger,
+    schemaValidators,
+    themeDocset: remoteThemeDocset,
   }: Dependencies,
 ) {
   const clientCapabilities = new ClientCapabilities();
@@ -52,11 +53,12 @@ export function startServer(
   const themeDocset = new AugmentedThemeDocset(remoteThemeDocset);
   const runChecks = debounce(
     makeRunChecks(documentManager, diagnosticsManager, {
-      loadConfig,
-      findRootURI,
-      getDefaultTranslationsFactory,
-      getDefaultLocaleFactory,
       fileExists,
+      fileSize,
+      findRootURI,
+      getDefaultLocaleFactory,
+      getDefaultTranslationsFactory,
+      loadConfig,
       themeDocset,
       schemaValidators,
     }),

--- a/packages/theme-language-server-common/src/types.ts
+++ b/packages/theme-language-server-common/src/types.ts
@@ -95,4 +95,6 @@ export interface RequiredDependencies {
   getDefaultLocaleFactory(rootURI: URI): ThemeCheckDependencies['getDefaultLocale'];
 
   fileExists: ThemeCheckDependencies['fileExists'];
+
+  fileSize: ThemeCheckDependencies['fileSize'];
 }

--- a/packages/theme-language-server-node/src/dependencies.ts
+++ b/packages/theme-language-server-node/src/dependencies.ts
@@ -54,12 +54,23 @@ export const findRootURI: Dependencies['findRootURI'] = async function findRootU
 
 export const fileExists: Dependencies['fileExists'] = async function fileExists(path) {
   try {
-    // This gets called from within theme-check-js which assumes
+    // This will get called within theme-check-common which assumes
     // forward-slashes. We need to denormalize those here.
     await fs.stat(asFsPath(path));
     return true;
   } catch (e) {
     return false;
+  }
+};
+
+export const fileSize: Dependencies['fileSize'] = async function fileSize(
+  absolutePath: string,
+): Promise<number> {
+  try {
+    const stats = await fs.stat(asFsPath(absolutePath));
+    return stats.size;
+  } catch (e) {
+    throw new Error(`Failed to get file size: ${e}`);
   }
 };
 

--- a/packages/theme-language-server-node/src/index.ts
+++ b/packages/theme-language-server-node/src/index.ts
@@ -1,9 +1,10 @@
 import { startServer as startCoreServer } from '@shopify/liquid-language-server-common';
 import { ThemeLiquidDocsManager } from '@shopify/theme-check-docs-updater';
-import { createConnection } from 'vscode-languageserver/node';
 import { stdin, stdout } from 'node:process';
+import { createConnection } from 'vscode-languageserver/node';
 import {
   fileExists,
+  fileSize,
   findRootURI,
   getDefaultLocaleFactory,
   getDefaultTranslationsFactory,
@@ -22,6 +23,7 @@ export function startServer() {
     getDefaultLocaleFactory,
     findRootURI,
     fileExists,
+    fileSize,
     loadConfig,
     themeDocset: themeLiquidDocsManager,
     schemaValidators: themeLiquidDocsManager,


### PR DESCRIPTION
# What are you adding in this PR?
Relates #33. Implemented `fileSize` for `@shopify/liquid-language-server-node` and verified that everything works against https://github.com/Shopify/theme-tools/pull/42

## What's next? Any followup issues?

We need to build this support for online-store-web.

## Before you deploy

- [x] I included a minor bump `changeset`
