### PR TITLE
Fix completion, hover and UndefinedObject reporting of a couple of exceptions

### DIFF
--- a/.changeset/famous-beers-return.md
+++ b/.changeset/famous-beers-return.md
@@ -3,4 +3,4 @@
 '@shopify/theme-check-common': patch
 ---
 
-Fix `paginate` object completion, hover and UndefinedObject reporting
+Fix `paginate` object completion, hover and `UndefinedObject` reporting

--- a/.changeset/famous-beers-return.md
+++ b/.changeset/famous-beers-return.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+Fix `paginate` object completion, hover and UndefinedObject reporting

--- a/.changeset/little-ducks-kick.md
+++ b/.changeset/little-ducks-kick.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+Add support for `{% layout none %}`

--- a/.changeset/metal-dolphins-raise.md
+++ b/.changeset/metal-dolphins-raise.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+Fix `recommendations` completion, hover and `UndefinedObject` reporting

--- a/.changeset/popular-spoons-begin.md
+++ b/.changeset/popular-spoons-begin.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+Fix `predictive_search` completion, hover and UndefinedObject reporting

--- a/.changeset/popular-spoons-begin.md
+++ b/.changeset/popular-spoons-begin.md
@@ -3,4 +3,4 @@
 '@shopify/theme-check-common': patch
 ---
 
-Fix `predictive_search` completion, hover and UndefinedObject reporting
+Fix `predictive_search` completion, hover and `UndefinedObject` reporting

--- a/.changeset/seven-teachers-peel.md
+++ b/.changeset/seven-teachers-peel.md
@@ -3,4 +3,4 @@
 '@shopify/theme-check-common': patch
 ---
 
-Fix completion, hover and `UndefinedObject` reporting of `form` object
+Fix `form` object completion, hover and `UndefinedObject` reporting

--- a/.changeset/seven-teachers-peel.md
+++ b/.changeset/seven-teachers-peel.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+Fix completion, hover and `UndefinedObject` reporting of `form` object

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -207,6 +207,19 @@ describe('Module: UndefinedObject', () => {
     expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'paginate' used."]);
   });
 
+  it('should contextually report on the undefined nature of the form object (defined in form tag, undefined outside)', async () => {
+    const sourceCode = `
+      {% form "cart" %}
+        {{ form }}
+      {% endform %}{{ form }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'form' used."]);
+  });
+
   it('should not report an offense when object is undefined in a "snippet" file', async () => {
     const sourceCode = `
       {{ my_var }}

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -220,6 +220,18 @@ describe('Module: UndefinedObject', () => {
     expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'form' used."]);
   });
 
+  it('should support {% layout none %}', async () => {
+    const sourceCode = `
+      {% layout none %}
+      {{ none }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'none' used."]);
+  });
+
   it('should not report an offense when object is undefined in a "snippet" file', async () => {
     const sourceCode = `
       {{ my_var }}

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -273,6 +273,7 @@ describe('Module: UndefinedObject', () => {
     const contexts: [object: string, goodPath: string][] = [
       ['section', 'sections/section.liquid'],
       ['predictive_search', 'sections/predictive-search.liquid'],
+      ['recommendations', 'sections/recommendations.liquid'],
     ];
     for (const [object, goodPath] of contexts) {
       offenses = await runLiquidCheck(UndefinedObject, `{{ ${object} }}`, goodPath);

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it } from 'vitest';
 import { UndefinedObject } from './index';
 import { runLiquidCheck, highlightedOffenses } from '../../test';
+import { Offense } from '../../types';
 
 describe('Module: UndefinedObject', () => {
   it('should report an offense when object is undefined', async () => {
@@ -264,6 +265,20 @@ describe('Module: UndefinedObject', () => {
       const offenses = await runLiquidCheck(UndefinedObject, sourceCode, 'file.liquid');
 
       expect(offenses).toHaveLength(0);
+    }
+  });
+
+  it('should support contextual exceptions', async () => {
+    let offenses: Offense[];
+    const contexts: [object: string, goodPath: string][] = [
+      ['section', 'sections/section.liquid'],
+      ['predictive_search', 'sections/predictive-search.liquid'],
+    ];
+    for (const [object, goodPath] of contexts) {
+      offenses = await runLiquidCheck(UndefinedObject, `{{ ${object} }}`, goodPath);
+      expect(offenses).toHaveLength(0);
+      offenses = await runLiquidCheck(UndefinedObject, `{{ ${object} }}`, 'file.liquid');
+      expect(offenses).toHaveLength(1);
     }
   });
 

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -193,6 +193,20 @@ describe('Module: UndefinedObject', () => {
     expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'c' used."]);
   });
 
+  it('should contextually report on the undefined nature of the paginate object (defined in paginate tag, undefined outside)', async () => {
+    const sourceCode = `
+      {% assign col = 'string' | split: '' %}
+      {% paginate col by 5 %}
+        {{ paginate }}
+      {% endpaginate %}{{ paginate }}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses.map((e) => e.message)).toEqual(["Unknown object 'paginate' used."]);
+  });
+
   it('should not report an offense when object is undefined in a "snippet" file', async () => {
     const sourceCode = `
       {{ my_var }}

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -71,8 +71,8 @@ export const UndefinedObject: LiquidCheckDefinition = {
           });
         }
 
-        if (node.name === 'paginate') {
-          indexVariableScope('paginate', {
+        if (['form', 'paginate'].includes(node.name)) {
+          indexVariableScope(node.name, {
             start: node.blockStartPosition.end,
             end: node.blockEndPosition?.start,
           });

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -71,6 +71,11 @@ export const UndefinedObject: LiquidCheckDefinition = {
           });
         }
 
+        /**
+         * {% form 'cart', cart %}
+         *   {{ form }}
+         * {% endform %}
+         */
         if (['form', 'paginate'].includes(node.name)) {
           indexVariableScope(node.name, {
             start: node.blockStartPosition.end,
@@ -78,6 +83,20 @@ export const UndefinedObject: LiquidCheckDefinition = {
           });
         }
 
+        /* {% layout none %} */
+        if (node.name === 'layout') {
+          indexVariableScope('none', {
+            start: node.position.start,
+            end: node.position.end,
+          });
+        }
+
+        /**
+         * {% for x in y %}
+         *   {{ forloop }}
+         *   {{ x }}
+         * {% endfor %}
+         */
         if (isLiquidForTag(node) || isLiquidTableRowTag(node)) {
           indexVariableScope(node.markup.variableName, {
             start: node.blockStartPosition.end,

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -158,7 +158,7 @@ async function globalObjects(themeDocset: ThemeDocset, relativePath: string) {
 
 function getContextualObjects(relativePath: string): string[] {
   if (relativePath.startsWith('sections/')) {
-    return ['section', 'predictive_search'];
+    return ['section', 'predictive_search', 'recommendations'];
   }
 
   return [];

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -71,6 +71,13 @@ export const UndefinedObject: LiquidCheckDefinition = {
           });
         }
 
+        if (node.name === 'paginate') {
+          indexVariableScope('paginate', {
+            start: node.blockStartPosition.end,
+            end: node.blockEndPosition?.start,
+          });
+        }
+
         if (isLiquidForTag(node) || isLiquidTableRowTag(node)) {
           indexVariableScope(node.markup.variableName, {
             start: node.blockStartPosition.end,

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -141,6 +141,22 @@ export async function check(
               template: [],
             },
           },
+          {
+            name: 'section',
+            access: {
+              global: false,
+              parents: [],
+              template: [],
+            },
+          },
+          {
+            name: 'predictive_search',
+            access: {
+              global: false,
+              parents: [],
+              template: [],
+            },
+          },
         ];
       },
       async tags() {

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -157,6 +157,14 @@ export async function check(
               template: [],
             },
           },
+          {
+            name: 'recommendations',
+            access: {
+              global: false,
+              parents: [],
+              template: [],
+            },
+          },
         ];
       },
       async tags() {

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -256,19 +256,11 @@ function buildSymbolsTable(
     // This also covers tablerow
     ForMarkup(node, ancestors) {
       const parentNode = ancestors.at(-1)! as LiquidTag;
-      return [
-        {
-          identifier: node.variableName,
-          type: LazyDeconstructedExpression(node.collection, node.position.start),
-          range: [parentNode.blockStartPosition.end, end(parentNode.blockEndPosition?.end)],
-        },
-        // Add the for/tablerow loop variables in the context of the tag.
-        {
-          identifier: parentNode.name === 'for' ? 'forloop' : 'tablerowloop',
-          type: parentNode.name === 'for' ? 'forloop' : 'tablerowloop',
-          range: [parentNode.blockStartPosition.end, end(parentNode.blockEndPosition?.end)],
-        },
-      ];
+      return {
+        identifier: node.variableName,
+        type: LazyDeconstructedExpression(node.collection, node.position.start),
+        range: [parentNode.blockStartPosition.end, end(parentNode.blockEndPosition?.end)],
+      };
     },
 
     // {% capture foo %}
@@ -280,6 +272,24 @@ function buildSymbolsTable(
           identifier: node.markup.name!,
           type: String,
           range: [node.position.end],
+        };
+      } else if (node.name === 'paginate') {
+        return {
+          identifier: 'paginate',
+          type: 'paginate',
+          range: [node.blockStartPosition.end, end(node.blockEndPosition?.end)],
+        };
+      } else if (node.name === 'for') {
+        return {
+          identifier: 'forloop',
+          type: 'forloop',
+          range: [node.blockStartPosition.end, end(node.blockEndPosition?.end)],
+        };
+      } else if (node.name === 'tablerow') {
+        return {
+          identifier: 'tablerowloop',
+          type: 'tablerowloop',
+          range: [node.blockStartPosition.end, end(node.blockEndPosition?.end)],
         };
       }
     },

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -142,7 +142,7 @@ export class TypeSystem {
 function getContextualEntries(uri: string): string[] {
   const absolutePath = toAbsolutePath(uri);
   if (/sections\/[^.\/]*\.liquid$/.test(absolutePath)) {
-    return ['section', 'predictive_search'];
+    return ['section', 'predictive_search', 'recommendations'];
   }
   return [];
 }

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -285,6 +285,12 @@ function buildSymbolsTable(
           type: node.name + 'loop',
           range: [node.blockStartPosition.end, end(node.blockEndPosition?.end)],
         };
+      } else if (node.name === 'layout') {
+        return {
+          identifier: 'none',
+          type: 'keyword',
+          range: [node.position.start, node.position.end],
+        };
       }
     },
   });

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -273,22 +273,16 @@ function buildSymbolsTable(
           type: String,
           range: [node.position.end],
         };
-      } else if (node.name === 'paginate') {
+      } else if (['form', 'paginate'].includes(node.name)) {
         return {
-          identifier: 'paginate',
-          type: 'paginate',
+          identifier: node.name,
+          type: node.name,
           range: [node.blockStartPosition.end, end(node.blockEndPosition?.end)],
         };
-      } else if (node.name === 'for') {
+      } else if (['for', 'tablerow'].includes(node.name)) {
         return {
-          identifier: 'forloop',
-          type: 'forloop',
-          range: [node.blockStartPosition.end, end(node.blockEndPosition?.end)],
-        };
-      } else if (node.name === 'tablerow') {
-        return {
-          identifier: 'tablerowloop',
-          type: 'tablerowloop',
+          identifier: node.name + 'loop',
+          type: node.name + 'loop',
           range: [node.blockStartPosition.end, end(node.blockEndPosition?.end)],
         };
       }

--- a/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.ts
@@ -35,7 +35,11 @@ export class FilterCompletionProvider implements Provider {
     // We'll infer the type of the variable up to the last filter (excluding this one)
     parentVariable = { ...parentVariable }; // soft clone
     parentVariable.filters = parentVariable.filters.slice(0, -1); // remove last one
-    const inputType = await this.typeSystem.inferType(parentVariable, partialAst);
+    const inputType = await this.typeSystem.inferType(
+      parentVariable,
+      partialAst,
+      params.textDocument.uri,
+    );
     const partial = node.name.replace(CURSOR, '');
     const options = await this.options(isArrayType(inputType) ? 'array' : inputType);
     return completionItems(options, partial);

--- a/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.ts
@@ -36,8 +36,11 @@ export class ObjectAttributeCompletionProvider implements Provider {
     const parentLookup = { ...node };
     parentLookup.lookups = [...parentLookup.lookups];
     parentLookup.lookups.pop();
-
-    const parentType = await this.typeSystem.inferType(parentLookup, partialAst);
+    const parentType = await this.typeSystem.inferType(
+      parentLookup,
+      partialAst,
+      params.textDocument.uri,
+    );
     if (isArrayType(parentType)) {
       return completionItems(
         ArrayCoreProperties.map((name) => ({ name })),

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
@@ -89,6 +89,7 @@ describe('Module: ObjectCompletionProvider', async () => {
   it('should complete contextual variables', async () => {
     const contexts: [context: string, expected: string][] = [
       ['{% paginate all_products by 5 %}{{ pagi█ }}{% endpaginate %}', 'paginate'],
+      ['{% form "cart" %}{{ for█ }}{% endform %}', 'form'],
       ['{% for p in all_products %}{{ for█ }}{% endfor %}', 'forloop'],
       ['{% tablerow p in all_products %}{{ tablerow█ }}{% endtablerow %}', 'tablerowloop'],
     ];

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
@@ -27,6 +27,14 @@ describe('Module: ObjectCompletionProvider', async () => {
             parents: [],
           },
         },
+        {
+          name: 'recommendations',
+          access: {
+            global: false,
+            template: [],
+            parents: [],
+          },
+        },
       ],
       tags: async () => [],
     });
@@ -124,6 +132,7 @@ describe('Module: ObjectCompletionProvider', async () => {
     const contexts: [object: string, goodPath: string][] = [
       ['section', 'sections/main-product.liquid'],
       ['predictive_search', 'sections/predictive-search.liquid'],
+      ['recommendations', 'sections/recommendations.liquid'],
     ];
     for (const [object, relativePath] of contexts) {
       const source = `{{ ${object}█ }}`;

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
@@ -86,6 +86,19 @@ describe('Module: ObjectCompletionProvider', async () => {
     );
   });
 
+  it('should complete contextual variables', async () => {
+    const contexts: [context: string, expected: string][] = [
+      ['{% paginate all_products by 5 %}{{ pagi█ }}{% endpaginate %}', 'paginate'],
+      ['{% for p in all_products %}{{ for█ }}{% endfor %}', 'forloop'],
+      ['{% tablerow p in all_products %}{{ tablerow█ }}{% endtablerow %}', 'tablerowloop'],
+    ];
+    for (const [context, expected] of contexts) {
+      await expect(provider, context).to.complete(context, [expected]);
+      const outOfContext = `{{ ${expected}█ }}`;
+      await expect(provider, outOfContext).to.complete(outOfContext, []);
+    }
+  });
+
   it('should not complete anything if there is nothing to complete', async () => {
     await expect(provider).to.complete('{% assign x = "█" %}', []);
   });

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
@@ -92,6 +92,7 @@ describe('Module: ObjectCompletionProvider', async () => {
       ['{% form "cart" %}{{ for█ }}{% endform %}', 'form'],
       ['{% for p in all_products %}{{ for█ }}{% endfor %}', 'forloop'],
       ['{% tablerow p in all_products %}{{ tablerow█ }}{% endtablerow %}', 'tablerowloop'],
+      ['{% layout non█ %}', 'none'],
     ];
     for (const [context, expected] of contexts) {
       await expect(provider, context).to.complete(context, [expected]);

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
@@ -8,7 +8,26 @@ describe('Module: ObjectCompletionProvider', async () => {
   beforeEach(async () => {
     provider = new CompletionsProvider(new DocumentManager(), {
       filters: async () => [],
-      objects: async () => [{ name: 'all_products' }, { name: 'global' }],
+      objects: async () => [
+        { name: 'all_products' },
+        { name: 'global' },
+        {
+          name: 'section',
+          access: {
+            global: false,
+            template: [],
+            parents: [],
+          },
+        },
+        {
+          name: 'predictive_search',
+          access: {
+            global: false,
+            template: [],
+            parents: [],
+          },
+        },
+      ],
       tags: async () => [],
     });
   });
@@ -98,6 +117,18 @@ describe('Module: ObjectCompletionProvider', async () => {
       await expect(provider, context).to.complete(context, [expected]);
       const outOfContext = `{{ ${expected}█ }}`;
       await expect(provider, outOfContext).to.complete(outOfContext, []);
+    }
+  });
+
+  it('should complete relative-path-dependent contextual variables', async () => {
+    const contexts: [object: string, goodPath: string][] = [
+      ['section', 'sections/main-product.liquid'],
+      ['predictive_search', 'sections/predictive-search.liquid'],
+    ];
+    for (const [object, relativePath] of contexts) {
+      const source = `{{ ${object}█ }}`;
+      await expect(provider, source).to.complete({ source, relativePath }, [object]);
+      await expect(provider, source).to.complete({ source, relativePath: 'file.liquid' }, []);
     }
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.ts
@@ -21,7 +21,12 @@ export class ObjectCompletionProvider implements Provider {
     }
 
     const partial = node.name.replace(CURSOR, '');
-    const options = await this.typeSystem.availableVariables(partialAst, partial, node);
+    const options = await this.typeSystem.availableVariables(
+      partialAst,
+      partial,
+      node,
+      params.textDocument.uri,
+    );
     return options.map(({ entry, type }) =>
       createCompletionItem(entry, { kind: CompletionItemKind.Variable }, 'object', type),
     );

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.ts
@@ -1,6 +1,6 @@
 import { NodeTypes } from '@shopify/liquid-html-parser';
 import { LiquidHtmlNode } from '@shopify/theme-check-common';
-import { Hover } from 'vscode-languageserver';
+import { Hover, HoverParams } from 'vscode-languageserver';
 import { TypeSystem, isArrayType } from '../../TypeSystem';
 import { render } from '../../docset';
 import { BaseHoverProvider } from '../BaseHoverProvider';
@@ -8,7 +8,11 @@ import { BaseHoverProvider } from '../BaseHoverProvider';
 export class LiquidObjectAttributeHoverProvider implements BaseHoverProvider {
   constructor(private typeSystem: TypeSystem) {}
 
-  async hover(currentNode: LiquidHtmlNode, ancestors: LiquidHtmlNode[]): Promise<Hover | null> {
+  async hover(
+    currentNode: LiquidHtmlNode,
+    ancestors: LiquidHtmlNode[],
+    params: HoverParams,
+  ): Promise<Hover | null> {
     const parentNode = ancestors.at(-1);
     if (
       currentNode.type !== NodeTypes.String ||
@@ -25,7 +29,7 @@ export class LiquidObjectAttributeHoverProvider implements BaseHoverProvider {
       lookups: parentNode.lookups.slice(0, lookupIndex),
     };
 
-    const parentType = await this.typeSystem.inferType(node, ancestors[0]);
+    const parentType = await this.typeSystem.inferType(node, ancestors[0], params.textDocument.uri);
     if (isArrayType(parentType)) {
       return null;
     }

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
@@ -56,6 +56,10 @@ describe('Module: LiquidObjectHoverProvider', async () => {
           name: 'predictive_search',
           access: { global: false, parents: [], template: [] },
         },
+        {
+          name: 'recommendations',
+          access: { global: false, parents: [], template: [] },
+        },
       ],
       tags: async () => [],
     });
@@ -134,6 +138,7 @@ describe('Module: LiquidObjectHoverProvider', async () => {
     const contexts: [object: string, goodPath: string][] = [
       ['section', 'sections/my-section.liquid'],
       ['predictive_search', 'sections/predictive-search.liquid'],
+      ['recommendations', 'sections/recommendations.liquid'],
     ];
     for (const [object, relativePath] of contexts) {
       const source = `{{ ${object}█ }}`;

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
@@ -48,6 +48,14 @@ describe('Module: LiquidObjectHoverProvider', async () => {
           description: 'image description',
           access: { global: false, parents: [], template: [] },
         },
+        {
+          name: 'section',
+          access: { global: false, parents: [], template: [] },
+        },
+        {
+          name: 'predictive_search',
+          access: { global: false, parents: [], template: [] },
+        },
       ],
       tags: async () => [],
     });
@@ -107,13 +115,34 @@ describe('Module: LiquidObjectHoverProvider', async () => {
         {{ tablerowloop█ }}
       {% endtablerow %}
     `;
-    await expect(provider).to.hover(context, expect.stringMatching(/##* tablerowloop: `tablerowloop`/));
+    await expect(provider).to.hover(
+      context,
+      expect.stringMatching(/##* tablerowloop: `tablerowloop`/),
+    );
     await expect(provider).to.hover('{{ tablerowloop█ }}', null);
   });
 
   it('should support {% layout none %}', async () => {
-    await expect(provider).to.hover(`{% layout none█ %}`, expect.stringMatching(/##* none: `keyword`/));
+    await expect(provider).to.hover(
+      `{% layout none█ %}`,
+      expect.stringMatching(/##* none: `keyword`/),
+    );
     await expect(provider).to.hover('{{ none█ }}', null);
+  });
+
+  it('should support contextual objects by relative path', async () => {
+    const contexts: [object: string, goodPath: string][] = [
+      ['section', 'sections/my-section.liquid'],
+      ['predictive_search', 'sections/predictive-search.liquid'],
+    ];
+    for (const [object, relativePath] of contexts) {
+      const source = `{{ ${object}█ }}`;
+      await expect(provider).to.hover(
+        { source, relativePath },
+        expect.stringContaining(`## ${object}`),
+      );
+      await expect(provider).to.hover({ source, relativePath: 'file.liquid' }, null);
+    }
   });
 
   it('should return nothing if the thing is untyped', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
@@ -111,6 +111,11 @@ describe('Module: LiquidObjectHoverProvider', async () => {
     await expect(provider).to.hover('{{ tablerowloop█ }}', null);
   });
 
+  it('should support {% layout none %}', async () => {
+    await expect(provider).to.hover(`{% layout none█ %}`, expect.stringMatching(/##* none: `keyword`/));
+    await expect(provider).to.hover('{{ none█ }}', null);
+  });
+
   it('should return nothing if the thing is untyped', async () => {
     await expect(provider).to.hover(`{{ unknown█ }}`, null);
   });

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
@@ -29,13 +29,24 @@ describe('Module: LiquidObjectHoverProvider', async () => {
           return_type: [{ type: 'array', array_value: 'product' }],
         },
         {
+          name: 'paginate',
+          access: { global: false, parents: [], template: [] },
+          return_type: [],
+        },
+        {
+          name: 'forloop',
+          access: { global: false, parents: [], template: [] },
+          return_type: [],
+        },
+        {
+          name: 'tablerowloop',
+          access: { global: false, parents: [], template: [] },
+          return_type: [],
+        },
+        {
           name: 'image',
           description: 'image description',
-          access: {
-            global: false,
-            parents: [],
-            template: [],
-          },
+          access: { global: false, parents: [], template: [] },
         },
       ],
       tags: async () => [],
@@ -58,6 +69,36 @@ describe('Module: LiquidObjectHoverProvider', async () => {
       await expect(provider).to.hover(context, expect.stringContaining('product description'));
       await expect(provider).to.hover(context, expect.stringMatching(/##* \w+: `product`/));
     }
+  });
+
+  it('should support paginate inside paginate tags', async () => {
+    const context = `
+      {% paginate all_products by 5 %}
+        {{ paginate█ }}
+      {% endpaginate %}
+    `;
+    await expect(provider).to.hover(context, expect.stringMatching(/##* paginate: `paginate`/));
+    await expect(provider).to.hover('{{ paginate█ }}', null);
+  });
+
+  it('should support forloop inside for tags', async () => {
+    const context = `
+      {% for p in all_products %}
+        {{ forloop█ }}
+      {% endfor %}
+    `;
+    await expect(provider).to.hover(context, expect.stringMatching(/##* forloop: `forloop`/));
+    await expect(provider).to.hover('{{ forloop█ }}', null);
+  });
+
+  it('should support tablerowloop inside tablerow tags', async () => {
+    const context = `
+      {% tablerow p in all_products %}
+        {{ tablerowloop█ }}
+      {% endtablerow %}
+    `;
+    await expect(provider).to.hover(context, expect.stringMatching(/##* tablerowloop: `tablerowloop`/));
+    await expect(provider).to.hover('{{ tablerowloop█ }}', null);
   });
 
   it('should return nothing if the thing is untyped', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
@@ -81,6 +81,16 @@ describe('Module: LiquidObjectHoverProvider', async () => {
     await expect(provider).to.hover('{{ paginate█ }}', null);
   });
 
+  it('should support form inside form tags', async () => {
+    const context = `
+      {% form all_products by 5 %}
+        {{ form█ }}
+      {% endform %}
+    `;
+    await expect(provider).to.hover(context, expect.stringMatching(/##* form: `form`/));
+    await expect(provider).to.hover('{{ form█ }}', null);
+  });
+
   it('should support forloop inside for tags', async () => {
     const context = `
       {% for p in all_products %}

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.ts
@@ -1,5 +1,5 @@
 import { LiquidHtmlNode, LiquidVariableLookup, NodeTypes } from '@shopify/liquid-html-parser';
-import { Hover } from 'vscode-languageserver';
+import { Hover, HoverParams } from 'vscode-languageserver';
 import { TypeSystem, isArrayType } from '../../TypeSystem';
 import { render } from '../../docset';
 import { BaseHoverProvider } from '../BaseHoverProvider';
@@ -7,7 +7,11 @@ import { BaseHoverProvider } from '../BaseHoverProvider';
 export class LiquidObjectHoverProvider implements BaseHoverProvider {
   constructor(private typeSystem: TypeSystem) {}
 
-  async hover(currentNode: LiquidHtmlNode, ancestors: LiquidHtmlNode[]): Promise<Hover | null> {
+  async hover(
+    currentNode: LiquidHtmlNode,
+    ancestors: LiquidHtmlNode[],
+    params: HoverParams,
+  ): Promise<Hover | null> {
     if (
       currentNode.type !== NodeTypes.VariableLookup &&
       currentNode.type !== NodeTypes.AssignMarkup
@@ -27,7 +31,7 @@ export class LiquidObjectHoverProvider implements BaseHoverProvider {
       } as LiquidVariableLookup;
     }
 
-    const type = await this.typeSystem.inferType(node, ancestors[0]);
+    const type = await this.typeSystem.inferType(node, ancestors[0], params.textDocument.uri);
     const objectMap = await this.typeSystem.objectMap();
     const entry = objectMap[isArrayType(type) ? type.valueType : type];
 

--- a/packages/theme-language-server-common/src/test/HoverAssertion.ts
+++ b/packages/theme-language-server-common/src/test/HoverAssertion.ts
@@ -4,8 +4,13 @@ import { HoverParams, MarkupContent } from 'vscode-languageserver-protocol';
 import { HoverProvider } from '../hover';
 
 interface CustomMatchers<R = unknown> {
-  hover(context: string, expected: null | string): Promise<R>;
+  hover(context: string | HoverContext, expected: null | string): Promise<R>;
 }
+
+export type HoverContext = {
+  source: string;
+  relativePath: string;
+};
 
 declare module 'vitest' {
   interface Assertion<T = any> extends CustomMatchers<T> {}
@@ -15,13 +20,15 @@ declare module 'vitest' {
 export const hover: RawMatcherFn<MatcherState> = async function (
   this: MatcherState,
   provider: HoverProvider,
-  context: string,
+  context: string | HoverContext,
   expected: any,
 ): AsyncExpectationResult {
   const { isNot, equals, utils } = this;
+  const hoverContext = asHoverContext(context);
+  const { source, relativePath } = hoverContext;
 
   const { documentManager } = provider;
-  const cursorPosition = context.indexOf('█');
+  const cursorPosition = source.indexOf('█');
 
   if (cursorPosition === -1) {
     return {
@@ -30,8 +37,8 @@ export const hover: RawMatcherFn<MatcherState> = async function (
     };
   }
 
-  const textDocumentUri = 'file:///file.liquid';
-  documentManager.open(textDocumentUri, context.replace(/█/g, ''), 0);
+  const textDocumentUri = `file:///${relativePath}`;
+  documentManager.open(textDocumentUri, source.replace(/█/g, ''), 0);
   const textDocument = documentManager.get(textDocumentUri)!.textDocument;
   const params: HoverParams = {
     position: textDocument.positionAt(cursorPosition),
@@ -70,3 +77,8 @@ export const hover: RawMatcherFn<MatcherState> = async function (
     expected: expected,
   };
 };
+
+function asHoverContext(context: string | HoverContext): HoverContext {
+  if (typeof context === 'string') return { source: context, relativePath: 'file.liquid' };
+  return context;
+}


### PR DESCRIPTION
# What are you adding in this PR?

- Fix `paginate` completion, hover and `UndefinedObject` reporting
  - `{{ paginate }}` is available inside `{% paginate ... %}`, but not outside. 
- Fix `form` object completion, hover and `UndefinedObject` reporting
  - `{{ form }}` is available inside `{% form ... %}`, but not outside. 
- Add support for `{% layout none %}`
- Fix `predictive_search` completion, hover and `UndefinedObject` reporting
  - `{{ predictive_search }}` is available in sections rendered by the Section Rendering API for predictive search. No way to know that so relativePath.startsWith(sections/) is the heuristic used.
- Fix `recommendations` completion, hover and `UndefinedObject` reporting
  - `{{ recommendations }}` is available in sections rendered by the Section Rendering API for recommendations. No way to know that so relativePath.startsWith(sections/) is the heuristic used.
- Similarly, I've made the `{{ section }}` object only available in `sections/*` files and not available globally. 

Fixes #150
Fixes #151
Fixes #152
Fixes #153
Fixes #154

## Before you deploy

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
