### PR TITLE
`UndefinedObject` should not show any offenses when `themeDocset` is not given

### DIFF
--- a/.changeset/funny-cycles-repeat.md
+++ b/.changeset/funny-cycles-repeat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+`UndefinedObject` should not show any offenses when themeDocset is not given

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -213,4 +213,16 @@ describe('Module: UndefinedObject', () => {
     expect(offenses).toHaveLength(1);
     expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'image' used."]);
   });
+
+  it('should not report an offenses when definitions for global objects are unavailable', async () => {
+    const sourceCode = `
+      {{ my_var }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode, 'file.liquid', {
+      themeDocset: null,
+    });
+
+    expect(offenses).toHaveLength(0);
+  });
 });

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -39,6 +39,14 @@ export const UndefinedObject: LiquidCheckDefinition = {
       return {};
     }
 
+    /**
+     * Skip this check when definitions for global objects are unavailable.
+     */
+    if (!context.themeDocset) {
+      return {};
+    }
+
+    const themeDocset = context.themeDocset;
     const variableScopes: Map<string, Scope[]> = new Map();
     const variables: LiquidVariableLookup[] = [];
 
@@ -80,11 +88,9 @@ export const UndefinedObject: LiquidCheckDefinition = {
       },
 
       async onCodePathEnd() {
-        if (context.themeDocset) {
-          const objects = await globalObjects(context.themeDocset);
+        const objects = await globalObjects(themeDocset);
 
-          objects.forEach((obj) => variableScopes.set(obj.name, []));
-        }
+        objects.forEach((obj) => variableScopes.set(obj.name, []));
 
         variables.forEach((variable) => {
           if (!variable.name) return;


### PR DESCRIPTION
Fixes https://github.com/Shopify/theme-tools/issues/129

# What are you adding in this PR?

This PR skips the `UndefinedObject` check when the `themeDocset` dependency is not present.

## Before you deploy

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
