### PR TITLE
Fix cursorOffset bug in prettier 3

### DIFF
--- a/.changeset/popular-pigs-kiss.md
+++ b/.changeset/popular-pigs-kiss.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+---
+
+Fix cursorOffset bug with prettier 3

--- a/packages/prettier-plugin-liquid/scripts/prettier
+++ b/packages/prettier-plugin-liquid/scripts/prettier
@@ -10,11 +10,11 @@ run() {
 }
 
 if [[ $PRETTIER_MAJOR = 3 ]]; then
-  prettier='./prettier3'
-  cmd="./node_modules/prettier3/bin/prettier.cjs --plugin ./dist/index.js --parser=liquid-html --ignore-path=.prettierignore"
+  prettier='../../../node_modules/prettier3'
+  cmd="../../node_modules/prettier3/bin/prettier.cjs --plugin ./dist/index.js --parser=liquid-html --ignore-path=.prettierignore"
 else
-  prettier='./prettier2'
-  cmd="./node_modules/prettier2/bin-prettier.js --plugin . --parser=liquid-html"
+  prettier='../../../node_modules/prettier2'
+  cmd="../../node_modules/prettier2/bin-prettier.js --plugin . --parser=liquid-html"
 fi
 
 # format with prettier2

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -536,7 +536,10 @@ export const printerLiquidHtml2: Printer2<LiquidHtmlNode> & {
   preprocess: preprocess as any,
   getVisitorKeys(node: any, nonTraversableKeys: Set<string>) {
     return Object.keys(node).filter(
-      (key) => !nonTraversableKeys.has(key) && !nonTraversableProperties.has(key),
+      (key) =>
+        !nonTraversableKeys.has(key) &&
+        !nonTraversableProperties.has(key) &&
+        hasOrIsNode(node, key as keyof LiquidHtmlNode),
     );
   },
 };
@@ -547,9 +550,23 @@ export const printerLiquidHtml3: Printer3<LiquidHtmlNode> & {
   print: printNode as any,
   embed: embed3,
   preprocess: preprocess as any,
-  getVisitorKeys(node: any, nonTraversableKeys: Set<string>) {
+  getVisitorKeys(node: LiquidHtmlNode, nonTraversableKeys: Set<string>) {
     return Object.keys(node).filter(
-      (key) => !nonTraversableKeys.has(key) && !nonTraversableProperties.has(key),
+      (key) =>
+        !nonTraversableKeys.has(key) &&
+        !nonTraversableProperties.has(key) &&
+        hasOrIsNode(node, key as keyof LiquidHtmlNode),
     );
   },
 };
+
+function hasOrIsNode<N extends LiquidHtmlNode, K extends keyof N>(node: N, key: K) {
+  const v = node[key];
+  // this works because there's no ()[] type that is string | Node, it only
+  // happens for singular nodes such as name: string | LiquidDrop, etc.
+  return Array.isArray(v) || isNode(v);
+}
+
+function isNode(x: unknown): x is LiquidHtmlNode {
+  return x !== null && typeof x === 'object' && 'type' in x && typeof x.type === 'string';
+}

--- a/packages/prettier-plugin-liquid/src/utils.ts
+++ b/packages/prettier-plugin-liquid/src/utils.ts
@@ -1,14 +1,16 @@
-import { Position } from '@shopify/liquid-html-parser';
+import { LiquidHtmlNode } from './types';
 
 export function assertNever(x: never): never {
   throw new Error(`Unexpected object: ${(x as any).type}`);
 }
 
-export function locStart(node: { position: Position }) {
+export function locStart(node: Pick<LiquidHtmlNode, 'position'> | string) {
+  if (typeof node === 'string') return -1;
   return node.position.start;
 }
 
-export function locEnd(node: { position: Position }) {
+export function locEnd(node: Pick<LiquidHtmlNode, 'position'> | string) {
+  if (typeof node === 'string') return -1;
   return node.position.end;
 }
 

--- a/packages/theme-language-server-common/src/visitor.ts
+++ b/packages/theme-language-server-common/src/visitor.ts
@@ -78,6 +78,7 @@ export function forEachChildNodes<S extends SourceCodeType>(
     }
   }
 }
+
 export function findCurrentNode(
   ast: LiquidHtmlNode,
   cursorPosition: number,


### PR DESCRIPTION

# What are you adding in this PR?

Fixes #145

Turns out getVisitorKeys assumes that everything _is_ a node. I was only filtering the ones that prevented circular dependencies. Which meant that all the boolean, string and position properties were getting visited when they shouldn't have been.

Output with changes

```
$ cat test.liquid
{% for x in col %}{{ x }}{% endfor %}

$ cross-env PRETTIER_MAJOR=3 scripts/prettier --cursor-offset 22 --print-width 1 test.liquid
../../node_modules/prettier3/bin/prettier.cjs --plugin ./dist/index.js --parser=liquid-html --ignore-path=.prettierignore --cursor-offset 22 --print-width 1 test.liquid
{% for x in col -%}
  {{- x -}}
{%- endfor %}
27

$ cross-env PRETTIER_MAJOR=2 scripts/prettier --cursor-offset 22 --print-width 1 test.liquid
../../node_modules/prettier2/bin-prettier.js --plugin . --parser=liquid-html --cursor-offset 22 --print-width 1 test.liquid
{% for x in col -%}
  {{- x -}}
{%- endfor %}
27
```

## Before you deploy

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
