### PR TITLE
Fix idempotence of script tags with backticks and Liquid in 'em

### DIFF
--- a/.changeset/witty-carrots-judge.md
+++ b/.changeset/witty-carrots-judge.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+---
+
+Fix idempotence of script tag bodies with both backticks and Liquid in them

--- a/packages/prettier-plugin-liquid/src/printer/print/element.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/element.ts
@@ -37,14 +37,9 @@ export function printRawElement(
   const attrGroupId = Symbol('element-attr-group-id');
   let body: Doc = [];
   const hasEmptyBody = node.body.value.trim() === '';
-  const shouldIndentBody = node.body.kind !== RawMarkupKinds.markdown;
 
   if (!hasEmptyBody) {
-    if (shouldIndentBody) {
-      body = [indent([hardline, path.call((p: any) => print(p), 'body')]), hardline];
-    } else {
-      body = [dedentToRoot([hardline, path.call((p: any) => print(p), 'body')]), hardline];
-    }
+    body = [path.call((p: any) => print(p), 'body')];
   }
 
   return group([

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -454,7 +454,6 @@ export function printLiquidRawTag(
   let body: Doc = [];
   const node = path.getValue();
   const hasEmptyBody = node.body.value.trim() === '';
-  const shouldNotIndentBody = node.name === 'schema' && !options.indentSchema;
   const shouldPrintAsIs =
     node.isIndentationSensitive ||
     !hasLineBreakInRange(node.source, node.body.position.start, node.body.position.end);
@@ -478,10 +477,8 @@ export function printLiquidRawTag(
     body = [node.source.slice(node.blockStartPosition.end, node.blockEndPosition.start)];
   } else if (hasEmptyBody) {
     body = [hardline];
-  } else if (shouldNotIndentBody) {
-    body = [hardline, path.call((p) => print(p), 'body'), hardline];
   } else {
-    body = [indent([hardline, path.call((p: any) => print(p), 'body')]), hardline];
+    body = [path.call((p) => print(p), 'body')];
   }
 
   return [blockStart, ...body, blockEnd];

--- a/packages/prettier-plugin-liquid/src/types.ts
+++ b/packages/prettier-plugin-liquid/src/types.ts
@@ -167,3 +167,4 @@ export type AttrUnquoted = Augmented<AST.AttrUnquoted, AllAugmentations>;
 export type AttrEmpty = Augmented<AST.AttrEmpty, AllAugmentations>;
 export type LiquidExpression = Augmented<AST.LiquidExpression, AllAugmentations>;
 export type TextNode = Augmented<AST.TextNode, AllAugmentations>;
+export type RawMarkup = Augmented<AST.RawMarkup, AllAugmentations>;

--- a/packages/prettier-plugin-liquid/src/utils.ts
+++ b/packages/prettier-plugin-liquid/src/utils.ts
@@ -1,4 +1,4 @@
-import { LiquidHtmlNode } from './types';
+import { LiquidHtmlNode } from '~/types';
 
 export function assertNever(x: never): never {
   throw new Error(`Unexpected object: ${(x as any).type}`);

--- a/packages/prettier-plugin-liquid/test/issue-162/fixed.liquid
+++ b/packages/prettier-plugin-liquid/test/issue-162/fixed.liquid
@@ -1,0 +1,35 @@
+When there's Liquid and no backticks, should reindent
+<div>
+  <script>
+    {% if cond %}
+      const x = '{{ product.featured_image}}'
+    {% endif %}
+  </script>
+</div>
+
+When there's Liquid and backticks, should not touch and be idempotent
+<div>
+  <script>
+  {% if cond %}
+    const x = `{{ product.featured_image}}`
+  {% endif %}
+  </script>
+</div>
+
+When there's Liquid and no backticks in Liquid JS tag, should reindent
+<div>
+  {% javascript %}
+    {% if cond %}
+      const x = '{{ product.featured_image}}'
+    {% endif %}
+  {% endjavascript %}
+</div>
+
+When there's Liquid and backticks in Liquid JS tag, should not touch and be idempotent
+<div>
+  {% javascript %}
+  {% if cond %}
+    const x = `{{ product.featured_image}}`
+  {% endif %}
+  {% endjavascript %}
+</div>

--- a/packages/prettier-plugin-liquid/test/issue-162/index.liquid
+++ b/packages/prettier-plugin-liquid/test/issue-162/index.liquid
@@ -1,0 +1,35 @@
+When there's Liquid and no backticks, should reindent
+<div>
+<script>
+  {% if cond %}
+    const x = '{{ product.featured_image}}'
+  {% endif %}
+</script>
+</div>
+
+When there's Liquid and backticks, should not touch and be idempotent
+<div>
+<script>
+  {% if cond %}
+    const x = `{{ product.featured_image}}`
+  {% endif %}
+</script>
+</div>
+
+When there's Liquid and no backticks in Liquid JS tag, should reindent
+<div>
+{% javascript %}
+  {% if cond %}
+    const x = '{{ product.featured_image}}'
+  {% endif %}
+{% endjavascript %}
+</div>
+
+When there's Liquid and backticks in Liquid JS tag, should not touch and be idempotent
+<div>
+{% javascript %}
+  {% if cond %}
+    const x = `{{ product.featured_image}}`
+  {% endif %}
+{% endjavascript %}
+</div>

--- a/packages/prettier-plugin-liquid/test/issue-162/index.spec.ts
+++ b/packages/prettier-plugin-liquid/test/issue-162/index.spec.ts
@@ -1,0 +1,7 @@
+import { test } from 'vitest';
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+test('Unit: issue-162', async () => {
+  await assertFormattedEqualsFixed(__dirname);
+});

--- a/packages/prettier-plugin-liquid/test/test-helpers.ts
+++ b/packages/prettier-plugin-liquid/test/test-helpers.ts
@@ -2,7 +2,7 @@ import { expect } from 'vitest';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as prettier from 'prettier';
-import * as plugin from '../src';
+import plugin from '../src';
 import { parse } from '../src/parser';
 import { preprocess } from '../src/printer/print-preprocess';
 import { LiquidParserOptions } from '../src/types';

--- a/packages/prettier-plugin-liquid/test/tsconfig.json
+++ b/packages/prettier-plugin-liquid/test/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": "./",
     "module": "commonjs",
     "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
     "strictPropertyInitialization": false,
     "isolatedModules": false,
     "strict": false,


### PR DESCRIPTION
# What are you adding in this PR?

- Fixes the idempotence of pretty printing script tags with Liquid _and_ backticks in them.
  - We were wrapping the contents in new lines and that wasn't the desired behaviour.

Fixes #162

## before 
https://github.com/Shopify/theme-tools/assets/4990691/2adcca35-4c6f-4836-ba15-a58125b04bd9 
## after
https://github.com/Shopify/theme-tools/assets/4990691/475430d6-5062-4bef-977c-16fa3121b26c



## Before you deploy

- [x] This PR fixes a bug
  - [x] I included a patch bump `changeset` to this PR
