### PR TITLE
Add `<` to the autocloseBefore character set

### DIFF
--- a/.changeset/cool-dragons-invite.md
+++ b/.changeset/cool-dragons-invite.md
@@ -1,0 +1,5 @@
+---
+'theme-check-vscode': patch
+---
+
+Include `<` in the autocloseBefore character set

--- a/packages/vscode-extension/scripts/language-configuration.ts
+++ b/packages/vscode-extension/scripts/language-configuration.ts
@@ -29,7 +29,7 @@ export async function makeConfig(): Promise<any> {
       ["'", "'"],
       ['<', '>'],
     ],
-    autoCloseBefore: '%-:.,=}])>\'"` \n\t',
+    autoCloseBefore: '%-:.,=}])<>\'"` \n\t',
     surroundingPairs: [
       ['-', '-'],
       ['<', '>'],


### PR DESCRIPTION
Fixes autocompletion inside HTML elements `<div>|</div>`

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
