### PR TITLE
Theme Tools Release: 25-10-23

### DIFF
--- a/.changeset/fifty-eggs-walk.md
+++ b/.changeset/fifty-eggs-walk.md
@@ -1,7 +1,0 @@
----
-'@shopify/liquid-html-parser': minor
----
-
-Add `nodes` property to RawMarkupKind to allow for subtree visiting
-
-- Partially breaking in the sense where Liquid (not LiquidHTML) syntax errors will be reported from within scripts, styles, and JSON blobs

--- a/.changeset/metal-comics-buy.md
+++ b/.changeset/metal-comics-buy.md
@@ -1,6 +1,0 @@
----
-'@shopify/theme-language-server-common': patch
-'@shopify/theme-check-common': patch
----
-
-Fix hover, completion and `UndefinedObject` reporting of `{% increment var %}` and `{% decrement var %}`

--- a/.changeset/perfect-pigs-matter.md
+++ b/.changeset/perfect-pigs-matter.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-check-common': patch
----
-
-Fix UnusedAssign false positives in raw-like nodes

--- a/packages/liquid-html-parser/CHANGELOG.md
+++ b/packages/liquid-html-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/liquid-html-parser
 
+## 1.1.0
+
+### Minor Changes
+
+- 0d71145: Add `nodes` property to RawMarkupKind to allow for subtree visiting
+
+  - Partially breaking in the sense where Liquid (not LiquidHTML) syntax errors will be reported from within scripts, styles, and JSON blobs
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/liquid-html-parser/package.json
+++ b/packages/liquid-html-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/liquid-html-parser",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Liquid HTML parser by Shopify",
   "repository": "shopify/theme-tools",
   "author": "CP Clermont <@charlespwd>",

--- a/packages/prettier-plugin-liquid/CHANGELOG.md
+++ b/packages/prettier-plugin-liquid/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/prettier-plugin-liquid
 
+## 1.3.3
+
+### Patch Changes
+
+- Patch bump because it depends on @shopify/liquid-html-parser
+- Updated dependencies [0d71145]
+  - @shopify/liquid-html-parser@1.1.0
+
 ## 1.3.2
 
 ### Patch Changes

--- a/packages/prettier-plugin-liquid/package.json
+++ b/packages/prettier-plugin-liquid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/prettier-plugin-liquid",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Prettier Liquid/HTML plugin by Shopify",
   "repository": "shopify/prettier-plugin-liquid",
   "author": "CP Clermont <@charlespwd>",
@@ -55,7 +55,7 @@
     "tsconfig-paths": "^3.14.1"
   },
   "dependencies": {
-    "@shopify/liquid-html-parser": "^1.0.0",
+    "@shopify/liquid-html-parser": "^1.1.0",
     "html-styles": "^1.0.0"
   }
 }

--- a/packages/theme-check-browser/CHANGELOG.md
+++ b/packages/theme-check-browser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/theme-check-browser
 
+## 1.18.1
+
+### Patch Changes
+
+- Updated dependencies [aa33c5f]
+- Updated dependencies [0d71145]
+  - @shopify/theme-check-common@1.18.1
+
 ## 1.18.0
 
 ### Patch Changes

--- a/packages/theme-check-browser/package.json
+++ b/packages/theme-check-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-browser",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-check-common/README.md",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,6 +21,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "1.18.0"
+    "@shopify/theme-check-common": "1.18.1"
   }
 }

--- a/packages/theme-check-common/CHANGELOG.md
+++ b/packages/theme-check-common/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-check-common
 
+## 1.18.1
+
+### Patch Changes
+
+- aa33c5f: Fix hover, completion and `UndefinedObject` reporting of `{% increment var %}` and `{% decrement var %}`
+- 0d71145: Fix UnusedAssign false positives in raw-like nodes
+- Updated dependencies [0d71145]
+  - @shopify/liquid-html-parser@1.1.0
+
 ## 1.18.0
 
 ### Minor Changes

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-common",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "license": "MIT",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-check-common/README.md",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/liquid-html-parser": "1.0.0",
+    "@shopify/liquid-html-parser": "1.1.0",
     "cross-fetch": "^4.0.0",
     "json-to-ast": "^2.1.0",
     "line-column": "^1.0.2",

--- a/packages/theme-check-docs-updater/CHANGELOG.md
+++ b/packages/theme-check-docs-updater/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/theme-check-docs-updater
 
+## 1.18.1
+
+### Patch Changes
+
+- Updated dependencies [aa33c5f]
+- Updated dependencies [0d71145]
+  - @shopify/theme-check-common@1.18.1
+
 ## 1.18.0
 
 ### Patch Changes

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-docs-updater",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Scripts to initialize theme-check data with assets from the theme-liquid-docs repo.",
   "main": "dist/index.js",
   "author": "Albert Chu <albert.chu@shopify.com>",
@@ -20,7 +20,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "^1.18.0",
+    "@shopify/theme-check-common": "^1.18.1",
     "ajv": "^8.12.0",
     "env-paths": "^2.2.1",
     "node-fetch": "^2.6.11"

--- a/packages/theme-check-node/CHANGELOG.md
+++ b/packages/theme-check-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-check-node
 
+## 1.18.1
+
+### Patch Changes
+
+- Updated dependencies [aa33c5f]
+- Updated dependencies [0d71145]
+  - @shopify/theme-check-common@1.18.1
+  - @shopify/theme-check-docs-updater@1.18.1
+
 ## 1.18.0
 
 ### Minor Changes

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-node",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -25,8 +25,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "1.18.0",
-    "@shopify/theme-check-docs-updater": "1.18.0",
+    "@shopify/theme-check-common": "1.18.1",
+    "@shopify/theme-check-docs-updater": "1.18.1",
     "glob": "^8.0.3",
     "yaml": "^2.3.0"
   },

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-browser
 
+## 1.4.4
+
+### Patch Changes
+
+- Updated dependencies [aa33c5f]
+  - @shopify/theme-language-server-common@1.4.4
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -22,7 +22,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.4.3",
+    "@shopify/theme-language-server-common": "1.4.4",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @shopify/theme-language-server-common
 
+## 1.4.4
+
+### Patch Changes
+
+- aa33c5f: Fix hover, completion and `UndefinedObject` reporting of `{% increment var %}` and `{% decrement var %}`
+- Updated dependencies [0d71145]
+- Updated dependencies [aa33c5f]
+- Updated dependencies [0d71145]
+  - @shopify/liquid-html-parser@1.1.0
+  - @shopify/theme-check-common@1.18.1
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -22,8 +22,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/liquid-html-parser": "^1.0.0",
-    "@shopify/theme-check-common": "1.18.0",
+    "@shopify/liquid-html-parser": "^1.1.0",
+    "@shopify/theme-check-common": "1.18.1",
     "@vscode/web-custom-data": "^0.4.6",
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.8",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-language-server-node
 
+## 1.4.4
+
+### Patch Changes
+
+- Updated dependencies [aa33c5f]
+  - @shopify/theme-language-server-common@1.4.4
+  - @shopify/theme-check-node@1.18.1
+  - @shopify/theme-check-docs-updater@1.18.1
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -22,9 +22,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.4.3",
-    "@shopify/theme-check-node": "^1.18.0",
-    "@shopify/theme-check-docs-updater": "^1.18.0",
+    "@shopify/theme-language-server-common": "1.4.4",
+    "@shopify/theme-check-node": "^1.18.1",
+    "@shopify/theme-check-docs-updater": "^1.18.1",
     "glob": "^8.0.3",
     "node-fetch": "^2.6.11",
     "vscode-languageserver": "^8.0.2",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## theme-check-vscode
 
+## 1.11.17
+
+### Patch Changes
+
+- Patch bump because it depends on:
+  - @shopify/liquid-html-parser
+  - @shopify/theme-language-server-node
+- Updated dependencies
+- Updated dependencies [0d71145]
+  - @shopify/prettier-plugin-liquid@1.3.3
+  - @shopify/liquid-html-parser@1.1.0
+  - @shopify/theme-language-server-node@1.4.4
+
 ## 1.11.16
 
 ### Patch Changes

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Patch bump because it depends on:
   - @shopify/liquid-html-parser
   - @shopify/theme-language-server-node
+    - Fix hover, completion and `UndefinedObject` reporting of `{% increment var %}` and `{% decrement var %}`
+    - Fix UnusedAssign false positives in raw-like nodes
 - Updated dependencies
 - Updated dependencies [0d71145]
   - @shopify/prettier-plugin-liquid@1.3.3

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "charlespwd"
   },
-  "version": "1.11.16",
+  "version": "1.11.17",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -59,9 +59,9 @@
     "vscode": "^1.74.0"
   },
   "dependencies": {
-    "@shopify/liquid-html-parser": "^1.0.0",
-    "@shopify/prettier-plugin-liquid": "^1.3.2",
-    "@shopify/theme-language-server-node": "^1.4.3",
+    "@shopify/liquid-html-parser": "^1.1.0",
+    "@shopify/prettier-plugin-liquid": "^1.3.3",
+    "@shopify/theme-language-server-node": "^1.4.4",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0"
   },


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `1.11.16` -> `1.11.17`
### Changes:
- Patch bump because it depends on:
 - @shopify/liquid-html-parser
 - @shopify/theme-language-server-node

## `@shopify/prettier-plugin-liquid`
Patch incremented `1.3.2` -> `1.3.3`
### Changes:
- Patch bump because it depends on @shopify/liquid-html-parser

## `@shopify/liquid-html-parser`
Minor incremented `1.0.0` -> `1.1.0`
### Changes:
- Add `nodes` property to RawMarkupKind to allow for subtree visiting

- Partially breaking in the sense where Liquid (not LiquidHTML) syntax errors will be reported from within scripts, styles, and JSON blobs

## `@shopify/theme-language-server-common`
Patch incremented `1.4.3` -> `1.4.4`
### Changes:
- Fix hover, completion and `UndefinedObject` reporting of `{% increment var %}` and `{% decrement var %}`

## `@shopify/theme-check-common`
Patch incremented `1.18.0` -> `1.18.1`
### Changes:
- Fix hover, completion and `UndefinedObject` reporting of `{% increment var %}` and `{% decrement var %}`
- Fix UnusedAssign false positives in raw-like nodes

## `@shopify/theme-language-server-browser`
Patch incremented `1.4.3` -> `1.4.4`

## `@shopify/theme-language-server-node`
Patch incremented `1.4.3` -> `1.4.4`

## `@shopify/theme-check-browser`
Patch incremented `1.18.0` -> `1.18.1`

## `@shopify/theme-check-node`
Patch incremented `1.18.0` -> `1.18.1`

## `@shopify/theme-check-docs-updater`
Patch incremented `1.18.0` -> `1.18.1`

