### PR TITLE
Fix tsconfig project references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# What are you adding in this PR?
+## What are you adding in this PR?
 
 <!-- Describe your changes. Provide enough context so that someone new can understand the 'why' behind this change. -->
 <!-- Remember to use `fixes` or `solves` keywords to close issues automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->
@@ -6,6 +6,10 @@
 ## What's next? Any followup issues?
 
 <!-- Outline follow up tasks with links to issues so they're tracked. -->
+
+## What did you learn?
+
+<!-- Totally optional. But... If you learned something interesting, why not share it? -->
 
 ## Before you deploy
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
         "${workspaceRoot}/packages/theme-check-common/dist/**/*.js",
         "${workspaceRoot}/packages/theme-check-node/dist/**/*.js",
       ],
-			"preLaunchTask": "npm: build:extension:dev - packages/vscode-extension"
+			"preLaunchTask": "vscode dev watch"
 		},
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,15 +1,16 @@
 {
-	"version": "2.0.0",
-	"tasks": [
+  "version": "2.0.0",
+  "tasks": [
     {
-      "type": "npm",
-      "script": "build:extension:dev",
-      "path": "packages/vscode-extension",
+      "type": "shell",
+      "command": "yarn --cwd packages/vscode-extension build:extension:dev",
       "group": "build",
-      "label": "npm: build:extension:dev - packages/vscode-extension",
-      "detail": "webpack --mode development",
+      "label": "vscode dev watch",
       "dependsOrder": "parallel",
-      "dependsOn": ["parser pre build", "theme check build"],
+      "dependsOn": [
+        "parser pre build",
+        "theme check build"
+      ],
     },
     {
       "label": "parser pre build",

--- a/packages/prettier-plugin-liquid/tsconfig.build.json
+++ b/packages/prettier-plugin-liquid/tsconfig.build.json
@@ -3,6 +3,6 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules", "src/**/*.spec.ts"],
   "references": [
-    { "path": "../liquid-html-parser" }
+    { "path": "../liquid-html-parser/tsconfig.build.json" }
   ]
 }

--- a/packages/theme-check-browser/tsconfig.build.json
+++ b/packages/theme-check-browser/tsconfig.build.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.spec.ts"],
   "references": [
-    { "path": "../theme-check-common" }
+    { "path": "../theme-check-common/tsconfig.build.json" }
   ]
 }

--- a/packages/theme-check-browser/tsconfig.json
+++ b/packages/theme-check-browser/tsconfig.json
@@ -3,13 +3,17 @@
   "include": ["./src/**/*.ts"],
   "exclude": ["./dist"],
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "dist",
     "rootDir": "src",
     "lib": [
       "es2019",
       "webworker"
     ],
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "paths": {
+      "@shopify/theme-check-common": ["../theme-check-common/src"],
+    }
   },
   "references": [
     { "path": "../theme-check-common" }

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -1,8 +1,4 @@
-import {
-  ConfigTarget,
-  JSONCheckDefinition,
-  LiquidCheckDefinition,
-} from '@shopify/theme-check-common';
+import { ConfigTarget, JSONCheckDefinition, LiquidCheckDefinition } from '../types';
 
 import { AppBlockValidTags } from './app-block-valid-tags';
 import { AssetPreload } from './asset-preload';

--- a/packages/theme-check-common/tsconfig.build.json
+++ b/packages/theme-check-common/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "exclude": ["**/*.spec.ts", "**/test/*.ts"],
+  "references": [
+    { "path": "../liquid-html-parser/tsconfig.build.json" }
+  ]
 }

--- a/packages/theme-check-common/tsconfig.json
+++ b/packages/theme-check-common/tsconfig.json
@@ -4,17 +4,17 @@
     "./src/**/*.ts",
     "./src/**/*.json"
   ],
-  "exclude": [
-    "./dist"
-  ],
+  "exclude": ["./dist"],
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "baseUrl": ".",
+    "paths": {
+      "@shopify/liquid-html-parser": ["../liquid-html-parser/src"]
+    }
   },
   "references": [
-    {
-      "path": "../liquid-html-parser"
-    },
+    { "path": "../liquid-html-parser" }
   ]
 }

--- a/packages/theme-check-docs-updater/tsconfig.build.json
+++ b/packages/theme-check-docs-updater/tsconfig.build.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.spec.ts"],
   "references": [
-    { "path": "../theme-check-common" }
+    { "path": "../theme-check-common/tsconfig.build.json" }
   ]
 }

--- a/packages/theme-check-docs-updater/tsconfig.json
+++ b/packages/theme-check-docs-updater/tsconfig.json
@@ -3,9 +3,13 @@
   "include": ["./src/**/*.ts"],
   "exclude": ["./dist"],
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "dist",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "paths": {
+      "@shopify/theme-check-common": ["../theme-check-common/src"]
+    }
   },
   "references": [
     { "path": "../theme-check-common" }

--- a/packages/theme-check-node/tsconfig.build.json
+++ b/packages/theme-check-node/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.spec.ts"],
   "references": [
-    { "path": "../theme-check-common" }
+    { "path": "../theme-check-common/tsconfig.build.json" },
+    { "path": "../theme-check-docs-updater/tsconfig.build.json" }
   ]
 }

--- a/packages/theme-check-node/tsconfig.json
+++ b/packages/theme-check-node/tsconfig.json
@@ -3,12 +3,18 @@
   "include": ["./src/**/*.ts"],
   "exclude": ["./dist"],
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "dist",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "paths": {
+      "@shopify/theme-check-common": ["../theme-check-common/src"],
+      "@shopify/theme-check-docs-updater": ["../theme-check-docs-updater/src"]
+    }
   },
   "references": [
-    { "path": "../theme-check-common" }
+    { "path": "../theme-check-common" },
+    { "path": "../theme-check-docs-updater" }
   ]
 }
 

--- a/packages/theme-language-server-browser/tsconfig.build.json
+++ b/packages/theme-language-server-browser/tsconfig.build.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.spec.ts"],
   "references": [
-    { "path": "../theme-language-server-common/src" }
+    { "path": "../theme-language-server-common/src/tsconfig.build.json" }
   ]
 }

--- a/packages/theme-language-server-browser/tsconfig.json
+++ b/packages/theme-language-server-browser/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["./src/**/*.ts"],
   "exclude": ["./dist"],
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "dist",
     "rootDir": "src",
     "types": [],
@@ -11,7 +12,10 @@
       "webworker"
     ],
     "target": "ES2019",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "paths": {
+      "@shopify/theme-language-server-common": ["../theme-language-server-common/src"]
+    }
   },
   "references": [
     { "path": "../theme-language-server-common/src" }

--- a/packages/theme-language-server-common/src/tsconfig.build.json
+++ b/packages/theme-language-server-common/src/tsconfig.build.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.spec.ts", "test/*.ts"],
   "references": [
-    { "path": ".." }
+    { "path": ".." },
+    { "path": "../../theme-check-common/tsconfig.build.json" },
+    { "path": "../../liquid-html-parser/tsconfig.build.json" }
   ]
 }

--- a/packages/theme-language-server-common/src/tsconfig.json
+++ b/packages/theme-language-server-common/src/tsconfig.json
@@ -1,13 +1,21 @@
 {
   "extends": "../../../tsconfig.json",
-  "include": ["./**/*.ts"],
+  "include": [
+    "./**/*.ts"
+  ],
   "compilerOptions": {
     "outDir": "../dist",
     "rootDir": ".",
-    "tsBuildInfoFile": "../dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "../dist/tsconfig.tsbuildinfo",
+    "baseUrl": ".",
+    "paths": {
+      "@shopify/theme-check-common": ["../../theme-check-common/src"],
+      "@shopify/liquid-html-parser": ["../../liquid-html-parser/src"]
+    }
   },
   "references": [
-    { "path": ".." }
+    { "path": ".." },
+    { "path": "../../theme-check-common" },
+    { "path": "../../liquid-html-parser" }
   ]
 }
-

--- a/packages/theme-language-server-common/tsconfig.json
+++ b/packages/theme-language-server-common/tsconfig.json
@@ -6,13 +6,5 @@
   "compilerOptions": {
     "outDir": ".",
     "rootDir": "."
-  },
-  "references": [
-    {
-      "path": "../theme-check-common"
-    },
-    {
-      "path": "../liquid-html-parser"
-    }
-  ]
+  }
 }

--- a/packages/theme-language-server-node/src/dependencies.ts
+++ b/packages/theme-language-server-node/src/dependencies.ts
@@ -4,8 +4,7 @@ import { basename } from 'node:path';
 import * as fs from 'node:fs/promises';
 import { promisify } from 'node:util';
 import { glob as callbackGlob } from 'glob';
-import { Config, Translations } from '@shopify/theme-check-common';
-import { loadConfig as loadConfigFromPath } from '@shopify/theme-check-node';
+import { Config, Translations, loadConfig as loadConfigFromPath } from '@shopify/theme-check-node';
 
 const glob = promisify(callbackGlob);
 

--- a/packages/theme-language-server-node/tsconfig.build.json
+++ b/packages/theme-language-server-node/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.spec.ts"],
   "references": [
-    { "path": "../theme-language-server-common/src" },
-    { "path": "../theme-check-docs-updater" }
+    { "path": "../theme-language-server-common/src/tsconfig.build.json" },
+    { "path": "../theme-check-docs-updater/tsconfig.build.json" },
+    { "path": "../theme-check-node/tsconfig.build.json" },
   ]
 }

--- a/packages/theme-language-server-node/tsconfig.json
+++ b/packages/theme-language-server-node/tsconfig.json
@@ -3,13 +3,20 @@
   "include": ["./src/**/*.ts"],
   "exclude": ["./dist"],
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "dist",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "paths": {
+      "@shopify/theme-language-server-common": ["../theme-language-server-common/src"],
+      "@shopify/theme-check-docs-updater": ["../theme-check-docs-updater/src"],
+      "@shopify/theme-check-node": ["../theme-check-node/src"],
+    }
   },
   "references": [
     { "path": "../theme-language-server-common/src" },
-    { "path": "../theme-check-docs-updater" }
+    { "path": "../theme-check-docs-updater" },
+    { "path": "../theme-check-node" }
   ]
 }
 

--- a/packages/vscode-extension/src/formatter.ts
+++ b/packages/vscode-extension/src/formatter.ts
@@ -8,7 +8,7 @@ import {
   Position,
 } from 'vscode';
 import * as prettier from 'prettier';
-import * as LiquidPrettierPlugin from '@shopify/prettier-plugin-liquid/standalone';
+import * as LiquidPrettierPlugin from '@shopify/prettier-plugin-liquid';
 import { LiquidHTMLASTParsingError } from '@shopify/liquid-html-parser';
 
 export default class LiquidFormatter {

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -8,12 +8,16 @@
     "strict": true,
     "resolveJsonModule": true,
     "paths": {
-      "@shopify/theme-language-server-node": ["../../theme-language-server-node/src"]
+      "@shopify/theme-language-server-node": ["../../theme-language-server-node/src"],
+      "@shopify/prettier-plugin-liquid": ["../../prettier-plugin-liquid/src"],
+      "@shopify/liquid-html-parser": ["../../theme-language-server-node/src"]
     }
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.spec.ts", "node_modules"],
   "references": [
-    { "path": "../theme-language-server-node" }
+    { "path": "../theme-language-server-node/tsconfig.build.json" },
+    { "path": "../prettier-plugin-liquid/tsconfig.build.json" },
+    { "path": "../liquid-html-parser/tsconfig.build.json" },
   ]
 }


### PR DESCRIPTION
# What are you adding in this PR?

- Fix the tsconfigs so that the code loaded by webpack is the code in src and not the one in dist
- Fix the tsconfigs so that the code changed in one project causes a refresh (codemirror playground)

## What did I learn?

- The `paths` compiler option is for telling TS where to find the code for some imports. We have to put the `/src` at the end of those or else we'd use the one in package.json (which points to dist).
- The `references` compiler options is a list of paths to folders with tsconfig files in them. It can _also_ be the path to a tsconfig file (say you wanted build to reference _build_ tsconfigs!)

## Before you deploy

- [x] This does not require a `changeset`
