### PR TITLE
Theme Tools Release: 22-09-23

### DIFF
--- a/.changeset/thick-lions-join.md
+++ b/.changeset/thick-lions-join.md
@@ -1,6 +1,0 @@
----
-'theme-check-vscode': patch
-'@shopify/theme-language-server-node': patch
----
-
-Fixup missing dep

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-language-server-browser
 
+## 1.0.2
+
+### Patch Changes
+
+- @shopify/theme-language-server-common@1.0.2
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -23,7 +23,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.0.1",
+    "@shopify/theme-language-server-common": "1.0.2",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @shopify/theme-language-server-common
 
+## 1.0.2
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-node
 
+## 1.0.2
+
+### Patch Changes
+
+- da94dfe: Fixup missing dep
+  - @shopify/theme-language-server-common@1.0.2
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -22,7 +22,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.0.1",
+    "@shopify/theme-language-server-common": "1.0.2",
     "@shopify/theme-check-node": "^1.13.1",
     "@shopify/theme-check-docs-updater": "^1.13.1",
     "node-fetch": "^2.6.11",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## theme-check-vscode
 
+## 1.11.2
+
+### Patch Changes
+
+- da94dfe: Fixup missing dep
+- Updated dependencies [da94dfe]
+  - @shopify/theme-language-server-node@1.0.2
+
 ## 1.11.1
 
 ### Patch Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "charlespwd"
   },
-  "version": "1.11.1",
+  "version": "1.11.2",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -58,7 +58,7 @@
     "vscode": "^1.74.0"
   },
   "dependencies": {
-    "@shopify/theme-language-server-node": "^1.0.1",
+    "@shopify/theme-language-server-node": "^1.0.2",
     "@shopify/liquid-html-parser": "^1.0.0",
     "@shopify/prettier-plugin-liquid": "^1.3.0",
     "prettier": "^2.6.2",


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `1.11.1` -> `1.11.2`
### Changes:
- Fixup missing dep

## `@shopify/theme-language-server-node`
Patch incremented `1.0.1` -> `1.0.2`
### Changes:
- Fixup missing dep

## `@shopify/theme-language-server-browser`
Patch incremented `1.0.1` -> `1.0.2`

## `@shopify/theme-language-server-common`
Patch incremented `1.0.1` -> `1.0.2`

