### PR TITLE
Theme Tools Release: 05-10-23

### DIFF
--- a/.changeset/popular-pigs-kiss.md
+++ b/.changeset/popular-pigs-kiss.md
@@ -1,5 +1,0 @@
----
-'@shopify/prettier-plugin-liquid': patch
----
-
-Fix cursorOffset bug with prettier 3

--- a/packages/prettier-plugin-liquid/CHANGELOG.md
+++ b/packages/prettier-plugin-liquid/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/prettier-plugin-liquid
 
+## 1.3.1
+
+### Patch Changes
+
+- 328ba49: Fix cursorOffset bug with prettier 3
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/prettier-plugin-liquid/package.json
+++ b/packages/prettier-plugin-liquid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/prettier-plugin-liquid",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Prettier Liquid/HTML plugin by Shopify",
   "repository": "shopify/prettier-plugin-liquid",
   "author": "CP Clermont <@charlespwd>",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## theme-check-vscode
 
+## 1.11.9
+
+### Patch Changes
+
+- Patch bump because it depends on @shopify/prettier-plugin-liquid
+- Updated dependencies [328ba49]
+  - @shopify/prettier-plugin-liquid@1.3.1
+
 ## 1.11.8
 
 ### Patch Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "charlespwd"
   },
-  "version": "1.11.8",
+  "version": "1.11.9",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@shopify/liquid-html-parser": "^1.0.0",
-    "@shopify/prettier-plugin-liquid": "^1.3.0",
+    "@shopify/prettier-plugin-liquid": "^1.3.1",
     "@shopify/theme-language-server-node": "^1.3.1",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0"


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `1.11.8` -> `1.11.9`
### Changes:
- Patch bump because it depends on @shopify/prettier-plugin-liquid

## `@shopify/prettier-plugin-liquid`
Patch incremented `1.3.0` -> `1.3.1`
### Changes:
- Fix cursorOffset bug with prettier 3

