### PR TITLE
Improved message reporting for `AssetSize*` checks.

### DIFF
--- a/.changeset/strange-cups-sleep.md
+++ b/.changeset/strange-cups-sleep.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Improved message reporting for `AssetSize*` checks

--- a/packages/theme-check-common/src/checks/asset-size-app-block-css/index.spec.ts
+++ b/packages/theme-check-common/src/checks/asset-size-app-block-css/index.spec.ts
@@ -45,7 +45,7 @@ describe('Module: AssetSizeAppBlockCSS', () => {
 
     expect(offenses).toHaveLength(1);
     expect(offenses[0]).toMatchObject({
-      message: "The file size for 'app.css' exceeds the configured threshold.",
+      message: `The file size for 'app.css' (19 B) exceeds the configured threshold (1 B)`,
       absolutePath: '/blocks/app.liquid',
       start: { index: 51 },
       end: { index: 58 },

--- a/packages/theme-check-common/src/checks/asset-size-app-block-css/index.ts
+++ b/packages/theme-check-common/src/checks/asset-size-app-block-css/index.ts
@@ -63,11 +63,12 @@ export const AssetSizeAppBlockCSS: LiquidCheckDefinition<typeof schema> = {
           return;
         }
 
-        const fileExceedsThreshold = await assertFileSize(context, absolutePath, thresholdInBytes);
+        const fileSize = await context.fileSize!(absolutePath);
+        const fileExceedsThreshold = await assertFileSize(thresholdInBytes, fileSize);
 
         if (fileExceedsThreshold) {
           context.report({
-            message: `The file size for '${filePath}' exceeds the configured threshold.`,
+            message: `The file size for '${filePath}' (${fileSize} B) exceeds the configured threshold (${thresholdInBytes} B)`,
             startIndex: startIndex,
             endIndex: endIndex,
           });

--- a/packages/theme-check-common/src/checks/asset-size-app-block-javascript/index.spec.ts
+++ b/packages/theme-check-common/src/checks/asset-size-app-block-javascript/index.spec.ts
@@ -45,7 +45,7 @@ describe('Module: AssetSizeAppBlockJavaScript', () => {
 
     expect(offenses).toHaveLength(1);
     expect(offenses[0]).toMatchObject({
-      message: "The file size for 'app.js' exceeds the configured threshold.",
+      message: `The file size for 'app.js' (29 B) exceeds the configured threshold (1 B)`,
       absolutePath: '/blocks/app.liquid',
       start: { index: 51 },
       end: { index: 57 },

--- a/packages/theme-check-common/src/checks/asset-size-app-block-javascript/index.ts
+++ b/packages/theme-check-common/src/checks/asset-size-app-block-javascript/index.ts
@@ -62,11 +62,13 @@ export const AssetSizeAppBlockJavaScript: LiquidCheckDefinition<typeof schema> =
           });
           return;
         }
-        const fileExceedsThreshold = await assertFileSize(context, absolutePath, thresholdInBytes);
+
+        const fileSize = await context.fileSize!(absolutePath);
+        const fileExceedsThreshold = await assertFileSize(thresholdInBytes, fileSize);
 
         if (fileExceedsThreshold) {
           context.report({
-            message: `The file size for '${filePath}' exceeds the configured threshold.`,
+            message: `The file size for '${filePath}' (${fileSize} B) exceeds the configured threshold (${thresholdInBytes} B)`,
             startIndex: startIndex,
             endIndex: endIndex,
           });

--- a/packages/theme-check-common/src/utils/file-utils.ts
+++ b/packages/theme-check-common/src/utils/file-utils.ts
@@ -10,12 +10,9 @@ export async function assertFileExists<T extends SourceCodeType, S extends Schem
 }
 
 export async function assertFileSize<T extends SourceCodeType, S extends Schema>(
-  context: Context<T, S>,
-  filePath: RelativePath,
   thresholdInBytes: number,
+  fileSize: number,
 ): Promise<boolean> {
-  const absolutePath = context.absolutePath(filePath);
-  const fileSize = await context.fileSize!(absolutePath);
   if (fileSize <= thresholdInBytes) return false;
   return true;
 }
@@ -49,7 +46,8 @@ export async function hasLocalAssetSizeExceededThreshold<
   const fileExists = await assertFileExists(context, absolutePath);
 
   if (!fileExists) return;
-  const fileExceedsThreshold = await assertFileSize(context, absolutePath, thresholdInBytes);
+  const fileSize = await context.fileSize!(absolutePath);
+  const fileExceedsThreshold = await assertFileSize(thresholdInBytes, fileSize);
 
   return fileExceedsThreshold;
 }

--- a/packages/theme-check-common/src/utils/files-utils.spec.ts
+++ b/packages/theme-check-common/src/utils/files-utils.spec.ts
@@ -28,23 +28,13 @@ describe('file-utils', () => {
 
   describe('assertFileSize', () => {
     it('returns false if file size is less than or equal to threshold', async () => {
-      const context = {
-        absolutePath: (filePath: string) => `absolute/${filePath}`,
-        fileSize: async (filePath: string) => (filePath === 'absolute/test-file' ? 100 : 0),
-      };
-
-      const isOverThreshold = await assertFileSize(context as any, 'test-file', 100);
+      const isOverThreshold = await assertFileSize(100, 50);
 
       expect(isOverThreshold).toBe(false);
     });
 
     it('returns true if file size is greater than threshold', async () => {
-      const context = {
-        absolutePath: (filePath: string) => `absolute/${filePath}`,
-        fileSize: async (filePath: string) => (filePath === 'absolute/test-file' ? 200 : 0),
-      };
-
-      const isOverThreshold = await assertFileSize(context as any, 'test-file', 100);
+      const isOverThreshold = await assertFileSize(100, 200);
 
       expect(isOverThreshold).toBe(true);
     });


### PR DESCRIPTION
Resolves https://github.com/Shopify/theme-tools/issues/222
## What are you adding in this PR?

This PR is adding better message reporting for our `AssetSize*` checks, by reporting the file size and the threshold in bytes, in the context report.

## What's next? Any followup issues?

None


## Before you deploy
<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
