### PR TITLE
Add Shopify Reference links at the bottom of Liquid completion/hover items

### DIFF
--- a/.changeset/fresh-wolves-notice.md
+++ b/.changeset/fresh-wolves-notice.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Add Shopify Reference links at the bottom of Liquid Hover and Completion items

--- a/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.ts
@@ -81,7 +81,11 @@ function completionItems(options: MaybeDeprioritisedFilterEntry[], partial: stri
 }
 
 function toPropertyCompletionItem(entry: MaybeDeprioritisedFilterEntry) {
-  return createCompletionItem(entry, {
-    kind: CompletionItemKind.Function,
-  });
+  return createCompletionItem(
+    entry,
+    {
+      kind: CompletionItemKind.Function,
+    },
+    'filter',
+  );
 }

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
@@ -32,7 +32,7 @@ export class LiquidTagsCompletionProvider implements Provider {
     return tags
       .filter(({ name }) => name.startsWith(partial))
       .sort(sortByName)
-      .map((tag) => createCompletionItem(tag, { kind: CompletionItemKind.Keyword }))
+      .map((tag) => createCompletionItem(tag, { kind: CompletionItemKind.Keyword }, 'tag'))
       .concat(
         blockParent && `end${blockParent.name}`.startsWith(partial)
           ? {

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.ts
@@ -28,7 +28,7 @@ export class ObjectCompletionProvider implements Provider {
     return options
       .filter(({ name }) => name.startsWith(partial))
       .sort(sortByName)
-      .map((tag) => createCompletionItem(tag, { kind: CompletionItemKind.Variable }));
+      .map((tag) => createCompletionItem(tag, { kind: CompletionItemKind.Variable }, 'object'));
   }
 }
 

--- a/packages/theme-language-server-common/src/completions/providers/common/CompletionItemProperties.ts
+++ b/packages/theme-language-server-common/src/completions/providers/common/CompletionItemProperties.ts
@@ -1,5 +1,5 @@
 import { CompletionItem, CompletionItemTag, MarkupContent } from 'vscode-languageserver';
-import { render } from '../../../docset';
+import { DocsetEntryType, render } from '../../../docset';
 import { DocsetEntry } from '@shopify/theme-check-common';
 
 // ASCII tokens that make a string appear lower in the list.
@@ -17,6 +17,7 @@ enum SortTokens {
 export function createCompletionItem(
   entry: DocsetEntry & { deprioritized?: boolean },
   extraProperties: Partial<CompletionItem> = {},
+  docsetEntryType?: DocsetEntryType,
 ): CompletionItem {
   // prettier-ignore
   const sortToken = entry.deprecated
@@ -29,16 +30,19 @@ export function createCompletionItem(
   return {
     label: entry.name,
     sortText: `${sortToken}${entry.name}`,
-    ...documentationProperties(entry),
+    ...documentationProperties(entry, docsetEntryType),
     ...deprecatedProperties(entry),
     ...extraProperties,
   };
 }
 
-function documentationProperties(entry: DocsetEntry): {
+function documentationProperties(
+  entry: DocsetEntry,
+  docsetEntryType?: DocsetEntryType,
+): {
   documentation: MarkupContent;
 } {
-  const value = render(entry);
+  const value = render(entry, undefined, docsetEntryType);
 
   return {
     documentation: {

--- a/packages/theme-language-server-common/src/docset/index.ts
+++ b/packages/theme-language-server-common/src/docset/index.ts
@@ -1,3 +1,3 @@
 export { AugmentedThemeDocset } from './AugmentedThemeDocset';
-export { render, renderHtmlEntry } from './MarkdownRenderer';
+export { render, renderHtmlEntry, DocsetEntryType } from './MarkdownRenderer';
 export * from './HtmlDocset';

--- a/packages/theme-language-server-common/src/hover/providers/LiquidFilterHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidFilterHoverProvider.ts
@@ -22,7 +22,7 @@ export class LiquidFilterHoverProvider implements BaseHoverProvider {
     return {
       contents: {
         kind: 'markdown',
-        value: render(entry),
+        value: render(entry, undefined, 'filter'),
       },
     };
   }

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.ts
@@ -46,6 +46,7 @@ export class LiquidObjectHoverProvider implements BaseHoverProvider {
               name: currentNode.name,
             },
             type,
+            'object',
           ),
         },
       };
@@ -54,7 +55,7 @@ export class LiquidObjectHoverProvider implements BaseHoverProvider {
     return {
       contents: {
         kind: 'markdown',
-        value: render({ ...entry, name: currentNode.name }, type),
+        value: render({ ...entry, name: currentNode.name }, type, 'object'),
       },
     };
   }

--- a/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.ts
@@ -22,7 +22,7 @@ export class LiquidTagHoverProvider implements BaseHoverProvider {
     return {
       contents: {
         kind: 'markdown',
-        value: render(entry),
+        value: render(entry, undefined, 'tag'),
       },
     };
   }


### PR DESCRIPTION
We do that for HTML, we should do it for our own stuff too!

# What are you adding in this PR?

- Add `Shopify Reference` links at the bottom of hover and completion items for Liquid Docset Entries.

https://github.com/Shopify/theme-tools/assets/4990691/cea437a3-65c0-4e16-8617-b711d017af4b



## Before you deploy

- [x] I included a minor bump `changeset`
