### PR TITLE
Improve resilience of theme check pipeline by preventing entire failure if an individual check fails

### DIFF
--- a/.changeset/silent-baboons-confess.md
+++ b/.changeset/silent-baboons-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Improve resilience of theme check pipeline by preventing entire failure if an individual check fails

--- a/packages/theme-check-common/src/index.ts
+++ b/packages/theme-check-common/src/index.ts
@@ -31,6 +31,10 @@ export * from './checks';
 export * from './to-source-code';
 export * from './ignore';
 
+const defaultErrorHandler = (_error: Error): void => {
+  // Silently ignores errors by default.
+};
+
 export async function check(
   sourceCodes: Theme,
   config: Config,
@@ -69,7 +73,8 @@ export async function check(
     }
   }
 
-  await Promise.all(pipelines);
+  const onRejected = config.onError || defaultErrorHandler;
+  await Promise.all(pipelines.map((pipeline) => pipeline.catch(onRejected)));
 
   return offenses.filter((offense) => !isDisabled(offense));
 }

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -94,6 +94,7 @@ export interface Config {
   checks: CheckDefinition<SourceCodeType, Schema>[];
   root: AbsolutePath;
   ignore?: string[];
+  onError?: (error: Error) => void;
 }
 
 export type NodeOfType<T extends SourceCodeType, NT> = Extract<AST[T], { type: NT }>;


### PR DESCRIPTION
Fixes https://github.com/Shopify/theme-check-js/issues/151

# What are you adding in this PR?

This PR addresses an issue where a crash in any check would lead to the failure of the entire pipeline, thereby impacting the execution of the remaining valid checks.

To mitigate this, the PR introduces the `onError` callback in the `Config` interface. This allows each channel (node, browser, etc.) to optionally define a unique callback to handle or report errors, enhancing error management capabilities.

By default, errors are still ignored, but they no longer impact the functioning of other checks.

**Before:**

https://github.com/Shopify/theme-tools/assets/1079279/1fdd7bd6-19a0-463f-892f-54bde634705e


**After:**

https://github.com/Shopify/theme-tools/assets/1079279/b48bf1bb-7f10-43fc-b22b-153ab365a601


## Before you deploy

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
