### PR TITLE
Rename the opt-in flag to themeCheckNextDevPreview

### DIFF
--- a/archives/theme-check-js/CONTRIBUTING.md
+++ b/archives/theme-check-js/CONTRIBUTING.md
@@ -69,7 +69,7 @@ code ../theme-check-vscode
 
 - In the Settings.json, set these setting:
 ```json
-"shopifyLiquid.onlineStoreCodeEditorMode": true,
+"shopifyLiquid.themeCheckNextDevPreview": true,
 "shopifyLiquid.trace.server": "verbose",
 ```
 - Now simply open a theme directory in the VSCode window and you should see the checks running.

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -44,7 +44,7 @@ To install the `shopify` CLI, follow these steps:
 
 - `"shopifyLiquid.shopifyCLIPath": string`, (optional, Unix-only) a path to the `shopify` executable.
 - `"shopifyLiquid.languageServerPath": string`, (optional) a path to the `theme-check-language-server` executable.
-- `"shopifyLiquid.onlineStoreCodeEditorMode": boolean`, (optional) when true, will use `@shopify/theme-language-server-node` as the language server instead of the ruby version (aka batteries-included mode). Supercedes `shopifyCLIPath` and `languageServerPath`.
+- `"shopifyLiquid.themeCheckNextDevPreview": boolean`, (optional) when true, will use `@shopify/theme-language-server-node` as the language server instead of the ruby version (aka batteries-included mode). Supercedes `shopifyCLIPath` and `languageServerPath`.
 - `"shopifyLiquid.disableWindowsWarning": boolean`, (default: `false`) When true, theme check won't bug you with the Windows warning anymore.
 - `"themeCheck.checkOnOpen": boolean`, (default: `true`) makes it so theme check runs on file open.
 - `"themeCheck.checkOnChange": boolean`, (default: `true`) makes it so theme check runs on file change.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -119,7 +119,7 @@
           "default": null,
           "description": "Path to theme-check-language-server. Defaults to `which theme-check-language-server` if available on `$PATH`."
         },
-        "shopifyLiquid.onlineStoreCodeEditorMode": {
+        "shopifyLiquid.themeCheckNextDevPreview": {
           "type": [
             "boolean"
           ],

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -50,7 +50,7 @@ export async function activate(extensionContext: ExtensionContext) {
   context.subscriptions.push(commands.registerCommand('shopifyLiquid.restart', restartServer));
   context.subscriptions.push(
     commands.registerCommand('shopifyLiquid.runChecks', () => {
-      const isRubyLanguageServer = !getConfig('shopifyLiquid.onlineStoreCodeEditorMode');
+      const isRubyLanguageServer = !getConfig('shopifyLiquid.themeCheckNextDevPreview');
       client!.sendRequest('workspace/executeCommand', {
         command: isRubyLanguageServer ? 'runChecks' : 'themeCheck/runChecks',
       });
@@ -140,7 +140,7 @@ function onConfigChange(event: { affectsConfiguration: (arg0: string) => any }) 
   const didChangeThemeCheck = event.affectsConfiguration('shopifyLiquid.languageServerPath');
   const didChangeShopifyCLI = event.affectsConfiguration('shopifyLiquid.shopifyCLIPath');
   const didChangeOnlineStoreCodeEditorMode = event.affectsConfiguration(
-    'shopifyLiquid.onlineStoreCodeEditorMode',
+    'shopifyLiquid.themeCheckNextDevPreview',
   );
   if (didChangeThemeCheck || didChangeShopifyCLI || didChangeOnlineStoreCodeEditorMode) {
     restartServer();
@@ -157,7 +157,7 @@ async function getServerOptions(): Promise<ServerOptions | undefined> {
     );
   }
 
-  if (getConfig('shopifyLiquid.onlineStoreCodeEditorMode')) {
+  if (getConfig('shopifyLiquid.themeCheckNextDevPreview')) {
     const serverModule = context!.asAbsolutePath(path.join('dist', 'server.js'));
     return {
       run: {


### PR DESCRIPTION
# What are you adding in this PR?

Before:
```
"shopifyLiquid.onlineStoreCodeEditorMode": true,
```

After:
```
"shopifyLiquid.themeCheckNextDevPreview": true,
```

- [x] I included a patch bump `changeset` to this PR
