### PR TITLE
Fix backward compatibility with legacy `{include,exclude}_categories` settings

### DIFF
--- a/.changeset/orange-geese-live.md
+++ b/.changeset/orange-geese-live.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': patch
+---
+
+Fix backward compatibility with legacy `{include,exclude}_categories` settings

--- a/packages/theme-check-node/src/config/resolve/read-yaml.spec.ts
+++ b/packages/theme-check-node/src/config/resolve/read-yaml.spec.ts
@@ -241,6 +241,14 @@ describe('Unit: readYamlConfigDescription', () => {
     );
   });
 
+  it('does not complain over legacy settings', async () => {
+    const filePath = await createMockYamlFile(`
+include_categories: []
+exclude_categories: []
+    `);
+    await expect(readYamlConfigDescription(filePath)).resolves.toEqual(expect.anything());
+  });
+
   async function createMockYamlFile(content: string): Promise<string> {
     return createMockConfigFile(tempDir, content);
   }

--- a/packages/theme-check-node/src/config/resolve/read-yaml.ts
+++ b/packages/theme-check-node/src/config/resolve/read-yaml.ts
@@ -64,6 +64,10 @@ export async function readYamlConfigDescription(
     config.extends = [resolveExtends(root, 'theme-check:recommended')!];
   }
 
+  // legacy settings that screw up assumptions
+  if (yamlFile.include_categories) delete yamlFile.include_categories;
+  if (yamlFile.exclude_categories) delete yamlFile.exclude_categories;
+
   for (const [checkName, settings] of Object.entries(yamlFile)) {
     if (!isPlainObject(settings)) {
       throw new Error(`Expected a plain object value for ${checkName} but got ${typeof settings}`);


### PR DESCRIPTION
# What are you adding in this PR?

While we no longer honor `include_categories` and `exclude_categories`, them being present in legacy config files made the CLI crash because it expected non-supported settings to be settings for checks. This fixes that.

Fixes #149

## Before you deploy

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
