### PR TITLE
Completed `AssetSizeJavascript` check

### DIFF
--- a/.changeset/light-masks-exercise.md
+++ b/.changeset/light-masks-exercise.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-browser': minor
+'@shopify/theme-check-node': minor
+---
+
+Add `AssetSizeJavascript` check

--- a/packages/theme-check-common/src/checks/asset-size-javascript/index.spec.ts
+++ b/packages/theme-check-common/src/checks/asset-size-javascript/index.spec.ts
@@ -1,0 +1,169 @@
+import { expect, describe, it } from 'vitest';
+import { AssetSizeJavaScript } from '.';
+import { check, MockTheme } from '../../test';
+import { SchemaProp } from '../../types';
+
+describe('Module: AssetSizeJavaScript', () => {
+  const theme: MockTheme = {
+    'assets/theme.js': "console.log('hello world'); console.log('Oh. Hi Mark!')",
+    'templates/index.liquid': `
+      <html>
+        <head>
+          <script src="{{ 'theme.js' | asset_url }}" defer></script>
+        </head>
+      </html>
+    `,
+  };
+
+  const httpTest: MockTheme = {
+    'templates/index.liquid': `
+      <html>
+        <head>
+          <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" defer></script>
+        </head>
+      </html>
+    `,
+  };
+
+  it('should not find file size for invalid URLs', async () => {
+    const invalidUrls = [
+      'https://{{ settings.url }}',
+      "{{ 'this_file_does_not_exist.js' | asset_url }}",
+      '{% if on_product %}https://hello.world{% else %}https://hi.world{% endif %}',
+    ];
+
+    for (const url of invalidUrls) {
+      const offenses = await check(
+        { 'templates/index.liquid': `<script src="${url}" defer></script>` },
+        [AssetSizeJavaScript],
+      );
+      expect(offenses).toHaveLength(0);
+    }
+  });
+
+  it('should report a warning when the JavaScript http request exceeds the threshold', async () => {
+    const CustomAssetSizeJavaScript = {
+      ...AssetSizeJavaScript,
+      meta: {
+        ...AssetSizeJavaScript.meta,
+        schema: {
+          thresholdInBytes: SchemaProp.number(1),
+        },
+      },
+    };
+    const offenses = await check(httpTest, [CustomAssetSizeJavaScript]);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0]).toMatchObject({
+      message:
+        'JavaScript on every page load exceeds compressed size threshold (1 Bytes), consider using the import on interaction pattern.',
+      absolutePath: '/templates/index.liquid',
+      start: { index: 52 },
+      end: { index: 121 },
+    });
+  });
+
+  it('should not report any offenses if JavaScript is smaller than threshold', async () => {
+    const offenses = await check(theme, [AssetSizeJavaScript]);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should report an offense if JavaScript is larger than threshold', async () => {
+    const CustomAssetSizeJavaScript = {
+      ...AssetSizeJavaScript,
+      meta: {
+        ...AssetSizeJavaScript.meta,
+        schema: {
+          thresholdInBytes: SchemaProp.number(2),
+        },
+      },
+    };
+
+    const offenses = await check(theme, [CustomAssetSizeJavaScript]);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0]).toMatchObject({
+      message:
+        'JavaScript on every page load exceeds compressed size threshold (2 Bytes), consider using the import on interaction pattern.',
+      absolutePath: '/templates/index.liquid',
+      start: { index: 52 },
+      end: { index: 80 },
+    });
+  });
+
+  it('should not report any offenses for inline JavaScript', async () => {
+    const inlineTheme: MockTheme = {
+      'templates/index.liquid': `
+        <html>
+          <head>
+            <script>
+              console.log('hello world');
+            </script>
+          </head>
+        </html>
+      `,
+    };
+
+    const offenses = await check(inlineTheme, [AssetSizeJavaScript]);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should report an offense if JS is larger than threshold', async () => {
+    const extensionFiles: MockTheme = {
+      'assets/theme.js': 'console.log("hello world");',
+      'templates/index.liquid': `
+        <html>
+          <head>
+            {{ 'theme.js' | asset_url | script_tag }}
+            {{ "https://example.com" | script_tag }}
+          </head>
+        </html>
+      `,
+    };
+
+    const CustomAssetSizeCSS = {
+      ...AssetSizeJavaScript,
+      meta: {
+        ...AssetSizeJavaScript.meta,
+        schema: {
+          thresholdInBytes: SchemaProp.number(2),
+        },
+      },
+    };
+
+    const offenses = await check(extensionFiles, [CustomAssetSizeCSS]);
+
+    expect(offenses).toHaveLength(2);
+    expect(offenses[0]).toMatchObject({
+      message:
+        'JavaScript on every page load exceeds compressed size threshold (2 Bytes), consider using the import on interaction pattern.',
+      absolutePath: '/templates/index.liquid',
+      start: { index: 48 },
+      end: { index: 84 },
+    });
+    expect(offenses[1]).toMatchObject({
+      message:
+        'JavaScript on every page load exceeds compressed size threshold (2 Bytes), consider using the import on interaction pattern.',
+      absolutePath: '/templates/index.liquid',
+      start: { index: 102 },
+      end: { index: 123 },
+    });
+  });
+
+  it('should not report any offenses if there is no javascript', async () => {
+    const extensionFiles: MockTheme = {
+      'templates/index.liquid': `
+        <html>
+          <head>
+          </head>
+        </html>
+      `,
+    };
+
+    const offenses = await check(extensionFiles, [AssetSizeJavaScript]);
+
+    expect(offenses).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/asset-size-javascript/index.ts
+++ b/packages/theme-check-common/src/checks/asset-size-javascript/index.ts
@@ -1,0 +1,142 @@
+import {
+  LiquidString,
+  LiquidVariable,
+  LiquidVariableOutput,
+  NodeTypes,
+  TextNode,
+} from '@shopify/liquid-html-parser';
+import {
+  LiquidCheckDefinition,
+  LiquidHtmlNode,
+  SchemaProp,
+  Severity,
+  SourceCodeType,
+} from '../../types';
+import { last } from '../../utils';
+import {
+  hasRemoteAssetSizeExceededThreshold,
+  hasLocalAssetSizeExceededThreshold,
+} from '../../utils/file-utils';
+import { ValuedHtmlAttribute, isAttr, isNodeOfType, isValuedHtmlAttribute } from '../utils';
+
+const schema = {
+  thresholdInBytes: SchemaProp.number(10000),
+};
+
+function isTextNode(node: LiquidHtmlNode): node is TextNode {
+  return node.type === NodeTypes.TextNode;
+}
+
+function isLiquidVariableOutput(node: LiquidHtmlNode): node is LiquidVariableOutput {
+  return node.type === NodeTypes.LiquidVariableOutput;
+}
+
+function isLiquidVariable(node: LiquidHtmlNode | string): node is LiquidVariable {
+  return typeof node !== 'string' && node.type === NodeTypes.LiquidVariable;
+}
+
+function isString(node: LiquidHtmlNode): node is LiquidString {
+  return node.type === NodeTypes.String;
+}
+
+export const AssetSizeJavaScript: LiquidCheckDefinition<typeof schema> = {
+  meta: {
+    code: 'AssetSizeJavaScript',
+    name: 'Prevent Large JavaScript bundles',
+    docs: {
+      description: 'This check is aimed at preventing large JavaScript bundles for speed.',
+      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/asset-size-javascript',
+      recommended: false,
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema,
+    targets: [],
+  },
+
+  create(context) {
+    if (!context.fileSize) {
+      return {};
+    }
+
+    const thresholdInBytes = context.settings.thresholdInBytes;
+
+    async function checkRemoteAssetSize(url: string, position: { start: number; end: number }) {
+      if (await hasRemoteAssetSizeExceededThreshold(url, thresholdInBytes)) {
+        context.report({
+          message: `JavaScript on every page load exceeds compressed size threshold (${thresholdInBytes} Bytes), consider using the import on interaction pattern.`,
+          startIndex: position.start,
+          endIndex: position.end,
+        });
+      }
+    }
+
+    async function checkThemeAssetSize(srcValue: string, position: { start: number; end: number }) {
+      if (await hasLocalAssetSizeExceededThreshold(context, srcValue, thresholdInBytes)) {
+        context.report({
+          message: `JavaScript on every page load exceeds compressed size threshold (${thresholdInBytes} Bytes), consider using the import on interaction pattern.`,
+          startIndex: position.start,
+          endIndex: position.end,
+        });
+      }
+    }
+
+    return {
+      async HtmlRawNode(node) {
+        if (node.name !== 'script') return;
+
+        const src: ValuedHtmlAttribute | undefined = node.attributes
+          .filter(isValuedHtmlAttribute)
+          .find((attr) => isAttr(attr, 'src'));
+        if (!src) return;
+        if (src.value.length !== 1) return;
+
+        if (isTextNode(src.value[0]) && /(https?:)?\/\//.test(src.value[0].value)) {
+          const url = src.value[0].value;
+          await checkRemoteAssetSize(url, src.attributePosition);
+        }
+
+        if (
+          isLiquidVariableOutput(src.value[0]) &&
+          isLiquidVariable(src.value[0].markup) &&
+          isString(src.value[0].markup.expression) &&
+          src.value[0].markup.filters.length === 1 &&
+          src.value[0].markup.filters[0].name === 'asset_url'
+        ) {
+          const assetName = src.value[0].markup.expression.value;
+          await checkThemeAssetSize(assetName, src.attributePosition);
+        }
+      },
+
+      async LiquidFilter(node, ancestors) {
+        if (node.name !== 'script_tag') return;
+
+        const liquidVariableParent = last(ancestors);
+
+        if (!liquidVariableParent || !isNodeOfType(NodeTypes.LiquidVariable, liquidVariableParent))
+          return;
+
+        if (liquidVariableParent.expression.type !== NodeTypes.String) return;
+
+        if (
+          liquidVariableParent.expression.value[0].length == 1 &&
+          liquidVariableParent.filters.length == 1 &&
+          /(https?:)?\/\//.test(liquidVariableParent.expression.value)
+        ) {
+          const url = liquidVariableParent.expression.value;
+          await checkRemoteAssetSize(url, liquidVariableParent.expression.position);
+        }
+
+        if (
+          liquidVariableParent.expression.value[0].length == 1 &&
+          liquidVariableParent.filters.length == 2 &&
+          liquidVariableParent.filters[0].name === 'asset_url' &&
+          liquidVariableParent.filters[1].name === 'script_tag'
+        ) {
+          const js = liquidVariableParent.expression.value;
+          await checkThemeAssetSize(js, liquidVariableParent.position);
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -30,6 +30,7 @@ import { AssetSizeAppBlockJavaScript } from './asset-size-app-block-javascript';
 import { AssetSizeCSS } from './asset-size-css';
 import { DeprecatedFilters } from './deprecated-filters';
 import { DeprecatedTags } from './deprecated-tags';
+import { AssetSizeJavaScript } from './asset-size-javascript';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
@@ -37,6 +38,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AssetSizeAppBlockCSS,
   AssetSizeAppBlockJavaScript,
   AssetSizeCSS,
+  AssetSizeJavaScript,
   AssetUrlFilters,
   CdnPreconnect,
   ContentForHeaderModification,

--- a/packages/theme-check-common/src/utils/file-utils.ts
+++ b/packages/theme-check-common/src/utils/file-utils.ts
@@ -35,3 +35,21 @@ export async function getFileSize(url: string): Promise<number> {
     return 0;
   }
 }
+
+export async function hasRemoteAssetSizeExceededThreshold(url: string, thresholdInBytes: number) {
+  const fileSize = await getFileSize(url);
+  return fileSize > thresholdInBytes;
+}
+
+export async function hasLocalAssetSizeExceededThreshold<
+  T extends SourceCodeType,
+  S extends Schema,
+>(context: Context<T, S>, path: string, thresholdInBytes: number) {
+  const absolutePath = `assets/${path}`;
+  const fileExists = await assertFileExists(context, absolutePath);
+
+  if (!fileExists) return;
+  const fileExceedsThreshold = await assertFileSize(context, absolutePath, thresholdInBytes);
+
+  return fileExceedsThreshold;
+}

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -21,6 +21,10 @@ AssetSizeCSS:
   enabled: true
   severity: 0
   thresholdInBytes: 100000
+AssetSizeJavaScript:
+  enabled: true
+  severity: 0
+  thresholdInBytes: 10000
 AssetUrlFilters:
   enabled: true
   severity: 1


### PR DESCRIPTION
Resolves https://github.com/Shopify/theme-check-js/issues/44
# What are you adding in this PR?

This PR is adding the `AssetSizeJavascript` check. This solution is very similar to the `AssetSizeCSS` check, but deals with its own unique cases such as the use of a script/script tag

I also made 2 functions which are, `isRemoteAssetFileSize` and `isThemeAssetSize` universal to make the code cleaner.
## What's next? Any followup issues?

None.

## Before you deploy

<!-- If a checklist is not applicable, you can delete it. -->

## TopHat Screenshots
<img width="767" alt="Screenshot 2023-09-19 at 1 26 08 PM" src="https://github.com/Shopify/theme-tools/assets/90271670/49195820-a6cd-4226-96ab-8b30b2ceb421">

<img width="786" alt="Screenshot 2023-09-19 at 1 26 45 PM" src="https://github.com/Shopify/theme-tools/assets/90271670/89bce450-9870-4076-bee3-7c470f9d8a28">



<!-- Include this check when updating anything within packages/theme-check-* -->
- [x] This PR includes a new checks
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn update-configs` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->

