### PR TITLE
Add theme, section and block setting completion and hover support

### DIFF
--- a/.changeset/bright-panthers-ring.md
+++ b/.changeset/bright-panthers-ring.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-language-server-node': minor
+---
+
+Add hover and completion support for global theme settings

--- a/.changeset/bright-panthers-ring.md
+++ b/.changeset/bright-panthers-ring.md
@@ -3,4 +3,4 @@
 '@shopify/theme-language-server-node': minor
 ---
 
-Add hover and completion support for global theme settings
+Add hover and completion support for theme, section and block settings

--- a/.changeset/eight-rocks-compete.md
+++ b/.changeset/eight-rocks-compete.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+Add internal-use property to DocumentNode

--- a/.changeset/seven-avocados-cry.md
+++ b/.changeset/seven-avocados-cry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': minor
+---
+
+Export config types (modern identifiers, legacy identifiers, etc.)

--- a/.changeset/stale-shirts-doubt.md
+++ b/.changeset/stale-shirts-doubt.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-language-server-node': patch
+'@shopify/theme-check-node': patch
+---
+
+Fix root finding for theme app extensions without a config file

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -110,6 +110,9 @@ export type LiquidHtmlNode =
 export interface DocumentNode extends ASTNode<NodeTypes.Document> {
   children: LiquidHtmlNode[];
   name: '#document';
+  // only used internally where source could be different from _source...
+  // used for the fixed partial ASTs shenanigans...
+  _source: string;
 }
 
 export interface YAMLFrontmatter extends ASTNode<NodeTypes.YAMLFrontmatter> {
@@ -814,6 +817,7 @@ export function toLiquidAST(
   const root: DocumentNode = {
     type: NodeTypes.Document,
     source: source,
+    _source: source, // this can get replaced somewhere else...
     children: cstToAst(cst, options),
     name: '#document',
     position: {
@@ -835,6 +839,7 @@ export function toLiquidHtmlAST(
   const root: DocumentNode = {
     type: NodeTypes.Document,
     source: source,
+    _source: source,
     children: cstToAst(cst, options),
     name: '#document',
     position: {

--- a/packages/theme-check-node/src/config/load-config.ts
+++ b/packages/theme-check-node/src/config/load-config.ts
@@ -3,6 +3,7 @@ import { AbsolutePath, Config } from '@shopify/theme-check-common';
 import { resolveConfig } from './resolve';
 import { loadConfigDescription } from './load-config-description';
 import { validateConfig } from './validation';
+import { ModernIdentifier, ModernIdentifiers } from './types';
 
 /**
  * Given an absolute path to a config file, this function returns
@@ -16,9 +17,11 @@ import { validateConfig } from './validation';
  */
 export async function loadConfig(
   /** The absolute path of config file */
-  configPath: AbsolutePath | undefined,
+  configPath: AbsolutePath | ModernIdentifier | undefined,
   /** The root of the theme */
-  root: AbsolutePath | undefined = configPath ? path.dirname(configPath) : undefined,
+  root: AbsolutePath | undefined = configPath && !ModernIdentifiers.includes(configPath as any)
+    ? path.dirname(configPath)
+    : undefined,
 ): Promise<Config> {
   if (!root) throw new Error('loadConfig cannot be called without a root argument');
   const configDescription = await resolveConfig(configPath ?? 'theme-check:recommended', true);

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -22,6 +22,7 @@ const defaultLocale = 'en';
 const asyncGlob = promisify(glob);
 
 export * from '@shopify/theme-check-common';
+export * from './config/types';
 export { loadConfig };
 
 export type ThemeCheckRun = {

--- a/packages/theme-language-server-common/src/TypeSystem.spec.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.spec.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, vi, it, expect, assert } from 'vitest';
+import { SettingsSchemaJSONFile } from './settings';
+import { TypeSystem } from './TypeSystem';
+import {
+  AssignMarkup,
+  LiquidVariableOutput,
+  NamedTags,
+  NodeTypes,
+  toLiquidHtmlAST,
+} from '@shopify/liquid-html-parser';
+import { isLiquidVariableOutput, isNamedLiquidTag } from './utils';
+
+describe('Module: TypeSystem', () => {
+  let typeSystem: TypeSystem;
+  let settingsProvider: any;
+  const literalContexts = [
+    { value: `10`, type: 'number' },
+    { value: `'string'`, type: 'string' },
+    { value: `true`, type: 'boolean' },
+    //      { value: `null`, type: 'untyped' },
+  ];
+
+  beforeEach(() => {
+    settingsProvider = vi.fn().mockResolvedValue([]);
+    typeSystem = new TypeSystem(
+      {
+        tags: async () => [],
+        objects: async () => [
+          {
+            name: 'all_products',
+            return_type: [{ type: 'array', array_value: 'product' }],
+          },
+          {
+            name: 'product',
+            access: {
+              global: false,
+              parents: [],
+              template: [],
+            },
+            return_type: [],
+            properties: [
+              {
+                name: 'featured_image',
+                description: 'ze best image for ze product',
+                return_type: [{ type: 'image', name: '' }],
+              },
+            ],
+          },
+          {
+            name: 'settings',
+            return_type: [],
+            properties: [], // these should be populated dynamically
+          },
+        ],
+        filters: async () => [
+          {
+            name: 'size',
+            return_type: [{ type: 'number', name: '' }],
+          },
+        ],
+      },
+      settingsProvider,
+    );
+  });
+
+  it('should return the type of assign markup nodes (basic test)', async () => {
+    for (const { value, type } of literalContexts) {
+      const ast = toLiquidHtmlAST(`{% assign x = ${value} %}`);
+      const assignMarkup = (ast as any).children[0].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(assignMarkup, ast, 'file:///file.liquid');
+      expect(inferredType, value).to.equal(type);
+    }
+  });
+
+  it('should return the type of other variables', async () => {
+    for (const { value, type } of literalContexts) {
+      const ast = toLiquidHtmlAST(`{% assign x = ${value} %}{% assign y = x %}`);
+      const yVariable = (ast as any).children[1].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(yVariable, ast, 'file:///file.liquid');
+      expect(inferredType).to.equal(type);
+    }
+  });
+
+  it('should return the type of expressions', async () => {
+    for (const { value, type } of literalContexts) {
+      const ast = toLiquidHtmlAST(`{{ ${value} }}`);
+      const output = ast.children[0] as LiquidVariableOutput;
+      const variable = output.markup;
+      if (typeof variable === 'string') throw new Error('expecting real deal');
+      const expression = variable.expression;
+      const inferredType = await typeSystem.inferType(expression, ast, 'file:///file.liquid');
+      expect(inferredType, value).to.equal(type);
+    }
+  });
+
+  it('should return the type of array variables', async () => {
+    const ast = toLiquidHtmlAST(`{% assign x = all_products %}`);
+    const xVariable = (ast as any).children[0].markup as AssignMarkup;
+    const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+    expect(inferredType).to.eql({ kind: 'array', valueType: 'product' });
+  });
+
+  it('should return the type of object properties', async () => {
+    const ast = toLiquidHtmlAST(`{% assign x = all_products[0].featured_image %}`);
+    const xVariable = (ast as any).children[0].markup as AssignMarkup;
+    const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+    expect(inferredType).to.equal('image');
+  });
+
+  it('should return the type of filtered variables', async () => {
+    const ast = toLiquidHtmlAST(`{% assign x = all_products | size %}`);
+    const xVariable = (ast as any).children[0].markup as AssignMarkup;
+    const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+    expect(inferredType).to.equal('number');
+  });
+
+  it('should return the type of variables in for loop', async () => {
+    const ast = toLiquidHtmlAST(`{% for item in all_products %}{{ item }}{% endfor %}`);
+    const forLoop = ast.children[0];
+    assert(isNamedLiquidTag(forLoop, NamedTags.for) && forLoop.children?.length === 1);
+    const branch = forLoop.children[0];
+    assert(branch.type === NodeTypes.LiquidBranch);
+    const variableOutput = branch.children[0];
+    assert(isLiquidVariableOutput(variableOutput));
+    const variable = variableOutput.markup;
+
+    const inferredType = await typeSystem.inferType(variable, ast, 'file:///file.liquid');
+    expect(inferredType).to.equal('product');
+  });
+
+  it('should patch the properties of settings when a schema is available', async () => {
+    settingsProvider.mockResolvedValue([
+      {
+        name: 'category',
+        settings: [
+          {
+            id: 'slide',
+            label: 'Slide label',
+            type: 'checkbox',
+          },
+          {
+            id: 'my_font',
+            label: 'my font',
+            type: 'font_picker',
+          },
+        ],
+      },
+    ] as SettingsSchemaJSONFile);
+
+    const contexts = [
+      { id: 'slide', expectedType: 'boolean' },
+      { id: 'my_font', expectedType: 'font' },
+    ];
+    for (const { id, expectedType } of contexts) {
+      const ast = toLiquidHtmlAST(`{{ settings.${id} }}`);
+      const variableOutput = ast.children[0];
+      assert(isLiquidVariableOutput(variableOutput));
+      const inferredType = await typeSystem.inferType(
+        variableOutput.markup,
+        ast,
+        'file:///file.liquid',
+      );
+      expect(inferredType).to.eql(expectedType);
+    }
+  });
+
+  // TODO
+  it.skip('should support narrowing the type of blocks', async () => {
+    const sourceCode = `
+      {% for block in section.blocks %}
+        {% case block.type %}
+          {% when 'slide' %}
+            {{ block.settings.image }}
+          {% else %}
+        {% endcase }
+        {% if block.type == 'slide' %}
+          {{ block.settings.image }}
+        {% endif %}
+      {% endfor %}
+      {% schema %}
+      {
+        "name": "Slideshow",
+        "tag": "section",
+        "class": "slideshow",
+        "settings": [],
+        "blocks": [
+          {
+            "name": "Slide",
+            "type": "slide",
+            "settings": [
+              {
+                "type": "image_picker",
+                "id": "image",
+                "label": "Image"
+              }
+            ]
+          }
+        ]
+      }
+      {% endschema %}
+    `;
+
+    const ast = toLiquidHtmlAST(sourceCode);
+  });
+});

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -2,6 +2,8 @@ import { SourceCodeType, ThemeDocset } from '@shopify/theme-check-common';
 import { CompletionItem, CompletionParams } from 'vscode-languageserver';
 import { TypeSystem } from '../TypeSystem';
 import { DocumentManager } from '../documents';
+import { GetThemeSettingsSchemaForURI } from '../settings';
+import { GetTranslationsForURI } from '../translations';
 import { createLiquidCompletionParams } from './params';
 import {
   FilterCompletionProvider,
@@ -11,24 +13,39 @@ import {
   LiquidTagsCompletionProvider,
   ObjectAttributeCompletionProvider,
   ObjectCompletionProvider,
-  TranslationCompletionProvider,
-  RenderSnippetCompletionProvider,
   Provider,
+  RenderSnippetCompletionProvider,
+  TranslationCompletionProvider,
 } from './providers';
-import { GetTranslationsForURI } from '../translations';
 import { GetSnippetNamesForURI } from './providers/RenderSnippetCompletionProvider';
+
+export interface CompletionProviderDependencies {
+  documentManager: DocumentManager;
+  themeDocset: ThemeDocset;
+  getTranslationsForURI?: GetTranslationsForURI;
+  getSnippetNamesForURI?: GetSnippetNamesForURI;
+  getThemeSettingsSchemaForURI?: GetThemeSettingsSchemaForURI;
+  log?: (message: string) => void;
+}
 
 export class CompletionsProvider {
   private providers: Provider[] = [];
+  readonly documentManager: DocumentManager;
+  readonly themeDocset: ThemeDocset;
+  readonly log: (message: string) => void;
 
-  constructor(
-    readonly documentManager: DocumentManager,
-    readonly themeDocset: ThemeDocset,
-    readonly getTranslationsForURI: GetTranslationsForURI = async () => ({}),
-    readonly getSnippetNamesForURI: GetSnippetNamesForURI = async () => [],
-    readonly log: (message: string) => void = (_m: string) => {},
-  ) {
-    const typeSystem = new TypeSystem(themeDocset);
+  constructor({
+    documentManager,
+    themeDocset,
+    getTranslationsForURI = async () => ({}),
+    getSnippetNamesForURI = async () => [],
+    getThemeSettingsSchemaForURI = async () => [],
+    log = () => {},
+  }: CompletionProviderDependencies) {
+    this.documentManager = documentManager;
+    this.themeDocset = themeDocset;
+    this.log = log;
+    const typeSystem = new TypeSystem(themeDocset, getThemeSettingsSchemaForURI);
 
     this.providers = [
       new HtmlTagCompletionProvider(),
@@ -36,7 +53,7 @@ export class CompletionsProvider {
       new HtmlAttributeValueCompletionProvider(),
       new LiquidTagsCompletionProvider(themeDocset),
       new ObjectCompletionProvider(typeSystem),
-      new ObjectAttributeCompletionProvider(typeSystem),
+      new ObjectAttributeCompletionProvider(typeSystem, getThemeSettingsSchemaForURI),
       new FilterCompletionProvider(typeSystem),
       new TranslationCompletionProvider(documentManager, getTranslationsForURI),
       new RenderSnippetCompletionProvider(getSnippetNamesForURI),

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -105,10 +105,12 @@ function parsePartial(
   let fixedSource: string | undefined;
   try {
     fixedSource = fix(sourceCode.source, cursorPosition);
-    return toLiquidHtmlAST(fixedSource, {
+    const ast = toLiquidHtmlAST(fixedSource, {
       allowUnclosedDocumentNode: true,
       mode: 'completion',
     });
+    ast._source = sourceCode.source;
+    return ast;
   } catch (err: any) {
     // We swallow errors here, because we gracefully accept that and
     // simply don't offer completions when that happens.

--- a/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.spec.ts
@@ -85,10 +85,13 @@ describe('Module: FilterCompletionProvider', async () => {
   let provider: CompletionsProvider;
 
   beforeEach(async () => {
-    provider = new CompletionsProvider(new DocumentManager(), {
-      filters: async () => filters,
-      objects: async () => objects,
-      tags: async () => [],
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => filters,
+        objects: async () => objects,
+        tags: async () => [],
+      },
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
@@ -12,10 +12,13 @@ describe('Module: HtmlAttributeCompletionProvider', async () => {
   let provider: CompletionsProvider;
 
   beforeEach(async () => {
-    provider = new CompletionsProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [],
-      tags: async () => [],
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+      },
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeValueCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeValueCompletionProvider.spec.ts
@@ -6,10 +6,13 @@ describe('Module: HtmlAttributeValueCompletionProvider', async () => {
   let provider: CompletionsProvider;
 
   beforeEach(async () => {
-    provider = new CompletionsProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [],
-      tags: async () => [],
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+      },
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/HtmlTagCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlTagCompletionProvider.spec.ts
@@ -10,10 +10,13 @@ describe('Module: HtmlTagCompletionProvider', async () => {
   let provider: CompletionsProvider;
 
   beforeEach(async () => {
-    provider = new CompletionsProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [],
-      tags: async () => [],
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+      },
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
@@ -14,10 +14,13 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
   let provider: CompletionsProvider;
 
   beforeEach(async () => {
-    provider = new CompletionsProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [],
-      tags: async () => tags,
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => tags,
+      },
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.ts
@@ -4,12 +4,16 @@ import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
 import { TypeSystem, isArrayType } from '../../TypeSystem';
 import { CURSOR, LiquidCompletionParams } from '../params';
 import { Provider, createCompletionItem, sortByName } from './common';
+import { GetThemeSettingsSchemaForURI } from '../../settings';
 
 const ArrayCoreProperties = ['size', 'first', 'last'] as const;
 const StringCoreProperties = ['size'] as const;
 
 export class ObjectAttributeCompletionProvider implements Provider {
-  constructor(private readonly typeSystem: TypeSystem) {}
+  constructor(
+    private readonly typeSystem: TypeSystem,
+    private readonly getThemeSettingsSchema: GetThemeSettingsSchemaForURI,
+  ) {}
 
   async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
     if (!params.completionContext) return [];
@@ -53,7 +57,7 @@ export class ObjectAttributeCompletionProvider implements Provider {
       );
     }
 
-    const objectMap = await this.typeSystem.objectMap();
+    const objectMap = await this.typeSystem.objectMap(params.textDocument.uri);
     const parentTypeProperties = objectMap[parentType]?.properties || [];
     return completionItems(parentTypeProperties, partial);
   }

--- a/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.ts
@@ -57,7 +57,7 @@ export class ObjectAttributeCompletionProvider implements Provider {
       );
     }
 
-    const objectMap = await this.typeSystem.objectMap(params.textDocument.uri);
+    const objectMap = await this.typeSystem.objectMap(params.textDocument.uri, partialAst);
     const parentTypeProperties = objectMap[parentType]?.properties || [];
     return completionItems(parentTypeProperties, partial);
   }

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
@@ -6,45 +6,48 @@ describe('Module: ObjectCompletionProvider', async () => {
   let provider: CompletionsProvider;
 
   beforeEach(async () => {
-    provider = new CompletionsProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [
-        { name: 'all_products' },
-        { name: 'global' },
-        {
-          name: 'section',
-          access: {
-            global: false,
-            template: [],
-            parents: [],
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [
+          { name: 'all_products' },
+          { name: 'global' },
+          {
+            name: 'section',
+            access: {
+              global: false,
+              template: [],
+              parents: [],
+            },
           },
-        },
-        {
-          name: 'block',
-          access: {
-            global: false,
-            template: [],
-            parents: [],
+          {
+            name: 'block',
+            access: {
+              global: false,
+              template: [],
+              parents: [],
+            },
           },
-        },
-        {
-          name: 'predictive_search',
-          access: {
-            global: false,
-            template: [],
-            parents: [],
+          {
+            name: 'predictive_search',
+            access: {
+              global: false,
+              template: [],
+              parents: [],
+            },
           },
-        },
-        {
-          name: 'recommendations',
-          access: {
-            global: false,
-            template: [],
-            parents: [],
+          {
+            name: 'recommendations',
+            access: {
+              global: false,
+              template: [],
+              parents: [],
+            },
           },
-        },
-      ],
-      tags: async () => [],
+        ],
+        tags: async () => [],
+      },
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.spec.ts
@@ -6,16 +6,16 @@ describe('Module: RenderSnippetCompletionProvider', async () => {
   let provider: CompletionsProvider;
 
   beforeEach(async () => {
-    provider = new CompletionsProvider(
-      new DocumentManager(),
-      {
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
         filters: async () => [],
         objects: async () => [],
         tags: async () => [],
       },
-      async (_) => ({}),
-      async (_) => ['product-card', 'image'],
-    );
+      getTranslationsForURI: async (_) => ({}),
+      getSnippetNamesForURI: async (_) => ['product-card', 'image'],
+    });
   });
 
   it('should complete snippets correctly', async () => {

--- a/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.spec.ts
@@ -6,14 +6,14 @@ describe('Module: TranslationCompletionProvider', async () => {
   let provider: CompletionsProvider;
 
   beforeEach(async () => {
-    provider = new CompletionsProvider(
-      new DocumentManager(),
-      {
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
         filters: async () => [],
         objects: async () => [],
         tags: async () => [],
       },
-      async (_) => ({
+      getTranslationsForURI: async (_) => ({
         general: {
           username_html: '<b>username</b>',
           password: 'password',
@@ -23,7 +23,7 @@ describe('Module: TranslationCompletionProvider', async () => {
           },
         },
       }),
-    );
+    });
   });
 
   it('should complete translations correctly', async () => {

--- a/packages/theme-language-server-common/src/hover/HoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/HoverProvider.ts
@@ -15,6 +15,7 @@ import {
 } from './providers';
 import { HtmlAttributeValueHoverProvider } from './providers/HtmlAttributeValueHoverProvider';
 import { findCurrentNode } from '../visitor';
+import { GetThemeSettingsSchemaForURI } from '../settings';
 
 export class HoverProvider {
   private providers: BaseHoverProvider[] = [];
@@ -23,8 +24,9 @@ export class HoverProvider {
     readonly documentManager: DocumentManager,
     readonly themeDocset: ThemeDocset,
     readonly getTranslationsForURI: GetTranslationsForURI = async () => ({}),
+    readonly getSettingsSchemaForURI: GetThemeSettingsSchemaForURI = async () => [],
   ) {
-    const typeSystem = new TypeSystem(themeDocset);
+    const typeSystem = new TypeSystem(themeDocset, getSettingsSchemaForURI);
     this.providers = [
       new LiquidTagHoverProvider(themeDocset),
       new LiquidFilterHoverProvider(themeDocset),

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.ts
@@ -34,7 +34,7 @@ export class LiquidObjectAttributeHoverProvider implements BaseHoverProvider {
       return null;
     }
 
-    const objectMap = await this.typeSystem.objectMap();
+    const objectMap = await this.typeSystem.objectMap(params.textDocument.uri);
     const parentEntry = objectMap[parentType];
     if (!parentEntry) {
       return null;

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.ts
@@ -34,7 +34,7 @@ export class LiquidObjectAttributeHoverProvider implements BaseHoverProvider {
       return null;
     }
 
-    const objectMap = await this.typeSystem.objectMap(params.textDocument.uri);
+    const objectMap = await this.typeSystem.objectMap(params.textDocument.uri, ancestors[0]);
     const parentEntry = objectMap[parentType];
     if (!parentEntry) {
       return null;

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.ts
@@ -32,7 +32,7 @@ export class LiquidObjectHoverProvider implements BaseHoverProvider {
     }
 
     const type = await this.typeSystem.inferType(node, ancestors[0], params.textDocument.uri);
-    const objectMap = await this.typeSystem.objectMap(params.textDocument.uri);
+    const objectMap = await this.typeSystem.objectMap(params.textDocument.uri, ancestors[0]);
     const entry = objectMap[isArrayType(type) ? type.valueType : type];
 
     if (type === 'untyped') {

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.ts
@@ -32,7 +32,7 @@ export class LiquidObjectHoverProvider implements BaseHoverProvider {
     }
 
     const type = await this.typeSystem.inferType(node, ancestors[0], params.textDocument.uri);
-    const objectMap = await this.typeSystem.objectMap();
+    const objectMap = await this.typeSystem.objectMap(params.textDocument.uri);
     const entry = objectMap[isArrayType(type) ? type.valueType : type];
 
     if (type === 'untyped') {

--- a/packages/theme-language-server-common/src/server/startServer.spec.ts
+++ b/packages/theme-language-server-common/src/server/startServer.spec.ts
@@ -229,6 +229,7 @@ describe('Module: server', () => {
       fileSize: vi.fn().mockResolvedValue(420),
       getDefaultTranslationsFactory: () => async () => ({}),
       getDefaultLocaleFactory: () => async () => 'en',
+      getThemeSettingsSchemaForRootURI: async () => [],
       loadConfig: async () => ({
         settings: {},
         checks: MissingTemplate,

--- a/packages/theme-language-server-common/src/settings/index.ts
+++ b/packages/theme-language-server-common/src/settings/index.ts
@@ -1,0 +1,50 @@
+export type GetThemeSettingsSchemaForURI = (uri: string) => Promise<SettingsSchemaJSONFile>;
+
+export type SettingsSchemaJSONFile = (ThemeInfo | SettingsCategory)[];
+
+export interface ThemeInfo {
+  name: string;
+  theme_name: string;
+  theme_author: string;
+  theme_version: string;
+  theme_documentation_url: string;
+  theme_support_url?: string;
+  theme_support_email?: string;
+}
+
+export interface SettingsCategory {
+  name: string;
+  settings: Setting[];
+}
+
+export type Setting = SideBarSetting | InputSetting;
+
+export interface SideBarSetting {
+  type: string;
+  content: string;
+}
+
+export interface InputSetting {
+  type: string;
+  id: string;
+  label: string;
+  default?: number | string | boolean | string[];
+  info?: string;
+}
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+interface MaybeGroupedOption extends Option {
+  group?: string;
+}
+
+export function isSettingsCategory(x: ThemeInfo | SettingsCategory): x is SettingsCategory {
+  return 'settings' in x;
+}
+
+export function isInputSetting(x: Setting): x is InputSetting {
+  return 'id' in x && 'type' in x && 'label' in x;
+}

--- a/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
+++ b/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
@@ -8,10 +8,13 @@ describe('Module: CompletionItemsAssertion', () => {
 
   beforeEach(async () => {
     documentManager = new DocumentManager();
-    provider = new CompletionsProvider(documentManager, {
-      filters: async () => [],
-      objects: async () => [],
-      tags: async () => [{ name: 'render' }],
+    provider = new CompletionsProvider({
+      documentManager,
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [{ name: 'render' }],
+      },
     });
   });
 

--- a/packages/theme-language-server-common/src/tsconfig.json
+++ b/packages/theme-language-server-common/src/tsconfig.json
@@ -7,7 +7,6 @@
     "outDir": "../dist",
     "rootDir": ".",
     "tsBuildInfoFile": "../dist/tsconfig.tsbuildinfo",
-    "baseUrl": ".",
     "paths": {
       "@shopify/theme-check-common": ["../../theme-check-common/src"],
       "@shopify/liquid-html-parser": ["../../liquid-html-parser/src"]

--- a/packages/theme-language-server-common/src/types.ts
+++ b/packages/theme-language-server-common/src/types.ts
@@ -2,6 +2,7 @@ import { URI } from 'vscode-languageserver';
 import { Config, Dependencies as ThemeCheckDependencies } from '@shopify/theme-check-common';
 
 import { WithOptional } from './utils';
+import { SettingsSchemaJSONFile } from './settings';
 
 export type Dependencies = WithOptional<RequiredDependencies, 'log'>;
 
@@ -93,6 +94,13 @@ export interface RequiredDependencies {
    * A factory because different repos have different default locales.
    */
   getDefaultLocaleFactory(rootURI: URI): ThemeCheckDependencies['getDefaultLocale'];
+
+  /**
+   * getThemeSettingsSchemaForRootURI(root: URI)
+   *
+   * Should return parsed contents of the config/settings_schema.json file.
+   */
+  getThemeSettingsSchemaForRootURI(rootURI: URI): Promise<SettingsSchemaJSONFile>;
 
   /**
    * filesForURI(uri: URI)

--- a/packages/theme-language-server-common/src/utils/node.ts
+++ b/packages/theme-language-server-common/src/utils/node.ts
@@ -1,4 +1,10 @@
-import { AttrEmpty, LiquidHtmlNode, NodeTypes, TextNode } from '@shopify/liquid-html-parser';
+import {
+  AttrEmpty,
+  LiquidHtmlNode,
+  NamedTags,
+  NodeTypes,
+  TextNode,
+} from '@shopify/liquid-html-parser';
 import { LiquidHtmlNodeOfType as NodeOfType } from '@shopify/theme-check-common';
 
 export type HtmlElementTypes = (typeof HtmlElementTypes)[number];
@@ -46,4 +52,19 @@ export function getCompoundName(node: NamedHtmlElementNode | HtmlAttribute): str
 
 export function isHtmlAttribute(node: LiquidHtmlNode): node is HtmlAttribute {
   return HtmlAttributeTypes.some((type) => node.type === type);
+}
+
+type ExcludeStringMarkup<T> = T extends { markup: string } ? never : T;
+
+export function isNamedLiquidTag<NT extends LiquidHtmlNode, T extends NamedTags>(
+  node: LiquidHtmlNode,
+  name: T,
+): node is ExcludeStringMarkup<Extract<NT, { type: NodeTypes.LiquidTag; name: T }>> {
+  return node.type === NodeTypes.LiquidTag && node.name === name && typeof node.markup !== 'string';
+}
+
+export function isLiquidVariableOutput<NT extends LiquidHtmlNode>(
+  node: LiquidHtmlNode,
+): node is ExcludeStringMarkup<Extract<NT, { type: NodeTypes.LiquidVariableOutput }>> {
+  return node.type === NodeTypes.LiquidVariableOutput && typeof node.markup !== 'string';
 }

--- a/packages/theme-language-server-node/src/dependencies.spec.ts
+++ b/packages/theme-language-server-node/src/dependencies.spec.ts
@@ -69,6 +69,14 @@ describe('Module: dependencies', () => {
           'fr.default.json': JSON.stringify({ beverage: 'café' }),
         },
       },
+      appWithThemeAppExtension: {
+        extensions: {
+          myThemeAppExtension: {
+            ...theme,
+            'shopify.extension.toml': '',
+          },
+        },
+      },
     });
   });
 
@@ -93,6 +101,13 @@ describe('Module: dependencies', () => {
       expect(await findRootURI(workspace.uri('multiRootTheme/src/snippets/header.liquid'))).to.eql(
         workspace.uri('multiRootTheme/src'),
       );
+      expect(
+        await findRootURI(
+          workspace.uri(
+            'appWithThemeAppExtension/extensions/myThemeAppExtension/snippets/header.liquid',
+          ),
+        ),
+      ).to.eql(workspace.uri('appWithThemeAppExtension/extensions/myThemeAppExtension'));
     });
   });
 

--- a/packages/theme-language-server-node/src/dependencies.ts
+++ b/packages/theme-language-server-node/src/dependencies.ts
@@ -159,3 +159,20 @@ function normalizeRoot(config: Config) {
   config.root = asPath(URI.file(config.root));
   return config;
 }
+
+export const getThemeSettingsSchemaForRootURI: Dependencies['getThemeSettingsSchemaForRootURI'] =
+  async (rootUriString: string) => {
+    try {
+      const rootURI = parse(rootUriString);
+      const settingsSchemaFilePath = Utils.joinPath(rootURI, 'config/settings_schema.json');
+      const contents = await fs.readFile(asFsPath(settingsSchemaFilePath), 'utf8');
+      const json = JSON.parse(contents);
+      if (!Array.isArray(json)) {
+        throw new Error('Settings JSON file not in correct format');
+      }
+      return json;
+    } catch (error) {
+      console.error(error);
+      return [];
+    }
+  };

--- a/packages/theme-language-server-node/src/index.ts
+++ b/packages/theme-language-server-node/src/index.ts
@@ -9,6 +9,7 @@ import {
   findRootURI,
   getDefaultLocaleFactory,
   getDefaultTranslationsFactory,
+  getThemeSettingsSchemaForRootURI,
   loadConfig,
 } from './dependencies';
 
@@ -22,6 +23,7 @@ export function startServer() {
     log,
     getDefaultTranslationsFactory,
     getDefaultLocaleFactory,
+    getThemeSettingsSchemaForRootURI,
     findRootURI,
     fileExists,
     fileSize,


### PR DESCRIPTION
## What are you adding in this PR?

- Add global theme settings completion and hover support
- Add block and section setting hover and completion support

https://github.com/Shopify/theme-tools/assets/4990691/3450d41d-b5fb-4da0-9e52-b21eb4fd2284

Fixes #218 
Fixes #221 

## Follow up issues

- #223 

## Before you deploy

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
