### PR TITLE
Re-add `ignoreMissing` support to `MissingTemplate`

### DIFF
--- a/.changeset/slimy-poets-shout.md
+++ b/.changeset/slimy-poets-shout.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': patch
+'@shopify/theme-check-node': patch
+---
+
+Re-add `ignoreMissing` support to `MissingTemplate`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,10 +9,10 @@
 
 ## Before you deploy
 
-<!-- If a checklist is not applicable, you can delete it. -->
+<!-- Delete the checklists you don't need -->
 
-<!-- Include this check when updating anything within packages/theme-check-* -->
-- [ ] This PR includes a new checks
+<!-- Check changes -->
+- [ ] This PR includes a new checks or changes the configuration of a check
   - [ ] I included a minor bump `changeset`
   - [ ] It's in the `allChecks` array in `src/checks/index.ts`
   - [ ] I ran `yarn update-configs` and committed the updated configuration files
@@ -21,8 +21,9 @@
     <!-- see packages/node/configs/theme-app-extension.yml -->
     - [ ] If applicable, I've updated the `theme-app-extension.yml` config
 
-- [ ] This PR changes the public API
-  - [ ] I included a minor bump `changeset` titled `Breaking: ...`
+<!-- Public API changes, new features -->
+- [ ] I included a minor bump `changeset`
+- [ ] My feature is backward compatible
 
-- [ ] This PR fixes a bug
-  - [ ] I included a patch bump `changeset` to this PR
+<!-- Bug fixes -->
+- [ ] I included a patch bump `changeset`

--- a/packages/theme-check-common/src/checks/missing-template/index.spec.ts
+++ b/packages/theme-check-common/src/checks/missing-template/index.spec.ts
@@ -62,4 +62,49 @@ describe('Module: MissingTemplate', () => {
       });
     }
   });
+
+  it('ignores missing files if ignored by ignore_missing pattern', async () => {
+    const contexts = [
+      {
+        file: '{% render "ignored" %}',
+        ignoreMissing: ['snippets/ignored.liquid'],
+      },
+      {
+        file: '{% render "ignored" %}',
+        ignoreMissing: ['snippets/*.liquid'],
+      },
+      {
+        file: '{% render "ignored" %}',
+        ignoreMissing: ['*/ignored.liquid'],
+      },
+      {
+        file: '{% section "ignored" %}',
+        ignoreMissing: ['sections/ignored.liquid'],
+      },
+      {
+        file: '{% section "ignored" %}',
+        ignoreMissing: ['sections/ignored.liquid'],
+      },
+      {
+        file: '{% section "ignored" %}',
+        ignoreMissing: ['*/ignored.liquid'],
+      },
+    ];
+
+    for (const { file, ignoreMissing } of contexts) {
+      MissingTemplate;
+      const offenses = await check(
+        { 'file.liquid': file },
+        [MissingTemplate],
+        {},
+        {
+          MissingTemplate: {
+            enabled: true,
+            ignoreMissing,
+          },
+        },
+      );
+      expect(offenses).to.be.empty;
+    }
+  });
 });

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -16,6 +16,7 @@ import {
   FixApplicator,
   createCorrector,
   Dependencies,
+  ChecksSettings,
 } from '../index';
 
 export { StringCorrector, JSONCorrector };
@@ -47,10 +48,11 @@ export async function check(
   themeDesc: MockTheme,
   checks: CheckDefinition<SourceCodeType>[] = recommended,
   mockDependencies: Partial<Dependencies> = {},
+  checkSettings: ChecksSettings = {},
 ): Promise<Offense[]> {
   const theme = getTheme(themeDesc);
   const config: Config = {
-    settings: {},
+    settings: { ...checkSettings },
     checks: checks,
     root: '/',
   };

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -61,6 +61,7 @@ MissingAsset:
 MissingTemplate:
   enabled: true
   severity: 0
+  ignoreMissing: []
 PaginationSize:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -42,6 +42,7 @@ MissingAsset:
 MissingTemplate:
   enabled: true
   severity: 0
+  ignoreMissing: []
 PaginationSize:
   enabled: true
   severity: 1


### PR DESCRIPTION
# What are you adding in this PR?

- Re-add `ignoreMissing` feature to MissingTemplate. For icons and stuff that only appear after a build step.

## Before you deploy

- [ ] This PR modifies a checks' configuration
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn update-configs` and committed the updated configuration files
