### PR TITLE
Added `DeprecatedGlobalAppBlockType` check

### DIFF
--- a/.changeset/curly-yaks-beg.md
+++ b/.changeset/curly-yaks-beg.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-browser': minor
+'@shopify/theme-check-node': minor
+---
+
+Add `DeprecatedGlobalAppBlockType` check

--- a/packages/theme-check-common/src/checks/deprecated-global-app-block-type/index.spec.ts
+++ b/packages/theme-check-common/src/checks/deprecated-global-app-block-type/index.spec.ts
@@ -1,0 +1,122 @@
+import { expect, describe, it } from 'vitest';
+import { highlightedOffenses, runLiquidCheck } from '../../test';
+import { DeprecatedGlobalAppBlockType } from './index';
+
+describe('Module: DeprecatedGlobalAppBlockType', () => {
+  it('rejects invalid global app block type in section schemas', async () => {
+    const sourceCode = `
+      {% schema %}
+        {
+          "name": "Product section",
+          "blocks": [{"type": "@global"}]
+        }
+      {% endschema %}
+    `;
+
+    const offenses = await runLiquidCheck(DeprecatedGlobalAppBlockType, sourceCode);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual(
+      'The global app block type `@global` is deprecated. Use `@app` instead.',
+    );
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual(['"blocks": [{"type": "@global"}]']);
+  });
+
+  it('rejects invalid global app block type in conditional statement', async () => {
+    const sourceCode = `
+      {% for block in section.blocks %}
+        {% if block.type = "@global" %}
+          {% render block %}
+        {% elsif "@global" == block.type %}
+        {% endif %}
+      {% endfor %}
+      {% schema %}
+        {
+          "name": "Product section",
+          "blocks": [{"type": "@global"}]
+        }
+      {% endschema %}
+    `;
+
+    const offenses = await runLiquidCheck(DeprecatedGlobalAppBlockType, sourceCode);
+    expect(offenses).toHaveLength(3);
+    expect(offenses[0].message).toEqual(
+      'The global app block type `@global` is deprecated. Use `@app` instead.',
+    );
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual([
+      '{% if block.type = "@global" %}',
+      '{% elsif "@global" == block.type %}',
+      '"blocks": [{"type": "@global"}]',
+    ]);
+  });
+
+  it('rejects invalid global app block type in switch case statement', async () => {
+    const sourceCode = `
+      {% for block in section.blocks %}
+        {% case block.type %}
+          {% when "@global" %}
+            {% render block %}
+          {% else %}
+        {% endcase %}
+      {% endfor %}
+      {% schema %}
+        {
+          "name": "Product section",
+          "blocks": [{"type": "@global"}]
+        }
+      {% endschema %}
+    `;
+
+    const offenses = await runLiquidCheck(DeprecatedGlobalAppBlockType, sourceCode);
+    expect(offenses).toHaveLength(2);
+    expect(offenses[0].message).toEqual(
+      'The global app block type `@global` is deprecated. Use `@app` instead.',
+    );
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual(['{% when "@global" %}', '"blocks": [{"type": "@global"}]']);
+  });
+
+  it('does not reject global string used outside liquid control flow statements', async () => {
+    const sourceCode = `
+      <p> This is "@global" </p>
+      <script> var i = "@global" </script>
+      {% schema %}
+        {
+          "name": "Product section"
+        }
+      {% endschema %}
+    `;
+
+    const offenses = await runLiquidCheck(DeprecatedGlobalAppBlockType, sourceCode);
+    expect(offenses).toHaveLength(0);
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toHaveLength(0);
+  });
+
+  it('accepts valid global app block type', async () => {
+    const sourceCode = `
+      {% for block in section.blocks %}
+        {% if block.type = "@app" %}
+          {% render block %}
+        {% endif %}
+      {% endfor %}
+      {% schema %}
+      {
+        "name": "Product section",
+        "blocks": [{"type": "@app"}]
+      }
+    {% endschema %}
+  `;
+
+    const offenses = await runLiquidCheck(DeprecatedGlobalAppBlockType, sourceCode);
+    expect(offenses).toHaveLength(0);
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+
+    expect(highlights).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/deprecated-global-app-block-type/index.spec.ts
+++ b/packages/theme-check-common/src/checks/deprecated-global-app-block-type/index.spec.ts
@@ -82,6 +82,7 @@ describe('Module: DeprecatedGlobalAppBlockType', () => {
 
   it('does not reject global string used outside liquid control flow statements', async () => {
     const sourceCode = `
+      {{ "@global" }}
       <p> This is "@global" </p>
       <script> var i = "@global" </script>
       {% schema %}
@@ -118,5 +119,22 @@ describe('Module: DeprecatedGlobalAppBlockType', () => {
     const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
 
     expect(highlights).toHaveLength(0);
+  });
+
+  it('rejects global string used in liquid control flow statements', async () => {
+    const sourceCode = `
+      {% if var = "@global" %}
+        <p> This is "@global" </p>
+      {% endif %}
+    `;
+
+    const offenses = await runLiquidCheck(DeprecatedGlobalAppBlockType, sourceCode);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual(
+      'The global app block type `@global` is deprecated. Use `@app` instead.',
+    );
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual([`{% if var = "@global" %}`]);
   });
 });

--- a/packages/theme-check-common/src/checks/deprecated-global-app-block-type/index.ts
+++ b/packages/theme-check-common/src/checks/deprecated-global-app-block-type/index.ts
@@ -1,0 +1,108 @@
+import {
+  LiquidBranchNamed,
+  LiquidConditionalExpression,
+  LiquidHtmlNode,
+  LiquidTag,
+  NamedTags,
+  NodeTypes,
+} from '@shopify/liquid-html-parser';
+import { Severity, SourceCodeType, LiquidCheckDefinition } from '../../types';
+
+function isGlobalStringNode(node: string | LiquidConditionalExpression): node is NodeTypes.String {
+  return typeof node !== 'string' && node.type === NodeTypes.String && node.value === '@global';
+}
+
+function isNamedBranch(node: LiquidHtmlNode): node is LiquidBranchNamed {
+  return node.type === NodeTypes.LiquidBranch && node.name !== null;
+}
+
+export const DeprecatedGlobalAppBlockType: LiquidCheckDefinition = {
+  meta: {
+    code: 'DeprecatedGlobalAppBlockType',
+    name: 'Deprecated Global App Block Type',
+    docs: {
+      description: 'Check for deprecated global app block type `@global`',
+      recommended: true,
+      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/deprecated-global-app-block-type',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    function report(position: { start: number; end: number }) {
+      context.report({
+        message: 'The global app block type `@global` is deprecated. Use `@app` instead.',
+        startIndex: position.start,
+        endIndex: position.end,
+      });
+    }
+    function hasGlobal(markup: string | LiquidConditionalExpression): boolean {
+      if (typeof markup === 'string') {
+        return markup.includes('@global');
+      } else if (markup.type === NodeTypes.Comparison) {
+        return hasGlobal(markup.left) || hasGlobal(markup.right);
+      }
+      return isGlobalStringNode(markup);
+    }
+
+    function checkBranch(node: LiquidBranchNamed | LiquidTag) {
+      if ((node.name === NamedTags.if || node.name === NamedTags.elsif) && hasGlobal(node.markup)) {
+        report({ start: node.blockStartPosition.start, end: node.blockStartPosition.end });
+      } else if (
+        node.name === NamedTags.when &&
+        typeof node.markup !== 'string' &&
+        node.markup.some(isGlobalStringNode)
+      ) {
+        report({ start: node.blockStartPosition.start, end: node.blockStartPosition.end });
+      }
+
+      if (node.type === NodeTypes.LiquidTag && Array.isArray(node.children)) {
+        node.children.filter(isNamedBranch).forEach(checkBranch);
+      }
+    }
+
+    return {
+      async LiquidTag(node) {
+        if (!node.children) return;
+        if (node.name === NamedTags.if || node.name === NamedTags.case) checkBranch(node);
+      },
+
+      async LiquidRawTag(node) {
+        if (node.name === 'schema') {
+          const schema = JSONSafeParse(node.body.value);
+          if ('blocks' in schema && Array.isArray(schema.blocks)) {
+            schema.blocks.forEach((block: unknown) => {
+              if (
+                typeof block === 'object' &&
+                block !== null &&
+                'type' in block &&
+                block.type === '@global'
+              ) {
+                const globalIndex = node.body.value.indexOf('"@global"');
+                const lineStart = node.body.value.lastIndexOf('\n', globalIndex);
+                const lineEnd = node.body.value.indexOf('\n', globalIndex);
+                const excludeSpaces = node.body.value.slice(lineStart + 1, lineEnd).search(/\S|$/);
+                const position = {
+                  start: node.body.position.start + lineStart + 1 + excludeSpaces,
+                  end: node.body.position.start + lineEnd,
+                };
+                report(position);
+              }
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+function JSONSafeParse(body: string): any {
+  try {
+    return JSON.parse(body);
+  } catch (_) {
+    return {};
+  }
+}

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -32,6 +32,7 @@ import { DeprecatedFilter } from './deprecated-filter';
 import { DeprecatedTag } from './deprecated-tag';
 import { AssetSizeJavaScript } from './asset-size-javascript';
 import { UndefinedObject } from './undefined-object';
+import { DeprecatedGlobalAppBlockType } from './deprecated-global-app-block-type';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
@@ -43,9 +44,10 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   CdnPreconnect,
   ContentForHeaderModification,
   DeprecateBgsizes,
-  DeprecateLazysizes,
   DeprecatedFilter,
+  DeprecatedGlobalAppBlockType,
   DeprecatedTag,
+  DeprecateLazysizes,
   ImgWidthAndHeight,
   JSONSyntaxError,
   LiquidHTMLSyntaxError,

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -94,3 +94,6 @@ ValidHTMLTranslation:
 ValidSchema:
   enabled: true
   severity: 0
+deprecated-global-app-block-type:
+  enabled: true
+  severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -75,3 +75,6 @@ ValidHTMLTranslation:
 ValidSchema:
   enabled: true
   severity: 0
+deprecated-global-app-block-type:
+  enabled: true
+  severity: 1


### PR DESCRIPTION
Resolves https://github.com/Shopify/theme-check-js/issues/52
# What are you adding in this PR?

This PR is adding the `DeprecatedGlobalAppBlockType` check. This check reports a message if `@global` is used, and prompts the user to use `@app` instead.

Quick summary of how the code works:
`LiquidTag` in this check deals with cases with conditional statements like `{% if block.type = "@global" %}` by calling the `checkBranch` function which recursively traverses through the children. This deals with nested conditional statements. `LiquidRawTag` on the other hand traverses through a schema by parsing it, and sees if `@global` is being used in `blocks`. Example being: ` "blocks": [{"type": "@global"}]`


## What's next? Any followup issues?

No followup issues.

## Before you deploy

<!-- If a checklist is not applicable, you can delete it. -->

<!-- Include this check when updating anything within packages/theme-check-* -->
- [x] This PR includes a new checks
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn update-configs` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->