### PR TITLE
Introducing `UndefinedObject` check

### DIFF
--- a/.changeset/green-candles-accept.md
+++ b/.changeset/green-candles-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Introduce 'UndefinedObject' check

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -31,6 +31,7 @@ import { AssetSizeCSS } from './asset-size-css';
 import { DeprecatedFilters } from './deprecated-filters';
 import { DeprecatedTags } from './deprecated-tags';
 import { AssetSizeJavaScript } from './asset-size-javascript';
+import { UndefinedObject } from './undefined-object';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
@@ -57,6 +58,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   RequiredLayoutThemeObject,
   TranslationKeyExists,
   UnknownFilter,
+  UndefinedObject,
   UnusedAssign,
   ValidHTMLTranslation,
   ValidSchema,

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -1,0 +1,205 @@
+import { expect, describe, it } from 'vitest';
+import { UndefinedObject } from './index';
+import { runLiquidCheck, highlightedOffenses } from '../../test';
+
+describe('Module: UndefinedObject', () => {
+  it('should report an offense when object is undefined', async () => {
+    const sourceCode = `
+      {{ my_var }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'my_var' used."]);
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual(['my_var']);
+  });
+
+  it('should report an offense when object with an attribute is undefined', async () => {
+    const sourceCode = `
+      {{ my_var.my_attr }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'my_var' used."]);
+  });
+
+  it('should report an offense when undefined object is used as an argument', async () => {
+    const sourceCode = `
+      {{ product[my_object] }}
+      {{ product[my_object] }}
+
+      {% comment %} string arguments should not be reported {% endcomment %}
+      {{ product["my_object"] }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(2);
+    expect(offenses.map((e) => e.message)).toEqual([
+      "Unknown object 'my_object' used.",
+      "Unknown object 'my_object' used.",
+    ]);
+  });
+
+  it('should report an offense when object is undefined in a Liquid tag', async () => {
+    const sourceCode = `
+    {% liquid
+      echo my_var
+    %}
+  `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'my_var' used."]);
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual(['my_var']);
+  });
+
+  it('should not report an offense when object is defined with an assign tag', async () => {
+    const sourceCode = `
+      {% assign my_var = "value" %}
+      {{ my_var }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should not report an offense when object is defined with an assign tag and it is used as an argument', async () => {
+    const sourceCode = `
+      {% assign prop = "title" %}
+      {{ product[prop] }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should not report an offense when object is defined with an assign tag in a Liquid tag', async () => {
+    const sourceCode = `
+      {% liquid
+        assign my_var = "value"
+        echo my_var
+      %}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should not report an offense when object is defined with a capture tag', async () => {
+    const sourceCode = `
+      {% capture my_var %} value {% endcapture %}
+      {{ my_var }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should not report an offense when object is defined in a for loop', async () => {
+    const sourceCode = `
+      {% for c in collections %}
+        {{ c }}
+      {% endfor %}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should report an offense when object is defined in a for loop but used outside of the scope', async () => {
+    const sourceCode = `
+      {% for c in collections %}
+        {{ c }}
+      {% endfor %}{{ c }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'c' used."]);
+  });
+
+  it('should report an offense when object is defined in a for loop but used outside of the scope (in scenarios where the same variable has multiple scopes in the file)', async () => {
+    const sourceCode = `
+      {% for c in collections %}
+        {% comment %} -- Scope 1 -- {% endcomment %}
+        {{ c }}
+      {% endfor %}
+      {{ c }}
+      {% for c in collections %}
+        {% comment %} -- Scope 2 -- {% endcomment %}
+        {{ c }}
+      {% endfor %}
+      {{ c }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(2);
+    expect(offenses.map((e) => e.message)).toEqual([
+      "Unknown object 'c' used.",
+      "Unknown object 'c' used.",
+    ]);
+  });
+
+  it('should report an offense when undefined object defines another object', async () => {
+    const sourceCode = `
+      {% assign my_object = my_var %}
+      {{ my_object }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'my_var' used."]);
+  });
+
+  it('should not report an offense when object is defined in a tablerow loop', async () => {
+    const sourceCode = `
+      {% tablerow c in collections %}
+        {{ c }}
+      {% endtablerow %}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should report an offense when object is defined in a tablerow loop but used outside of the scope', async () => {
+    const sourceCode = `
+      {% tablerow c in collections %}
+        {{ c }}
+      {% endtablerow %}{{ c }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'c' used."]);
+  });
+
+  it('should not report an offense when object is undefined in a "snippet" file', async () => {
+    const sourceCode = `
+      {{ my_var }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode, 'snippets/file.liquid');
+
+    expect(offenses).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -202,4 +202,15 @@ describe('Module: UndefinedObject', () => {
 
     expect(offenses).toHaveLength(0);
   });
+
+  it('should report an offense when object is not global', async () => {
+    const sourceCode = `
+      {{ image }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'image' used."]);
+  });
 });

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -1,0 +1,156 @@
+import {
+  LiquidHtmlNode,
+  LiquidTag,
+  LiquidTagAssign,
+  LiquidTagCapture,
+  LiquidTagFor,
+  LiquidTagTablerow,
+  LiquidVariableLookup,
+  NamedTags,
+  NodeTypes,
+  Position,
+} from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { last } from '../../utils';
+
+type Scope = { start?: number; end?: number };
+
+export const UndefinedObject: LiquidCheckDefinition = {
+  meta: {
+    code: 'UndefinedObject',
+    name: 'Undefined Object',
+    docs: {
+      description: 'This check exists to identify references to undefined Liquid objects.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/undefined-object',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    /**
+     * At present, snippet assets are not supported due to the inability of this
+     * check to handle objects defined in other assets.
+     */
+    if (context.relativePath(context.file.absolutePath).startsWith('snippets/')) {
+      return {};
+    }
+
+    const variableScopes: Map<string, Scope[]> = new Map();
+    const variables: LiquidVariableLookup[] = [];
+
+    function indexVariableScope(variableName: string | null, scope: Scope) {
+      if (!variableName) return;
+
+      const indexedScope = variableScopes.get(variableName) ?? [];
+      const currentScope = [...indexedScope, scope];
+
+      variableScopes.set(variableName, currentScope);
+    }
+
+    return {
+      async LiquidTag(node) {
+        if (isLiquidTagAssign(node)) {
+          indexVariableScope(node.markup.name, {
+            start: node.blockStartPosition.end,
+            end: node.blockEndPosition?.start,
+          });
+        }
+
+        if (isLiquidTagCapture(node)) {
+          indexVariableScope(node.markup.name, {
+            start: node.blockEndPosition?.end,
+          });
+        }
+
+        if (isLiquidForTag(node) || isLiquidTableRowTag(node)) {
+          indexVariableScope(node.markup.variableName, {
+            start: node.blockStartPosition.end,
+            end: node.blockEndPosition?.start,
+          });
+        }
+      },
+
+      async VariableLookup(node, ancestors) {
+        const parent = last(ancestors);
+
+        if (isLiquidTag(parent) && isLiquidTagCapture(parent)) return;
+
+        variables.push(node);
+      },
+
+      async onCodePathEnd() {
+        if (context.themeDocset) {
+          const objects = await context.themeDocset.objects();
+          objects.forEach((obj) => variableScopes.set(obj.name, []));
+        }
+
+        variables.forEach((variable) => {
+          if (!variable.name) return;
+
+          const isVariableDefined = isDefined(variable.name, variable.position, variableScopes);
+          if (isVariableDefined) return;
+
+          context.report({
+            message: `Unknown object '${variable.name}' used.`,
+            startIndex: variable.position.start,
+            endIndex: variable.position.end,
+          });
+        });
+      },
+    };
+  },
+};
+
+function isDefined(
+  variableName: string,
+  variablePosition: Position,
+  scopedVariables: Map<string, Scope[]>,
+): boolean {
+  const scopes = scopedVariables.get(variableName);
+  /**
+   * If there's no scope, the variable is not defined.
+   */
+  if (!scopes) return false;
+
+  /**
+   * If there are no scopes, the variable is globally defined.
+   */
+  if (scopes.length === 0) return true;
+
+  /**
+   * Checks if a variable is defined within any of the given scopes.
+   */
+  return scopes.some((scope) => isDefinedInScope(variablePosition, scope));
+}
+
+function isDefinedInScope(variablePosition: Position, scope: Scope) {
+  const start = variablePosition.start;
+  const isVariableAfterScopeStart = !scope.start || start > scope.start;
+  const isVariableBeforeScopeEnd = !scope.end || start < scope.end;
+
+  return isVariableAfterScopeStart && isVariableBeforeScopeEnd;
+}
+
+function isLiquidTag(node?: LiquidHtmlNode): node is LiquidTag {
+  return node?.type === NodeTypes.LiquidTag;
+}
+
+function isLiquidTagCapture(node: LiquidTag): node is LiquidTagCapture {
+  return node.name === NamedTags.capture;
+}
+
+function isLiquidTagAssign(node: LiquidTag): node is LiquidTagAssign {
+  return node.name === NamedTags.assign && typeof node.markup !== 'string';
+}
+
+function isLiquidForTag(node: LiquidTag): node is LiquidTagFor {
+  return node.name === NamedTags.for && typeof node.markup !== 'string';
+}
+
+function isLiquidTableRowTag(node: LiquidTag): node is LiquidTagTablerow {
+  return node.name === NamedTags.tablerow && typeof node.markup !== 'string';
+}

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -46,9 +46,7 @@ export const UndefinedObject: LiquidCheckDefinition = {
       if (!variableName) return;
 
       const indexedScope = variableScopes.get(variableName) ?? [];
-      const currentScope = [...indexedScope, scope];
-
-      variableScopes.set(variableName, currentScope);
+      variableScopes.set(variableName, indexedScope.concat(scope));
     }
 
     return {

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -121,7 +121,27 @@ export async function check(
         ];
       },
       async objects() {
-        return [{ name: 'product' }, { name: 'collections' }];
+        return [
+          {
+            name: 'collections',
+          },
+          {
+            name: 'product',
+            access: {
+              global: false,
+              parents: [],
+              template: ['product'],
+            },
+          },
+          {
+            name: 'image',
+            access: {
+              global: false,
+              parents: [],
+              template: [],
+            },
+          },
+        ];
       },
       async tags() {
         return [];

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -121,7 +121,7 @@ export async function check(
         ];
       },
       async objects() {
-        return [];
+        return [{ name: 'product' }, { name: 'collections' }];
       },
       async tags() {
         return [];

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -78,6 +78,9 @@ RequiredLayoutThemeObject:
 TranslationKeyExists:
   enabled: true
   severity: 0
+UndefinedObject:
+  enabled: true
+  severity: 1
 UnknownFilter:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -59,6 +59,9 @@ RequiredLayoutThemeObject:
 TranslationKeyExists:
   enabled: true
   severity: 0
+UndefinedObject:
+  enabled: true
+  severity: 1
 UnknownFilter:
   enabled: true
   severity: 0


### PR DESCRIPTION
Fixes https://github.com/Shopify/theme-check-js/issues/66


https://github.com/Shopify/theme-tools/assets/1079279/7ea13af5-11c6-44d6-a585-6ce6cb965c97



# What are you adding in this PR?

The `UndefinedObject` check is being introduced to identify references to undefined Liquid objects.

This implementation largely mirrors the Ruby version, and intentionally skips snippet assets. This is because these assets depend on variables defined in parent templates, and Theme Check is designed to focus on single asset checks.

Looking ahead, the following issue is planned to be addressed next: https://github.com/Shopify/theme-tools/issues/114. Once resolved, developers will be able to annotate available variables, thereby establishing an interface/contract between Liquid templates.

Finally, this check doesn't currently provide a fix or suggestion, as the main approaches would be about (1) removing the variable or (2) ignoring the check. To enhance this, I've opened a new issue: https://github.com/Shopify/theme-tools/issues/113. This proposes a global 'ignore check' implementation, so all checks will be able to suggest an ignore dialog. I don't foresee this leading to overuse of the ignore function, as I the ignore-code introduces some noise.



## Before you deploy

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
