### PR TITLE
Fix UnusedAssign false positives

### DIFF
--- a/.changeset/fifty-eggs-walk.md
+++ b/.changeset/fifty-eggs-walk.md
@@ -1,0 +1,7 @@
+---
+'@shopify/liquid-html-parser': minor
+---
+
+Add `nodes` property to RawMarkupKind to allow for subtree visiting
+
+- Partially breaking in the sense where Liquid (not LiquidHTML) syntax errors will be reported from within scripts, styles, and JSON blobs

--- a/.changeset/perfect-pigs-matter.md
+++ b/.changeset/perfect-pigs-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fix UnusedAssign false positives in raw-like nodes

--- a/packages/codemirror-language-client/package.json
+++ b/packages/codemirror-language-client/package.json
@@ -29,7 +29,8 @@
     "dev:playground": "webpack serve --open -c ./playground/webpack.config.js",
     "format": "prettier --write \"packages/*/src/**/*.ts\"",
     "format:check": "prettier --check --ignore-unknown \"packages/*/src/**/*.ts\"",
-    "test": "vitest"
+    "test": "vitest",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "vscode-languageserver-protocol": "^3.17.3",

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -1,7 +1,7 @@
 Helpers {
   Node = TextNode*
   TextNode = AnyExceptPlus<openControl>
-  openControl = empty
+  openControl = end
 
   empty = /* nothing */
   anyExcept<lit> = (~ lit any)

--- a/packages/liquid-html-parser/src/grammar.ts
+++ b/packages/liquid-html-parser/src/grammar.ts
@@ -2,6 +2,8 @@ import ohm from 'ohm-js';
 
 export const liquidHtmlGrammars = ohm.grammars(require('../grammar/liquid-html.ohm.js'));
 
+export const TextNodeGrammar = liquidHtmlGrammars['Helpers'];
+
 export interface LiquidGrammars {
   Liquid: ohm.Grammar;
   LiquidHTML: ohm.Grammar;

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -669,6 +669,8 @@ export interface RawMarkup extends ASTNode<NodeTypes.RawMarkup> {
   kind: RawMarkupKinds;
   /** string value of the contents */
   value: string;
+  /** parsed contents for when you want to visit the tree anyway! */
+  nodes: (LiquidNode | TextNode)[];
 }
 
 /** Used to represent the `<!doctype html>` nodes */
@@ -1073,7 +1075,7 @@ function buildAst(
           type: NodeTypes.LiquidRawTag,
           markup: markup(node.name, node.markup),
           name: node.name,
-          body: toRawMarkup(node),
+          body: toRawMarkup(node, options),
           whitespaceStart: node.whitespaceStart ?? '',
           whitespaceEnd: node.whitespaceEnd ?? '',
           delimiterWhitespaceStart: node.delimiterWhitespaceStart ?? '',
@@ -1144,7 +1146,7 @@ function buildAst(
         builder.push({
           type: NodeTypes.HtmlRawNode,
           name: node.name,
-          body: toRawMarkup(node),
+          body: toRawMarkup(node, options),
           attributes: toAttributes(node.attrList || [], options),
           position: position(node),
           source: node.source,
@@ -1533,10 +1535,14 @@ function toPaginateMarkup(node: ConcretePaginateMarkup): PaginateMarkup {
   };
 }
 
-function toRawMarkup(node: ConcreteHtmlRawTag | ConcreteLiquidRawTag): RawMarkup {
+function toRawMarkup(
+  node: ConcreteHtmlRawTag | ConcreteLiquidRawTag,
+  options: ASTBuildOptions,
+): RawMarkup {
   return {
     type: NodeTypes.RawMarkup,
     kind: toRawMarkupKind(node),
+    nodes: cstToAst(node.children, options) as (TextNode | LiquidNode)[],
     value: node.body,
     position: {
       start: node.blockStartLocEnd,

--- a/packages/theme-check-common/src/disabled-checks/index.spec.ts
+++ b/packages/theme-check-common/src/disabled-checks/index.spec.ts
@@ -30,9 +30,9 @@ function expectRenderMarkupOffense(offenses: Offense[], templateName: string) {
 describe('Module: DisabledChecks', () => {
   const checks = [LiquidFilter, RenderMarkup];
 
-  commentTypes.forEach((buildComment, index) => {
-    describe(`Comment variant ${index + 1}`, () => {
-      it('should disable checks for the entire document if comment is placed on the first line', async () => {
+  describe(`Comment variant`, () => {
+    it('should disable checks for the entire document if comment is placed on the first line', async () => {
+      for (const buildComment of commentTypes) {
         const file = `${buildComment('theme-check-disable LiquidFilter')}
 {% comment %}
   This is some comment about the file...
@@ -44,18 +44,22 @@ describe('Module: DisabledChecks', () => {
         const offenses = await check({ 'code.liquid': file }, checks);
         expect(offenses).to.have.length(1);
         expectRenderMarkupOffense(offenses, 'something.liquid');
-      });
+      }
+    });
 
-      it('should disable all checks even if comment has additional spaces', async () => {
+    it('should disable all checks even if comment has additional spaces', async () => {
+      for (const buildComment of commentTypes) {
         const file = `${buildComment('  theme-check-disable     ')}
 {{ 'asset' | random_filter }}
 {% render 'something' %}`;
 
         const offenses = await check({ 'code.liquid': file }, checks);
         expect(offenses).to.have.length(0);
-      });
+      }
+    });
 
-      it('should disable all checks for a section of the template', async () => {
+    it('should disable all checks for a section of the template', async () => {
+      for (const buildComment of commentTypes) {
         const file = `{{ 'asset-1' | random_filter }}
 {% render 'something-1' %}
 ${buildComment('theme-check-disable')}
@@ -69,9 +73,11 @@ ${buildComment('theme-check-enable')}
         expectLiquidFilterOffense(offenses, file, 'asset-1');
         expectLiquidFilterOffense(offenses, file, 'asset-3');
         expectRenderMarkupOffense(offenses, 'something-1.liquid');
-      });
+      }
+    });
 
-      it('should disable a specific check if check is included in the comment', async () => {
+    it('should disable a specific check if check is included in the comment', async () => {
+      for (const buildComment of commentTypes) {
         const file = `${buildComment('theme-check-disable LiquidFilter')}
 {{ 'asset-1' | random_filter }}
 {% render 'something' %}
@@ -82,9 +88,11 @@ ${buildComment('theme-check-enable LiquidFilter')}
         expect(offenses).to.have.length(2);
         expectLiquidFilterOffense(offenses, file, 'asset-2');
         expectRenderMarkupOffense(offenses, 'something.liquid');
-      });
+      }
+    });
 
-      it('should disable multiple checks if checks are separated by a comma (and maybe some spaces)', async () => {
+    it('should disable multiple checks if checks are separated by a comma (and maybe some spaces)', async () => {
+      for (const buildComment of commentTypes) {
         const file = `${buildComment('theme-check-disable LiquidFilter, RenderMarkup')}
 {{ 'asset-1' | random_filter }}
 {% render 'something' %}
@@ -94,9 +102,11 @@ ${buildComment('theme-check-enable LiquidFilter,RenderMarkup')}
         const offenses = await check({ 'code.liquid': file }, checks);
         expect(offenses).to.have.length(1);
         expectLiquidFilterOffense(offenses, file, 'asset-2');
-      });
+      }
+    });
 
-      it('should enable specific checks individually', async () => {
+    it('should enable specific checks individually', async () => {
+      for (const buildComment of commentTypes) {
         const file = `${buildComment('theme-check-disable LiquidFilter, RenderMarkup')}
 {{ 'asset-1' | random_filter }}
 {% render 'something-1' %}
@@ -112,10 +122,12 @@ ${buildComment('theme-check-enable LiquidFilter')}
         expectLiquidFilterOffense(offenses, file, 'asset-3');
         expectRenderMarkupOffense(offenses, 'something-2.liquid');
         expectRenderMarkupOffense(offenses, 'something-3.liquid');
-      });
+      }
+    });
 
-      describe('Mix of general and specific commands', () => {
-        it('should not reenable specific check when all checks have been disabled before', async () => {
+    describe('Mix of general and specific commands', () => {
+      it('should not reenable specific check when all checks have been disabled before', async () => {
+        for (const buildComment of commentTypes) {
           const file = `${buildComment('theme-check-disable')}
 {{ 'asset-1' | random_filter }}
 {% render 'something-1' %}
@@ -124,9 +136,11 @@ ${buildComment('theme-check-enable RenderMarkup')}
 {% render 'something-2' %}`;
           const offenses = await check({ 'code.liquid': file }, checks);
           expect(offenses).to.have.length(0);
-        });
+        }
+      });
 
-        it('should reenable all checks when specific ones have been disabled before', async () => {
+      it('should reenable all checks when specific ones have been disabled before', async () => {
+        for (const buildComment of commentTypes) {
           const file = `${buildComment('theme-check-disable LiquidFilter, RenderMarkup')}
 {{ 'asset-3' | random_filter }}
 {% render 'something-3' %}
@@ -138,7 +152,7 @@ ${buildComment('theme-check-enable')}
           expect(offenses).to.have.length(2);
           expectLiquidFilterOffense(offenses, file, 'asset-4');
           expectRenderMarkupOffense(offenses, 'something-4.liquid');
-        });
+        }
       });
     });
   });


### PR DESCRIPTION
# What are you adding in this PR?

- Fix UnusedAssign false positives due to subtree visiting of raw-like nodes
- Report unused assigns for `capture`d variables
- `@shopify/liquid-html-parser`
  - Add a `nodes: (TextNode | LiquidNode)[]` property to `RawMarkup` nodes
  - These are then automatically visited by `UnusedAssign`

Fixes #174 

## Before you deploy

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset` (for the parser)
- [x] My feature is backward compatible

<!-- Bug fixes -->
- [x] I included a patch bump `changeset` (for theme-check)
