### PR TITLE
Do not report UnusedAssign for variables starting with an underscore

### DIFF
--- a/.changeset/thick-pandas-thank.md
+++ b/.changeset/thick-pandas-thank.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Do not report UnusedAssign for variables starting with an underscore

--- a/packages/theme-check-common/src/checks/unused-assign/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unused-assign/index.spec.ts
@@ -114,14 +114,30 @@ describe('Module: UnusedAssign', () => {
     }
   });
 
+  it('should not report unused assigns for variables starting with an underscore', async () => {
+    const sourceCode = `
+      {% assign _ = 1 %}
+      {% assign _unusedVar = 1 %}
+      {% capture _ %}
+        {% form "cart", cart %}
+          {% assign some_var = cart.successfully_posted? %}
+        {% endform %}
+      {% endcapture %}
+      {{ some_var }}
+    `;
+
+    const offenses = await runLiquidCheck(UnusedAssign, sourceCode);
+    expect(offenses).to.have.lengthOf(0);
+  });
+
   it('should report unused assign for things used in a {% raw %} tag', async () => {
     const sourceCode = `
-        {% assign unusedVar = 1 %}
-        {% # It's a trap. It's not really used %}
-        {% raw %}
-          {{ unusedVar }}
-        {% endraw %}
-      `;
+      {% assign unusedVar = 1 %}
+      {% # It's a trap. It's not really used %}
+      {% raw %}
+        {{ unusedVar }}
+      {% endraw %}
+    `;
 
     const offenses = await runLiquidCheck(UnusedAssign, sourceCode);
     expect(offenses).to.have.lengthOf(1);

--- a/packages/theme-check-common/src/checks/unused-assign/index.ts
+++ b/packages/theme-check-common/src/checks/unused-assign/index.ts
@@ -52,7 +52,7 @@ export const UnusedAssign: LiquidCheckDefinition = {
 
       async onCodePathEnd() {
         for (const [variable, node] of assignedVariables.entries()) {
-          if (!usedVariables.has(variable)) {
+          if (!usedVariables.has(variable) && !variable.startsWith('_')) {
             context.report({
               message: `The variable '${variable}' is assigned but not used`,
               startIndex: node.position.start,


### PR DESCRIPTION
## What are you adding in this PR?

We're copying the TypeScript convention here.

You can now prefix your variables by an underscore for the `UnusedAssign` check to ignore your variable.
```liquid
{% capture _ %}
  {% form "cart", cart %}
    {% assign successfully_posted = cart.successfully_posted %}
  {% endform %}
{% endcapture %}
```

Fixes #206
Fixes https://github.com/Shopify/theme-check/issues/748

## What did you learn?

Folks can be creative to gain access to state without printing the form again.

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset` since this is a new feature
