### PR TITLE
Add blocks contextual completion, hover and UndefinedObject support

### DIFF
--- a/.changeset/wet-guests-whisper.md
+++ b/.changeset/wet-guests-whisper.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+Add blocks/ files contextual completion, hover and UndefinedObject support

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -274,6 +274,7 @@ describe('Module: UndefinedObject', () => {
       ['section', 'sections/section.liquid'],
       ['predictive_search', 'sections/predictive-search.liquid'],
       ['recommendations', 'sections/recommendations.liquid'],
+      ['block', 'blocks/theme-app-extension.liquid'],
     ];
     for (const [object, goodPath] of contexts) {
       offenses = await runLiquidCheck(UndefinedObject, `{{ ${object} }}`, goodPath);

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -161,6 +161,10 @@ function getContextualObjects(relativePath: string): string[] {
     return ['section', 'predictive_search', 'recommendations'];
   }
 
+  if (relativePath.startsWith('blocks/')) {
+    return ['section', 'block'];
+  }
+
   return [];
 }
 

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -150,6 +150,14 @@ export async function check(
             },
           },
           {
+            name: 'block',
+            access: {
+              global: false,
+              parents: [],
+              template: [],
+            },
+          },
+          {
             name: 'predictive_search',
             access: {
               global: false,

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -144,6 +144,9 @@ function getContextualEntries(uri: string): string[] {
   if (/sections\/[^.\/]*\.liquid$/.test(absolutePath)) {
     return ['section', 'predictive_search', 'recommendations'];
   }
+  if (/blocks\/[^.\/]*\.liquid$/.test(absolutePath)) {
+    return ['section', 'block'];
+  }
   return [];
 }
 

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
@@ -20,6 +20,14 @@ describe('Module: ObjectCompletionProvider', async () => {
           },
         },
         {
+          name: 'block',
+          access: {
+            global: false,
+            template: [],
+            parents: [],
+          },
+        },
+        {
           name: 'predictive_search',
           access: {
             global: false,
@@ -131,6 +139,7 @@ describe('Module: ObjectCompletionProvider', async () => {
   it('should complete relative-path-dependent contextual variables', async () => {
     const contexts: [string, string][] = [
       ['section', 'sections/main-product.liquid'],
+      ['block', 'blocks/my-block.liquid'],
       ['predictive_search', 'sections/predictive-search.liquid'],
       ['recommendations', 'sections/recommendations.liquid'],
     ];

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
@@ -53,6 +53,10 @@ describe('Module: LiquidObjectHoverProvider', async () => {
           access: { global: false, parents: [], template: [] },
         },
         {
+          name: 'block',
+          access: { global: false, parents: [], template: [] },
+        },
+        {
           name: 'predictive_search',
           access: { global: false, parents: [], template: [] },
         },
@@ -137,6 +141,7 @@ describe('Module: LiquidObjectHoverProvider', async () => {
   it('should support contextual objects by relative path', async () => {
     const contexts: [string, string][] = [
       ['section', 'sections/my-section.liquid'],
+      ['block', 'blocks/my-block.liquid'],
       ['predictive_search', 'sections/predictive-search.liquid'],
       ['recommendations', 'sections/recommendations.liquid'],
     ];


### PR DESCRIPTION
# What are you adding in this PR?

- Fix `block` and `section` completion, hover and `UndefinedObject` reporting in `blocks/*` files.

## Before you deploy

- [x] I included a `changeset` to this PR
