### PR TITLE
Add 'section' exception as a "global" variable

### DIFF
--- a/.changeset/cool-humans-argue.md
+++ b/.changeset/cool-humans-argue.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-language-server-common': patch
+---
+
+Fix hover support for section objects

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -96,7 +96,11 @@ export class TypeSystem {
   private globalVariables = memo(async () => {
     const entries = await this.objectEntries();
     return entries.filter(
-      (entry) => !entry.access || entry.access.global === true || entry.access.template.length > 0,
+      (entry) =>
+        entry.name === 'section' ||
+        !entry.access ||
+        entry.access.global === true ||
+        entry.access.template.length > 0,
     );
   });
 }


### PR DESCRIPTION
Bug this solves: Basically all the "type-system" stuff didn't work in sections files
because the `section` object appeared to not exist.

I'm not entirely sure if we should change that in theme-liquid-docs or not. It's only global inside sections/ files but nowhere else.

It doens't seem like we have a way to specific that generally.

## Before you deploy

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
