### PR TITLE
Rename LiquidDrop->LiquidVariableOutput

### DIFF
--- a/.changeset/kind-snakes-peel.md
+++ b/.changeset/kind-snakes-peel.md
@@ -1,0 +1,7 @@
+---
+'@shopify/liquid-language-server-common': minor
+'@shopify/prettier-plugin-liquid': minor
+'@shopify/theme-check-common': minor
+---
+
+Rename LiquidDrop -> LiquidVariableLookup

--- a/packages/prettier-plugin-liquid/HOW_IT_WORKS.md
+++ b/packages/prettier-plugin-liquid/HOW_IT_WORKS.md
@@ -72,7 +72,7 @@ flowchart TB
       c2["LiquidTagOpen#for el in col"] --->
       c3["HtmlTagOpen#li"]
       c3 -->
-      c4["LiquidDrop#el"] -->
+      c4["LiquidVariableOutput#el"] -->
       c5["HtmlTagClose#li"] -->
       c6["LiquidTagClose#for"]
       c3 .- attributes .-
@@ -88,7 +88,7 @@ flowchart TB
       a2["LiquidTag#for el in col"] -- children -->
       a3["HtmlElement#li"]
       a3 -- children -->
-      a4["LiquidDrop#el"]
+      a4["LiquidVariableOutput#el"]
       a3 -- attributes -->
       a3a["HtmlAttribute"]
       a3a -- name --> a3an["class"]

--- a/packages/prettier-plugin-liquid/src/parser/stage-1-cst.spec.ts
+++ b/packages/prettier-plugin-liquid/src/parser/stage-1-cst.spec.ts
@@ -19,15 +19,15 @@ describe('Unit: Stage 1 (CST)', () => {
 
     let cst: LiquidHtmlCST | LiquidCST;
 
-    describe('Case: LiquidDrop', () => {
+    describe('Case: LiquidVariableOutput', () => {
       it('should basically parse unparseables', () => {
         for (const { toCST, expectPath } of testCases) {
           cst = toCST('{{ !-asdl }}{{- !-asdl -}}');
-          expectPath(cst, '0.type').to.equal('LiquidDrop');
+          expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
           expectPath(cst, '0.markup').to.equal('!-asdl');
           expectPath(cst, '0.whitespaceStart').to.equal(null);
           expectPath(cst, '0.whitespaceEnd').to.equal(null);
-          expectPath(cst, '1.type').to.equal('LiquidDrop');
+          expectPath(cst, '1.type').to.equal('LiquidVariableOutput');
           expectPath(cst, '1.markup').to.equal('!-asdl');
           expectPath(cst, '1.whitespaceStart').to.equal('-');
           expectPath(cst, '1.whitespaceEnd').to.equal('-');
@@ -41,7 +41,7 @@ describe('Unit: Stage 1 (CST)', () => {
         ].forEach(({ expression, value, single }) => {
           for (const { toCST, expectPath } of testCases) {
             cst = toCST(`{{ ${expression} }}`);
-            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
             expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
             expectPath(cst, '0.markup.rawSource').to.equal(expression);
             expectPath(cst, '0.markup.expression.type').to.equal('String');
@@ -63,7 +63,7 @@ describe('Unit: Stage 1 (CST)', () => {
         ].forEach(({ expression, value }) => {
           for (const { toCST, expectPath } of testCases) {
             cst = toCST(`{{ ${expression} }}`);
-            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
             expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
             expectPath(cst, '0.markup.rawSource').to.equal(expression);
             expectPath(cst, '0.markup.expression.type').to.equal('Number');
@@ -84,7 +84,7 @@ describe('Unit: Stage 1 (CST)', () => {
         ].forEach(({ expression, value }) => {
           for (const { toCST, expectPath } of testCases) {
             cst = toCST(`{{ ${expression} }}`);
-            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
             expectPath(cst, '0.markup.type').to.equal('LiquidVariable', expression);
             expectPath(cst, '0.markup.rawSource').to.equal(expression);
             expectPath(cst, '0.markup.expression.type').to.equal('LiquidLiteral');
@@ -128,7 +128,7 @@ describe('Unit: Stage 1 (CST)', () => {
         ].forEach(({ expression, name, lookups }) => {
           for (const { toCST, expectPath } of testCases) {
             cst = toCST(`{{ ${expression} }}`);
-            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
             expectPath(cst, '0.markup.type').to.equal('LiquidVariable', expression);
             expectPath(cst, '0.markup.rawSource').to.equal(expression);
             expectPath(cst, '0.markup.expression.type').to.equal('VariableLookup');
@@ -194,7 +194,7 @@ describe('Unit: Stage 1 (CST)', () => {
         ].forEach(({ expression, start, end }) => {
           for (const { toCST, expectPath } of testCases) {
             cst = toCST(`{{ ${expression} }}`);
-            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
             expectPath(cst, '0.markup.type').to.equal('LiquidVariable', expression);
             expectPath(cst, '0.markup.rawSource').to.equal(expression);
             expectPath(cst, '0.markup.expression.type').to.equal('Range');
@@ -246,7 +246,7 @@ describe('Unit: Stage 1 (CST)', () => {
         ].forEach(({ expression, filters }) => {
           for (const { toCST, expectPath } of testCases) {
             cst = toCST(`{{ 'hello' ${expression} }}`);
-            expectPath(cst, '0.type').to.equal('LiquidDrop');
+            expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
             expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
             expectPath(cst, '0.markup.rawSource').to.equal((`'hello' ` + expression).trimEnd());
             expectPath(cst, '0.markup.filters').to.exist;
@@ -929,12 +929,12 @@ describe('Unit: Stage 1 (CST)', () => {
       it('should parse compound tag names', () => {
         cst = toLiquidHtmlCST('<{{header_type}}--header></{{header_type}}--header>');
         expectPath(cst, '0.type').to.eql('HtmlTagOpen');
-        expectPath(cst, '0.name.0.type').to.eql('LiquidDrop');
+        expectPath(cst, '0.name.0.type').to.eql('LiquidVariableOutput');
         expectPath(cst, '0.name.0.markup.type').to.eql('LiquidVariable');
         expectPath(cst, '0.name.0.markup.rawSource').to.eql('header_type');
         expectPath(cst, '0.name.1.value').to.eql('--header');
         expectPath(cst, '1.type').to.eql('HtmlTagClose');
-        expectPath(cst, '1.name.0.type').to.eql('LiquidDrop');
+        expectPath(cst, '1.name.0.type').to.eql('LiquidVariableOutput');
         expectPath(cst, '1.name.0.markup.type').to.eql('LiquidVariable');
         expectPath(cst, '0.name.0.markup.rawSource').to.eql('header_type');
         expectPath(cst, '1.name.1.value').to.eql('--header');
@@ -943,26 +943,26 @@ describe('Unit: Stage 1 (CST)', () => {
         expectPath(cst, '0.type').to.eql('HtmlTagOpen');
         expectPath(cst, '0.name.0.type').to.eql('TextNode');
         expectPath(cst, '0.name.0.value').to.eql('header--');
-        expectPath(cst, '0.name.1.type').to.eql('LiquidDrop');
+        expectPath(cst, '0.name.1.type').to.eql('LiquidVariableOutput');
         expectPath(cst, '0.name.1.markup.type').to.eql('LiquidVariable');
         expectPath(cst, '0.name.1.markup.rawSource').to.eql('header_type');
         expectPath(cst, '1.type').to.eql('HtmlTagClose');
         expectPath(cst, '1.name.0.type').to.eql('TextNode');
         expectPath(cst, '1.name.0.value').to.eql('header--');
-        expectPath(cst, '1.name.1.type').to.eql('LiquidDrop');
+        expectPath(cst, '1.name.1.type').to.eql('LiquidVariableOutput');
         expectPath(cst, '1.name.1.markup.type').to.eql('LiquidVariable');
         expectPath(cst, '0.name.1.markup.rawSource').to.eql('header_type');
       });
 
-      it('should parse liquid drop tag names', () => {
+      it('should parse liquid variable output tag names', () => {
         cst = toLiquidHtmlCST('<{{ node_type }}></{{ node_type }}>');
         expectPath(cst, '0.type').to.equal('HtmlTagOpen');
-        expectPath(cst, '0.name.0.type').to.equal('LiquidDrop');
+        expectPath(cst, '0.name.0.type').to.equal('LiquidVariableOutput');
         expectPath(cst, '0.name.0.markup.type').to.equal('LiquidVariable');
         expectPath(cst, '0.name.0.markup.expression.type').to.equal('VariableLookup');
         expectPath(cst, '0.name.0.markup.expression.name').to.equal('node_type');
         expectPath(cst, '1.type').to.equal('HtmlTagClose');
-        expectPath(cst, '1.name.0.type').to.equal('LiquidDrop');
+        expectPath(cst, '1.name.0.type').to.equal('LiquidVariableOutput');
         expectPath(cst, '1.name.0.markup.type').to.equal('LiquidVariable');
         expectPath(cst, '1.name.0.markup.expression.type').to.equal('VariableLookup');
         expectPath(cst, '1.name.0.markup.expression.name').to.equal('node_type');
@@ -1057,7 +1057,7 @@ describe('Unit: Stage 1 (CST)', () => {
               `<div\n${testConfig.name}=${testConfig.quote}https://{{ name }}${testConfig.quote}\n>`,
             ].forEach((text) => {
               cst = toLiquidHtmlCST(text);
-              expectPath(cst, '0.attrList.0.value.1.type').to.eql('LiquidDrop', text);
+              expectPath(cst, '0.attrList.0.value.1.type').to.eql('LiquidVariableOutput', text);
             });
           }
 
@@ -1172,20 +1172,20 @@ describe('Unit: Stage 1 (CST)', () => {
       expectPath(cst, '0.name').to.eql('█');
 
       cst = toCST('{{ █ }}');
-      expectPath(cst, '0.type').to.eql('LiquidDrop');
+      expectPath(cst, '0.type').to.eql('LiquidVariableOutput');
       expectPath(cst, '0.markup.type').to.eql('LiquidVariable');
       expectPath(cst, '0.markup.expression.type').to.eql('VariableLookup');
       expectPath(cst, '0.markup.expression.name').to.eql('█');
 
       cst = toCST('{{ var.█ }}');
-      expectPath(cst, '0.type').to.eql('LiquidDrop');
+      expectPath(cst, '0.type').to.eql('LiquidVariableOutput');
       expectPath(cst, '0.markup.type').to.eql('LiquidVariable');
       expectPath(cst, '0.markup.expression.type').to.eql('VariableLookup');
       expectPath(cst, '0.markup.expression.lookups.0.type').to.eql('String');
       expectPath(cst, '0.markup.expression.lookups.0.value').to.eql('█');
 
       cst = toCST('{{ var[█] }}');
-      expectPath(cst, '0.type').to.eql('LiquidDrop');
+      expectPath(cst, '0.type').to.eql('LiquidVariableOutput');
       expectPath(cst, '0.markup.type').to.eql('LiquidVariable');
       expectPath(cst, '0.markup.expression.type').to.eql('VariableLookup');
       expectPath(cst, '0.markup.expression.lookups.0.type').to.eql('VariableLookup');

--- a/packages/prettier-plugin-liquid/src/parser/stage-1-cst.ts
+++ b/packages/prettier-plugin-liquid/src/parser/stage-1-cst.ts
@@ -54,7 +54,7 @@ export enum ConcreteNodeTypes {
   AttrDoubleQuoted = 'AttrDoubleQuoted',
   AttrUnquoted = 'AttrUnquoted',
   AttrEmpty = 'AttrEmpty',
-  LiquidDrop = 'LiquidDrop',
+  LiquidVariableOutput = 'LiquidVariableOutput',
   LiquidRawTag = 'LiquidRawTag',
   LiquidTag = 'LiquidTag',
   LiquidTagOpen = 'LiquidTagOpen',
@@ -127,17 +127,17 @@ export interface ConcreteHtmlVoidElement
 }
 export interface ConcreteHtmlSelfClosingElement
   extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlSelfClosingElement> {
-  name: (ConcreteTextNode | ConcreteLiquidDrop)[];
+  name: (ConcreteTextNode | ConcreteLiquidVariableOutput)[];
 }
 export interface ConcreteHtmlTagOpen extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlTagOpen> {
-  name: (ConcreteTextNode | ConcreteLiquidDrop)[];
+  name: (ConcreteTextNode | ConcreteLiquidVariableOutput)[];
 }
 export interface ConcreteHtmlTagClose extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlTagClose> {
-  name: (ConcreteTextNode | ConcreteLiquidDrop)[];
+  name: (ConcreteTextNode | ConcreteLiquidVariableOutput)[];
 }
 
 export interface ConcreteAttributeNodeBase<T> extends ConcreteBasicNode<T> {
-  name: (ConcreteLiquidDrop | ConcreteTextNode)[];
+  name: (ConcreteLiquidVariableOutput | ConcreteTextNode)[];
   value: (ConcreteLiquidNode | ConcreteTextNode)[];
 }
 
@@ -155,7 +155,7 @@ export interface ConcreteAttrDoubleQuoted
 export interface ConcreteAttrUnquoted
   extends ConcreteAttributeNodeBase<ConcreteNodeTypes.AttrUnquoted> {}
 export interface ConcreteAttrEmpty extends ConcreteBasicNode<ConcreteNodeTypes.AttrEmpty> {
-  name: (ConcreteLiquidDrop | ConcreteTextNode)[];
+  name: (ConcreteLiquidVariableOutput | ConcreteTextNode)[];
 }
 
 export type ConcreteLiquidNode =
@@ -163,7 +163,7 @@ export type ConcreteLiquidNode =
   | ConcreteLiquidTagOpen
   | ConcreteLiquidTagClose
   | ConcreteLiquidTag
-  | ConcreteLiquidDrop;
+  | ConcreteLiquidVariableOutput;
 
 interface ConcreteBasicLiquidNode<T> extends ConcreteBasicNode<T> {
   whitespaceStart: null | '-';
@@ -337,7 +337,8 @@ export interface ConcreteRenderVariableExpression
   name: ConcreteLiquidExpression;
 }
 
-export interface ConcreteLiquidDrop extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidDrop> {
+export interface ConcreteLiquidVariableOutput
+  extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidVariableOutput> {
   markup: ConcreteLiquidVariable | string;
 }
 
@@ -763,7 +764,7 @@ function toCST<T>(
     renderAliasExpression: 3,
 
     liquidDrop: {
-      type: ConcreteNodeTypes.LiquidDrop,
+      type: ConcreteNodeTypes.LiquidVariableOutput,
       markup: 3,
       whitespaceStart: 1,
       whitespaceEnd: 4,

--- a/packages/prettier-plugin-liquid/src/parser/stage-2-ast.spec.ts
+++ b/packages/prettier-plugin-liquid/src/parser/stage-2-ast.spec.ts
@@ -19,12 +19,12 @@ describe('Unit: Stage 2 (AST)', () => {
       },
     ];
 
-    describe('Unit: LiquidDrop', () => {
-      it('should transform a base case Liquid Drop into a LiquidDrop', () => {
+    describe('Unit: LiquidVariableOutput', () => {
+      it('should transform a base case Liquid Drop into a LiquidVariableOutput', () => {
         for (const { toAST, expectPath, expectPosition } of testCases) {
           ast = toAST('{{ !-asd }}');
           expectPath(ast, 'children.0').to.exist;
-          expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+          expectPath(ast, 'children.0.type').to.eql('LiquidVariableOutput');
           expectPath(ast, 'children.0.markup').to.eql('!-asd');
           expectPosition(ast, 'children.0');
         }
@@ -38,7 +38,7 @@ describe('Unit: Stage 2 (AST)', () => {
           for (const { toAST, expectPath, expectPosition } of testCases) {
             ast = toAST(`{{ ${expression} }}`);
             expectPath(ast, 'children.0').to.exist;
-            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.type').to.eql('LiquidVariableOutput');
             expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
             expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
             expectPath(ast, 'children.0.markup.expression.type').to.eql('String');
@@ -62,7 +62,7 @@ describe('Unit: Stage 2 (AST)', () => {
           for (const { toAST, expectPath, expectPosition } of testCases) {
             ast = toAST(`{{ ${expression} }}`);
             expectPath(ast, 'children.0').to.exist;
-            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.type').to.eql('LiquidVariableOutput');
             expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
             expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
             expectPath(ast, 'children.0.markup.expression.type').to.eql('Number');
@@ -85,7 +85,7 @@ describe('Unit: Stage 2 (AST)', () => {
           for (const { toAST, expectPath, expectPosition } of testCases) {
             ast = toAST(`{{ ${expression} }}`);
             expectPath(ast, 'children.0').to.exist;
-            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.type').to.eql('LiquidVariableOutput');
             expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
             expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
             expectPath(ast, 'children.0.markup.expression.type').to.eql('LiquidLiteral');
@@ -119,7 +119,7 @@ describe('Unit: Stage 2 (AST)', () => {
           for (const { toAST, expectPath, expectPosition } of testCases) {
             ast = toAST(`{{ ${expression} }}`);
             expectPath(ast, 'children.0').to.exist;
-            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.type').to.eql('LiquidVariableOutput');
             expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
             expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
             expectPath(ast, 'children.0.markup.expression.type').to.eql('Range');
@@ -167,7 +167,7 @@ describe('Unit: Stage 2 (AST)', () => {
           for (const { toAST, expectPath, expectPosition } of testCases) {
             ast = toAST(`{{ ${expression} }}`);
             expectPath(ast, 'children.0').to.exist;
-            expectPath(ast, 'children.0.type').to.eql('LiquidDrop');
+            expectPath(ast, 'children.0.type').to.eql('LiquidVariableOutput');
             expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
             expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
             expectPath(ast, 'children.0.markup.expression.type').to.eql('VariableLookup');
@@ -260,7 +260,7 @@ describe('Unit: Stage 2 (AST)', () => {
         ].forEach(({ expression, filters }) => {
           for (const { toAST, expectPath, expectPosition } of testCases) {
             ast = toAST(`{{ 'hello' ${expression} }}`);
-            expectPath(ast, 'children.0.type').to.equal('LiquidDrop');
+            expectPath(ast, 'children.0.type').to.equal('LiquidVariableOutput');
             expectPath(ast, 'children.0.markup.type').to.equal('LiquidVariable');
             expectPath(ast, 'children.0.markup.rawSource').to.equal(`'hello' ` + expression);
             expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(filters.length);
@@ -781,7 +781,7 @@ describe('Unit: Stage 2 (AST)', () => {
         ast = toLiquidHtmlAST(testCase);
         expectPath(ast, 'children.0').to.exist;
         expectPath(ast, 'children.0.type').to.eql('HtmlElement');
-        expectPath(ast, 'children.0.name.0.type').to.eql('LiquidDrop');
+        expectPath(ast, 'children.0.name.0.type').to.eql('LiquidVariableOutput');
         expectPath(ast, 'children.0.name.0.markup.type').to.eql('LiquidVariable');
         expectPath(ast, 'children.0.name.0.markup.rawSource').to.eql('node_type');
         expectPath(ast, 'children.0.attributes.0.name.0.value').to.eql('src');
@@ -798,7 +798,7 @@ describe('Unit: Stage 2 (AST)', () => {
       ast = toLiquidHtmlAST(`<{{ node_type }}--header ></{{node_type}}--header>`);
       expectPath(ast, 'children.0').to.exist;
       expectPath(ast, 'children.0.type').to.eql('HtmlElement');
-      expectPath(ast, 'children.0.name.0.type').to.eql('LiquidDrop');
+      expectPath(ast, 'children.0.name.0.type').to.eql('LiquidVariableOutput');
       expectPath(ast, 'children.0.name.0.markup.type').to.eql('LiquidVariable');
       expectPath(ast, 'children.0.name.0.markup.rawSource').to.eql('node_type');
       expectPath(ast, 'children.0.name.1.value').to.eql('--header');
@@ -808,7 +808,7 @@ describe('Unit: Stage 2 (AST)', () => {
       ast = toLiquidHtmlAST(`<{{ node_type }}--header />`);
       expectPath(ast, 'children.0').to.exist;
       expectPath(ast, 'children.0.type').to.eql('HtmlSelfClosingElement');
-      expectPath(ast, 'children.0.name.0.type').to.eql('LiquidDrop');
+      expectPath(ast, 'children.0.name.0.type').to.eql('LiquidVariableOutput');
       expectPath(ast, 'children.0.name.0.markup.type').to.eql('LiquidVariable');
       expectPath(ast, 'children.0.name.0.markup.rawSource').to.eql('node_type');
       expectPath(ast, 'children.0.name.1.value').to.eql('--header');

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -93,7 +93,7 @@ function getCssDisplay(node: AugmentedNode<WithSiblings>, options: LiquidParserO
       }
 
     case NodeTypes.LiquidBranch:
-    case NodeTypes.LiquidDrop:
+    case NodeTypes.LiquidVariableOutput:
       return 'inline';
 
     case NodeTypes.AttrDoubleQuoted:
@@ -182,7 +182,7 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
       return CSS_WHITE_SPACE_LIQUID_TAGS[node.name] || CSS_WHITE_SPACE_DEFAULT;
 
     case NodeTypes.LiquidBranch:
-    case NodeTypes.LiquidDrop:
+    case NodeTypes.LiquidVariableOutput:
       return CSS_WHITE_SPACE_DEFAULT;
 
     case NodeTypes.AttrDoubleQuoted:

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-whitespace-helpers.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-whitespace-helpers.ts
@@ -124,7 +124,11 @@ function isLeadingWhitespaceSensitiveNode(node: AugmentedAstNode | undefined): b
   }
 
   // <a data-{{ this }}="hi">
-  if (node.parentNode && isAttributeNode(node.parentNode) && node.type === NodeTypes.LiquidDrop) {
+  if (
+    node.parentNode &&
+    isAttributeNode(node.parentNode) &&
+    node.type === NodeTypes.LiquidVariableOutput
+  ) {
     return true;
   }
 
@@ -256,7 +260,11 @@ function isTrailingWhitespaceSensitiveNode(node: AugmentedAstNode): boolean {
   }
 
   // <a data-{{ this }}="hi">
-  if (node.parentNode && isAttributeNode(node.parentNode) && node.type === NodeTypes.LiquidDrop) {
+  if (
+    node.parentNode &&
+    isAttributeNode(node.parentNode) &&
+    node.type === NodeTypes.LiquidVariableOutput
+  ) {
     return true;
   }
 
@@ -407,7 +415,7 @@ export function isTrimmingOuterRight(node: AugmentedAstNode | undefined): boolea
       return (node.delimiterWhitespaceEnd ?? node.whitespaceEnd) === '-';
     case NodeTypes.LiquidBranch:
       return false;
-    case NodeTypes.LiquidDrop: // {{ foo -}}
+    case NodeTypes.LiquidVariableOutput: // {{ foo -}}
       return node.whitespaceEnd === '-';
     default:
       return false;
@@ -420,7 +428,7 @@ export function isTrimmingOuterLeft(node: AugmentedAstNode | undefined): boolean
     case NodeTypes.LiquidRawTag:
     case NodeTypes.LiquidTag: // {%- if a %}{% endif %}, {%- assign x = 1 %}
     case NodeTypes.LiquidBranch: // {%- else %}
-    case NodeTypes.LiquidDrop: // {{- 'val' }}
+    case NodeTypes.LiquidVariableOutput: // {{- 'val' }}
       return node.whitespaceStart === '-';
     default:
       return false;
@@ -447,7 +455,7 @@ export function isTrimmingInnerLeft(node: AugmentedAstNode | undefined): boolean
 
       // Otherwise gets it from the delimiter. e.g. {% else -%}
       return node.whitespaceEnd === '-';
-    case NodeTypes.LiquidDrop:
+    case NodeTypes.LiquidVariableOutput:
     default:
       return false;
   }
@@ -473,7 +481,7 @@ export function isTrimmingInnerRight(node: AugmentedAstNode | undefined): boolea
 
       // Otherwise gets it from the next branch
       return isTrimmingOuterLeft(node.next);
-    case NodeTypes.LiquidDrop:
+    case NodeTypes.LiquidVariableOutput:
     default:
       return false;
   }

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -3,7 +3,7 @@ import {
   AstPath,
   LiquidAstPath,
   LiquidBranch,
-  LiquidDrop,
+  LiquidVariableOutput,
   LiquidParserOptions,
   LiquidPrinter,
   LiquidPrinterArgs,
@@ -44,13 +44,13 @@ const { builders, utils } = doc;
 const { group, hardline, ifBreak, indent, join, line, softline, literalline } = builders;
 const { replaceEndOfLine } = doc.utils as any;
 
-export function printLiquidDrop(
+export function printLiquidVariableOutput(
   path: LiquidAstPath,
   _options: LiquidParserOptions,
   print: LiquidPrinter,
   { leadingSpaceGroupId, trailingSpaceGroupId }: LiquidPrinterArgs,
 ) {
-  const node: LiquidDrop = path.getValue() as LiquidDrop;
+  const node: LiquidVariableOutput = path.getValue() as LiquidVariableOutput;
   const whitespaceStart = getWhitespaceTrim(
     node.whitespaceStart,
     hasMeaningfulLackOfLeadingWhitespace(node),

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -15,7 +15,7 @@ import {
   HtmlVoidElement,
   LiquidAstPath,
   LiquidBranch,
-  LiquidDrop,
+  LiquidVariableOutput,
   LiquidExpression,
   LiquidHtmlNode,
   LiquidParserOptions,
@@ -37,7 +37,7 @@ import { printElement } from '~/printer/print/element';
 import { printClosingTagSuffix, printOpeningTagPrefix } from '~/printer/print/tag';
 import {
   printLiquidBranch,
-  printLiquidDrop,
+  printLiquidVariableOutput,
   printLiquidRawTag,
   printLiquidTag,
 } from '~/printer/print/liquid';
@@ -63,14 +63,14 @@ function printAttributeName(
   node.name;
   return join(
     '',
-    (path as any).map((part: AstPath<string | LiquidDrop>) => {
+    (path as any).map((part: AstPath<string | LiquidVariableOutput>) => {
       const value = part.getValue();
       if (typeof value === 'string') {
         return value;
       } else {
-        // We want to force the LiquidDrop to be on one line to avoid weird
+        // We want to force the LiquidVariableOutput to be on one line to avoid weird
         // shenanigans
-        return utils.removeLines(print(part as AstPath<LiquidDrop>));
+        return utils.removeLines(print(part as AstPath<LiquidVariableOutput>));
       }
     }, 'name'),
   );
@@ -239,8 +239,8 @@ function printNode(
         : softline;
     }
 
-    case NodeTypes.LiquidDrop: {
-      return printLiquidDrop(path as AstPath<LiquidDrop>, options, print, args);
+    case NodeTypes.LiquidVariableOutput: {
+      return printLiquidVariableOutput(path as AstPath<LiquidVariableOutput>, options, print, args);
     }
 
     case NodeTypes.LiquidRawTag: {

--- a/packages/prettier-plugin-liquid/src/printer/utils/node.ts
+++ b/packages/prettier-plugin-liquid/src/printer/utils/node.ts
@@ -12,7 +12,7 @@ import {
   HtmlElement,
   LiquidTag,
   AttributeNode,
-  LiquidDrop,
+  LiquidVariableOutput,
   HtmlDanglingMarkerOpen,
   HtmlDanglingMarkerClose,
 } from '~/types';
@@ -324,7 +324,10 @@ export function getLastDescendant(node: LiquidHtmlNode): LiquidHtmlNode {
   return node.lastChild ? getLastDescendant(node.lastChild) : node;
 }
 
-function isTagNameIncluded(collection: string[], name: (TextNode | LiquidDrop)[]): boolean {
+function isTagNameIncluded(
+  collection: string[],
+  name: (TextNode | LiquidVariableOutput)[],
+): boolean {
   if (name.length !== 1 || name[0].type !== NodeTypes.TextNode) return false;
   return collection.includes(name[0].value);
 }

--- a/packages/prettier-plugin-liquid/src/types.ts
+++ b/packages/prettier-plugin-liquid/src/types.ts
@@ -17,7 +17,7 @@ export enum NodeTypes {
   LiquidRawTag = 'LiquidRawTag',
   LiquidTag = 'LiquidTag',
   LiquidBranch = 'LiquidBranch',
-  LiquidDrop = 'LiquidDrop',
+  LiquidVariableOutput = 'LiquidVariableOutput',
   HtmlSelfClosingElement = 'HtmlSelfClosingElement',
   HtmlVoidElement = 'HtmlVoidElement',
   HtmlDoctype = 'HtmlDoctype',
@@ -108,7 +108,7 @@ export const HtmlNodeTypes = [
 
 export const LiquidNodeTypes = [
   NodeTypes.LiquidTag,
-  NodeTypes.LiquidDrop,
+  NodeTypes.LiquidVariableOutput,
   NodeTypes.LiquidBranch,
   NodeTypes.LiquidRawTag,
 ] as const;
@@ -246,7 +246,7 @@ export type LiquidTag = Augmented<AST.LiquidTag, AllAugmentations>;
 export type LiquidTagNamed = Augmented<AST.LiquidTagNamed, AllAugmentations>;
 export type LiquidBranch = Augmented<AST.LiquidBranch, AllAugmentations>;
 export type LiquidBranchNamed = Augmented<AST.LiquidBranchNamed, AllAugmentations>;
-export type LiquidDrop = Augmented<AST.LiquidDrop, AllAugmentations>;
+export type LiquidVariableOutput = Augmented<AST.LiquidVariableOutput, AllAugmentations>;
 export type HtmlNode = Augmented<AST.HtmlNode, AllAugmentations>;
 export type HtmlTag = Exclude<HtmlNode, HtmlComment>;
 export type HtmlElement = Augmented<AST.HtmlElement, AllAugmentations>;

--- a/packages/prettier-plugin-liquid/test/embed-script-tag/fixed.liquid
+++ b/packages/prettier-plugin-liquid/test/embed-script-tag/fixed.liquid
@@ -23,7 +23,7 @@ It should pretty print json inside a script tag
 It should pretty print typescript
 <script type="application/x-typescript">
   type Node = LiquidNode | HtmlNode | TextNode;
-  type LiquidNode = LiquidDrop | LiquidTag;
+  type LiquidNode = LiquidVariableOutput | LiquidTag;
   function print(node: Node) {
     return node.toString();
   }

--- a/packages/prettier-plugin-liquid/test/embed-script-tag/index.liquid
+++ b/packages/prettier-plugin-liquid/test/embed-script-tag/index.liquid
@@ -15,7 +15,7 @@ It should pretty print json inside a script tag
 It should pretty print typescript
 <script type="application/x-typescript">
 type Node = LiquidNode|HtmlNode|TextNode
-type LiquidNode = LiquidDrop|LiquidTag
+type LiquidNode = LiquidVariableOutput|LiquidTag
 function print(node:Node){return node.toString();}
 </script>
 

--- a/packages/theme-check-common/src/checks/asset-size-css/index.ts
+++ b/packages/theme-check-common/src/checks/asset-size-css/index.ts
@@ -16,7 +16,10 @@ import {
 } from '../utils';
 import { assertFileExists, assertFileSize, getFileSize } from '../../utils/file-utils';
 import { last } from '../../utils';
-import { LiquidDrop, TextNode } from '@shopify/prettier-plugin-liquid/dist/parser/stage-2-ast';
+import {
+  LiquidVariableOutput,
+  TextNode,
+} from '@shopify/prettier-plugin-liquid/dist/parser/stage-2-ast';
 
 type LiquidVariable = NodeOfType<NodeTypes.LiquidVariable>;
 
@@ -28,8 +31,8 @@ function isTextNode(node: LiquidHtmlNode): node is TextNode {
   return node.type === NodeTypes.TextNode;
 }
 
-function isLiquidDrop(node: LiquidHtmlNode): node is LiquidDrop {
-  return node.type === NodeTypes.LiquidDrop;
+function isLiquidVariableOutput(node: LiquidHtmlNode): node is LiquidVariableOutput {
+  return node.type === NodeTypes.LiquidVariableOutput;
 }
 
 function isLiquidVariable(node: LiquidHtmlNode | string): node is LiquidVariable {
@@ -110,7 +113,7 @@ export const AssetSizeCSS: LiquidCheckDefinition = {
         if (!href) return;
         if (href.value.length !== 1) return;
 
-        /* This ensures that the link entered is a text and not anything else like http//..{} 
+        /* This ensures that the link entered is a text and not anything else like http//..{}
            This also checks if the value starts with 'http://', 'https://' or '//' to ensure its a valid link. */
         if (isTextNode(href.value[0]) && /(https?:)?\/\//.test(href.value[0].value)) {
           const url = href.value[0].value;
@@ -118,10 +121,10 @@ export const AssetSizeCSS: LiquidCheckDefinition = {
         }
 
         /* This code checks if we have a link with a liquid variable
-        and that its a string with one filter, `asset_url`. This is done to ensure our .css link is 
+        and that its a string with one filter, `asset_url`. This is done to ensure our .css link is
         entered with a 'asset_url' to produce valid output. */
         if (
-          isLiquidDrop(href.value[0]) &&
+          isLiquidVariableOutput(href.value[0]) &&
           isLiquidVariable(href.value[0].markup) &&
           isString(href.value[0].markup.expression) &&
           href.value[0].markup.filters.length === 1 &&

--- a/packages/theme-check-common/src/checks/asset-url-filters/index.ts
+++ b/packages/theme-check-common/src/checks/asset-url-filters/index.ts
@@ -32,7 +32,7 @@ function valueIsShopifyHosted(attr: ValuedHtmlAttribute): boolean {
   const ASSET_URL_OBJECT_NAMES = [LIQUID_OBJECT];
 
   return attr.value.some((node) => {
-    if (!isNodeOfType(NodeTypes.LiquidDrop, node)) return false;
+    if (!isNodeOfType(NodeTypes.LiquidVariableOutput, node)) return false;
     if (typeof node.markup === 'string') return false;
     if (!isNodeOfType(NodeTypes.LiquidVariable, node.markup)) return false;
 

--- a/packages/theme-check-common/src/checks/content-for-header-modification/index.ts
+++ b/packages/theme-check-common/src/checks/content-for-header-modification/index.ts
@@ -59,13 +59,13 @@ export const ContentForHeaderModification: LiquidCheckDefinition = {
           checkContentForHeader(node.markup.expression, node.position);
         } else if (isLiquidTagCapture(node) && node.children) {
           for (const child of node.children) {
-            if (child.type === NodeTypes.LiquidDrop && typeof child.markup !== 'string') {
+            if (child.type === NodeTypes.LiquidVariableOutput && typeof child.markup !== 'string') {
               checkContentForHeader(child.markup.expression, child.position);
             }
           }
         }
       },
-      async LiquidDrop(node) {
+      async LiquidVariableOutput(node) {
         if (typeof node.markup === 'string') return;
 
         if (node.markup.filters.length) {

--- a/packages/theme-check-common/src/checks/parser-blocking-script/index.spec.ts
+++ b/packages/theme-check-common/src/checks/parser-blocking-script/index.spec.ts
@@ -46,7 +46,7 @@ describe('Module: ParserBlockingScript', () => {
   });
 
   describe('Case: LiquidFilter corrections', () => {
-    it('should suggest to replace a LiquidDrop with a script tag that has the expression as URL', async () => {
+    it('should suggest to replace a LiquidVariableOutput with a script tag that has the expression as URL', async () => {
       const file = "{{ 'asset' | script_tag }}";
       const offenses = await reportOffenses(
         {
@@ -73,7 +73,7 @@ describe('Module: ParserBlockingScript', () => {
       expect(suggestions).to.include(`<script src="{{ 'asset' }}" async></script>`);
     });
 
-    it('should suggest to replace a LiquidDrop with a script tag that has the expression and previous filters as URL', async () => {
+    it('should suggest to replace a LiquidVariableOutput with a script tag that has the expression and previous filters as URL', async () => {
       const file = "{{ 'asset' | asset_url | script_tag }}";
       const offenses = await reportOffenses(
         {

--- a/packages/theme-check-common/src/checks/parser-blocking-script/index.ts
+++ b/packages/theme-check-common/src/checks/parser-blocking-script/index.ts
@@ -41,7 +41,7 @@ export const ParserBlockingScript: LiquidCheckDefinition = {
           endIndex: node.position.end,
           suggest:
             grandParentNode &&
-            grandParentNode.type === NodeTypes.LiquidDrop &&
+            grandParentNode.type === NodeTypes.LiquidVariableOutput &&
             parentNode &&
             parentNode.type === NodeTypes.LiquidVariable &&
             last(parentNode.filters) === node

--- a/packages/theme-check-common/src/checks/parser-blocking-script/suggestions.ts
+++ b/packages/theme-check-common/src/checks/parser-blocking-script/suggestions.ts
@@ -7,7 +7,7 @@ import { last } from '../../utils';
 
 type LiquidVariable = LiquidHtmlNodeOfType<NodeTypes.LiquidVariable>;
 type LiquidFilter = LiquidHtmlNodeOfType<NodeTypes.LiquidFilter>;
-type LiquidDrop = LiquidHtmlNodeOfType<NodeTypes.LiquidDrop>;
+type LiquidVariableOutput = LiquidHtmlNodeOfType<NodeTypes.LiquidVariableOutput>;
 type HtmlRawNode = LiquidHtmlNodeOfType<NodeTypes.HtmlRawNode>;
 
 const suggestionMessage = (attr: 'defer' | 'async') =>
@@ -17,7 +17,7 @@ export const liquidFilterSuggestion = (
   attr: 'defer' | 'async',
   node: LiquidFilter,
   parentNode: LiquidVariable,
-  grandParentNode: LiquidDrop,
+  grandParentNode: LiquidVariableOutput,
 ): LiquidHtmlSuggestion => ({
   message: suggestionMessage(attr),
   fix(corrector) {

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
@@ -24,13 +24,13 @@ describe('Module: LiquidCompletionParams', async () => {
           expectPath(partialAst, 'type').to.eql('Document');
           expectPath(partialAst, 'name').to.eql('#document');
 
-          expectPath(partialAst, 'children.0.type').to.eql('LiquidDrop');
+          expectPath(partialAst, 'children.0.type').to.eql('LiquidVariableOutput');
           expectPath(partialAst, 'children.0.markup.type').to.eql('LiquidVariable');
           expectPath(partialAst, 'children.0.markup.expression.type').to.eql('String');
           expectPath(partialAst, 'children.0.markup.expression.value').to.eql('hey');
           expectPath(partialAst, 'children.0.markup.rawSource').to.eql('"hey"');
 
-          expectPath(partialAst, 'children.1.type').to.eql('LiquidDrop');
+          expectPath(partialAst, 'children.1.type').to.eql('LiquidVariableOutput');
           expectPath(partialAst, 'children.1.markup.type').to.eql('LiquidVariable');
           expectPath(partialAst, 'children.1.markup.expression.type').to.eql('VariableLookup');
           expectPath(partialAst, 'children.1.markup.expression.name').to.eql('product');

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -277,7 +277,7 @@ function findCurrentNode(
         break;
       }
 
-      case NodeTypes.LiquidDrop: {
+      case NodeTypes.LiquidVariableOutput: {
         if (typeof current.markup !== 'string') {
           finder.current = current.markup;
         }

--- a/packages/theme-language-server-common/src/completions/params/fix.ts
+++ b/packages/theme-language-server-common/src/completions/params/fix.ts
@@ -85,9 +85,9 @@ class Fixer {
    *   - < "       # (single quote is ignored)
    *   - <         # close quote
    *   - < "       # open new quote
-   *   - < " {{    # open liquid drop
-   *   - < " {{ '  # open liquid string in drop
-   *   - < " {{    # close liquid string in drop
+   *   - < " {{    # open liquid variable output
+   *   - < " {{ '  # open liquid string in variable output
+   *   - < " {{    # close liquid string in variable output
    *
    * then we pop the close characters of that stack onto the string and
    * have a fixed string


### PR DESCRIPTION
A drop is a type. This node is meant to represent `{{ }}` and its
insides. This has been a mistake for a long time and we should fix this
before open sourcing and before folks write their own checks.

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
