### PR TITLE
Theme Tools Release: 19-10-23

### DIFF
--- a/.changeset/slimy-kangaroos-check.md
+++ b/.changeset/slimy-kangaroos-check.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-language-server-common': patch
----
-
-Revert the detail info in completion items, this causes weird things in VS Code

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-browser
 
+## 1.4.1
+
+### Patch Changes
+
+- Updated dependencies [54a9075]
+  - @shopify/theme-language-server-common@1.4.1
+
 ## 1.4.0
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -22,7 +22,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.4.0",
+    "@shopify/theme-language-server-common": "1.4.1",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-language-server-common
 
+## 1.4.1
+
+### Patch Changes
+
+- 54a9075: Revert the detail info in completion items, this causes weird things in VS Code
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-node
 
+## 1.4.1
+
+### Patch Changes
+
+- Updated dependencies [54a9075]
+  - @shopify/theme-language-server-common@1.4.1
+
 ## 1.4.0
 
 ### Patch Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -22,7 +22,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.4.0",
+    "@shopify/theme-language-server-common": "1.4.1",
     "@shopify/theme-check-node": "^1.17.0",
     "@shopify/theme-check-docs-updater": "^1.17.0",
     "glob": "^8.0.3",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## theme-check-vscode
 
+## 1.11.14
+
+### Patch Changes
+
+- Patch bump because it depends on @shopify/theme-language-server-node
+  - @shopify/theme-language-server-node@1.4.1
+
 ## 1.11.13
 
 ### Patch Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "charlespwd"
   },
-  "version": "1.11.13",
+  "version": "1.11.14",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -61,7 +61,7 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^1.0.0",
     "@shopify/prettier-plugin-liquid": "^1.3.2",
-    "@shopify/theme-language-server-node": "^1.4.0",
+    "@shopify/theme-language-server-node": "^1.4.1",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0"
   },


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `1.11.13` -> `1.11.14`
### Changes:
- Patch bump because it depends on @shopify/theme-language-server-node

## `@shopify/theme-language-server-common`
Patch incremented `1.4.0` -> `1.4.1`
### Changes:
- Revert the detail info in completion items, this causes weird things in VS Code

## `@shopify/theme-language-server-browser`
Patch incremented `1.4.0` -> `1.4.1`

## `@shopify/theme-language-server-node`
Patch incremented `1.4.0` -> `1.4.1`

