### PR TITLE
Revert adding detail to CompletionItem in language server

### DIFF
--- a/.changeset/slimy-kangaroos-check.md
+++ b/.changeset/slimy-kangaroos-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Revert the detail info in completion items, this causes weird things in VS Code

--- a/packages/theme-language-server-common/src/completions/providers/common/CompletionItemProperties.ts
+++ b/packages/theme-language-server-common/src/completions/providers/common/CompletionItemProperties.ts
@@ -43,13 +43,11 @@ function documentationProperties(
   docsetEntryType?: DocsetEntryType,
   entryType?: PseudoType | ArrayType,
 ): {
-  detail: string | undefined;
   documentation: MarkupContent;
 } {
   const value = render(entry, entryType, docsetEntryType);
 
   return {
-    detail: entry.summary,
     documentation: {
       kind: 'markdown',
       value,


### PR DESCRIPTION
# What are you adding in this PR?

- Remove the `detail` info from the CompletionItems in the LanguageServer because those make the doc window look weird.

## Before you deploy

- [x] I included a patch bump `changeset` to this PR
