### PR TITLE
Fix hover reporting wrong node inside liquid branches

### DIFF
--- a/.changeset/spotty-weeks-rescue.md
+++ b/.changeset/spotty-weeks-rescue.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+---
+
+Fixup the position of LiquidBranch nodes

--- a/packages/theme-language-server-common/src/hover/providers/HtmlAttributeHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/HtmlAttributeHoverProvider.spec.ts
@@ -22,6 +22,17 @@ describe('Module: HtmlAttributeHoverProvider', async () => {
     await expect(provider).to.hover(`<img src█>`, expect.stringMatching(/##* src/));
   });
 
+  it('should return the hover description inside if statements', async () => {
+    await expect(provider).to.hover(
+      `{% if cond %}<a hr█ef="..."></a>{% endif %}`,
+      expect.stringMatching(/##* href/),
+    );
+    await expect(provider).to.hover(
+      `{% if cond %}{% else %}<a hr█ef="..."></a>{% endif %}`,
+      expect.stringMatching(/##* href/),
+    );
+  });
+
   it('should return nothing if the thing is unknown', async () => {
     await expect(provider).to.hover(`<a unkn█own></a>`, null);
   });


### PR DESCRIPTION
Fix #78

# What are you adding in this PR?

This was happening because the LiquidBranch.position.end was incorrect.

It's hard to explain, but the unit tests didn't pass until I made the changes.

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
