### PR TITLE
Theme Tools Release: 03-11-23

### DIFF
--- a/.changeset/heavy-vans-teach.md
+++ b/.changeset/heavy-vans-teach.md
@@ -1,6 +1,0 @@
----
-'@shopify/theme-language-server-common': patch
-'@shopify/theme-check-common': patch
----
-
-Add `app` object support for theme app extensions

--- a/.changeset/strange-cups-sleep.md
+++ b/.changeset/strange-cups-sleep.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-check-common': patch
----
-
-Improved message reporting for `AssetSize*` checks

--- a/packages/theme-check-browser/CHANGELOG.md
+++ b/packages/theme-check-browser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/theme-check-browser
 
+## 1.20.1
+
+### Patch Changes
+
+- Updated dependencies [79b0549]
+- Updated dependencies [ac1deb4]
+  - @shopify/theme-check-common@1.20.1
+
 ## 1.20.0
 
 ### Patch Changes

--- a/packages/theme-check-browser/package.json
+++ b/packages/theme-check-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-browser",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-check-common/README.md",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,6 +21,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "1.20.0"
+    "@shopify/theme-check-common": "1.20.1"
   }
 }

--- a/packages/theme-check-common/CHANGELOG.md
+++ b/packages/theme-check-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-check-common
 
+## 1.20.1
+
+### Patch Changes
+
+- 79b0549: Add `app` object support for theme app extensions
+- ac1deb4: Improved message reporting for `AssetSize*` checks
+
 ## 1.20.0
 
 ### Patch Changes

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-common",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "license": "MIT",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-check-common/README.md",
   "main": "dist/index.js",

--- a/packages/theme-check-docs-updater/CHANGELOG.md
+++ b/packages/theme-check-docs-updater/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/theme-check-docs-updater
 
+## 1.20.1
+
+### Patch Changes
+
+- Updated dependencies [79b0549]
+- Updated dependencies [ac1deb4]
+  - @shopify/theme-check-common@1.20.1
+
 ## 1.20.0
 
 ### Patch Changes

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-docs-updater",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Scripts to initialize theme-check data with assets from the theme-liquid-docs repo.",
   "main": "dist/index.js",
   "author": "Albert Chu <albert.chu@shopify.com>",
@@ -20,7 +20,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "^1.20.0",
+    "@shopify/theme-check-common": "^1.20.1",
     "ajv": "^8.12.0",
     "env-paths": "^2.2.1",
     "node-fetch": "^2.6.11"

--- a/packages/theme-check-node/CHANGELOG.md
+++ b/packages/theme-check-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-check-node
 
+## 1.20.1
+
+### Patch Changes
+
+- Updated dependencies [79b0549]
+- Updated dependencies [ac1deb4]
+  - @shopify/theme-check-common@1.20.1
+  - @shopify/theme-check-docs-updater@1.20.1
+
 ## 1.20.0
 
 ### Minor Changes

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-node",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -25,8 +25,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "1.20.0",
-    "@shopify/theme-check-docs-updater": "1.20.0",
+    "@shopify/theme-check-common": "1.20.1",
+    "@shopify/theme-check-docs-updater": "1.20.1",
     "glob": "^8.0.3",
     "yaml": "^2.3.0"
   },

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-browser
 
+## 1.5.1
+
+### Patch Changes
+
+- Updated dependencies [79b0549]
+  - @shopify/theme-language-server-common@1.5.1
+
 ## 1.5.0
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -22,7 +22,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.5.0",
+    "@shopify/theme-language-server-common": "1.5.1",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-language-server-common
 
+## 1.5.1
+
+### Patch Changes
+
+- 79b0549: Add `app` object support for theme app extensions
+- Updated dependencies [79b0549]
+- Updated dependencies [ac1deb4]
+  - @shopify/theme-check-common@1.20.1
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@shopify/liquid-html-parser": "^1.1.1",
-    "@shopify/theme-check-common": "1.20.0",
+    "@shopify/theme-check-common": "1.20.1",
     "@vscode/web-custom-data": "^0.4.6",
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.8",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-language-server-node
 
+## 1.5.1
+
+### Patch Changes
+
+- Updated dependencies [79b0549]
+  - @shopify/theme-language-server-common@1.5.1
+  - @shopify/theme-check-node@1.20.1
+  - @shopify/theme-check-docs-updater@1.20.1
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/Shopify/theme-tools/blob/main/packages/theme-language-server-common/README.md",
@@ -22,9 +22,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.5.0",
-    "@shopify/theme-check-node": "^1.20.0",
-    "@shopify/theme-check-docs-updater": "^1.20.0",
+    "@shopify/theme-language-server-common": "1.5.1",
+    "@shopify/theme-check-node": "^1.20.1",
+    "@shopify/theme-check-docs-updater": "^1.20.1",
     "glob": "^8.0.3",
     "node-fetch": "^2.6.11",
     "vscode-languageserver": "^8.0.2",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## theme-check-vscode
 
+## 1.12.1
+
+### Patch Changes
+
+- Patch bump because it depends on @shopify/theme-language-server-node
+  - @shopify/theme-language-server-node@1.5.1
+
 ## 1.12.0
 
 ### Minor Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "charlespwd"
   },
-  "version": "1.12.0",
+  "version": "1.12.1",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -61,7 +61,7 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^1.1.1",
     "@shopify/prettier-plugin-liquid": "^1.3.4",
-    "@shopify/theme-language-server-node": "^1.5.0",
+    "@shopify/theme-language-server-node": "^1.5.1",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0"
   },


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `1.12.0` -> `1.12.1`
### Changes:
- Patch bump because it depends on @shopify/theme-language-server-node

## `@shopify/theme-language-server-common`
Patch incremented `1.5.0` -> `1.5.1`
### Changes:
- Add `app` object support for theme app extensions

## `@shopify/theme-check-common`
Patch incremented `1.20.0` -> `1.20.1`
### Changes:
- Add `app` object support for theme app extensions
- Improved message reporting for `AssetSize*` checks

## `@shopify/theme-language-server-browser`
Patch incremented `1.5.0` -> `1.5.1`

## `@shopify/theme-language-server-node`
Patch incremented `1.5.0` -> `1.5.1`

## `@shopify/theme-check-browser`
Patch incremented `1.20.0` -> `1.20.1`

## `@shopify/theme-check-node`
Patch incremented `1.20.0` -> `1.20.1`

## `@shopify/theme-check-docs-updater`
Patch incremented `1.20.0` -> `1.20.1`

