### PR TITLE
Remove the developer preview opt-in

### DIFF
--- a/.changeset/silent-impalas-fry.md
+++ b/.changeset/silent-impalas-fry.md
@@ -1,0 +1,30 @@
+---
+'theme-check-vscode': major
+---
+
+**Shopify Liquid VS Code and Theme Check 2.0**
+
+This new major version is the grand unification of Shopify theme developer tools.
+
+Going forward, all Language Server Protocol features (Intelligent Code Completion, hover documentation, theme checks, code navigation, etc.) will be shared with the Online Store Code Editor.
+
+This is the culmination of the major rewrite of our Ruby language server and linter to TypeScript.
+
+It includes a re-architecture of the linter and Language Server to work on a LiquidHTML AST.
+
+**Major changes:**
+
+- Hover documentation support
+- New completion providers
+  - HTML tag, attribute and value
+  - Theme, section and block settings
+  - Theme translations
+- Improved Type System
+- Automatically updated
+- Polished auto-closing pair UX
+- Proper monorepo and VS Code workspace support
+  - For those of you working on large projects
+- Comes with batteries included
+  - No longer requires a Ruby installation
+- Bring your own checks and/or publish them to npm
+- Runs in browser too

--- a/packages/prettier-plugin-liquid/tsconfig.json
+++ b/packages/prettier-plugin-liquid/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "commonjs",
     "target": "ES6",
     "rootDir": "src",
+    "esModuleInterop": true,
     "paths": {
       "@shopify/liquid-html-parser": ["../liquid-html-parser/src"]
     }

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -7,49 +7,49 @@
 
 <h4 align="center">A complete developer experience for Shopify themes</h4>
 
-Official VS Code extension for [Shopify Liquid](https://shopify.dev/docs/themes) powered by [Theme Check][tc] the Liquid linter and language server for online store themes.
+Official VS Code extension for [Shopify Liquid storefronts](https://shopify.dev/docs/themes) and [Theme App Extensions](https://shopify.dev/docs/apps/online-store/theme-app-extensions).
 
 ![](https://github.com/Shopify/theme-check-vscode/blob/feature/readme-revamp/images/demo.gif?raw=true)
 
-[Features](#features) |  [Installation](#installation) | [Configuration](#configuration) | [📦 VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=shopify.theme-check-vscode).
+[Features](#features) | [User guide](#user-guide) | [Installation](#installation) | [Configuration](#configuration) | [📦 VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=shopify.theme-check-vscode).
 
 ## Features
 
-- 🎨 Syntax highlighting
-- 💧 Liquid language server ([Theme Check][tc])
-  - 📗 Completions
-  - ✅ Linting
-  - 🔎 Go to source
-- 💅 Formatting ([Liquid Prettier plugin](https://github.com/shopify/prettier-plugin-liquid))
-- 📐 Automatic indentation
-- 🎎 Auto closing pairs
+* 🎨 Syntax highlighting
+* 💅 Code formatting
+* 💡 Code completion and documentation on hover
+  * 💧 Liquid tag, filter and object
+  * 🏷️ HTML tag, attribute and value
+  * 🖌️ Theme, section and block settings
+  * 🌐 Theme translation
+  * 🖼️ Render tag snippet
+* 🔎 Code navigation
+* 🎎 Auto-closing pairs
+* ✅ Theme checks and fixes
+
+## User guide
+
+Take a look at [our user guide](https://shopify.dev/docs/themes/tools/shopify-liquid-vscode) for an in-depth demonstration and explanation of all the features.
 
 ## Installation
 
-This VS Code extensions depends on the [Theme Check][tc] language server, which is bundled in the latest [Shopify CLI](https://shopify.dev/themes/tools/cli).
-
-To install the `shopify` CLI, follow these steps:
-
-1. Go to https://shopify.dev/themes/tools/cli/install
-2. Follow the instructions for your operating system
-
------
-
-⚠️ **Warning** Windows support is experimental. See [this issue](https://github.com/Shopify/theme-check-vscode/issues/5) for details.
-
------
+This VS Code extensions comes with batteries included.
 
 ## Configuration
 
-- `"shopifyLiquid.shopifyCLIPath": string`, (optional, Unix-only) a path to the `shopify` executable.
-- `"shopifyLiquid.languageServerPath": string`, (optional) a path to the `theme-check-language-server` executable.
-- `"shopifyLiquid.themeCheckNextDevPreview": boolean`, (optional) when true, will use `@shopify/theme-language-server-node` as the language server instead of the ruby version (aka batteries-included mode). Supercedes `shopifyCLIPath` and `languageServerPath`.
-- `"shopifyLiquid.disableWindowsWarning": boolean`, (default: `false`) When true, theme check won't bug you with the Windows warning anymore.
 - `"themeCheck.checkOnOpen": boolean`, (default: `true`) makes it so theme check runs on file open.
 - `"themeCheck.checkOnChange": boolean`, (default: `true`) makes it so theme check runs on file change.
 - `"themeCheck.checkOnSave": boolean`, (default: `true`) makes it so theme check runs on file save.
+
+### Deprecated configuration
+
+If you still want to use the Ruby `theme-check-language-server`, you may use the following deprecated settings:
+
+- `"shopifyLiquid.legacyMode": boolean`, (default: `false`) when true, will use the Ruby `theme-check-language-server`.
+- `"shopifyLiquid.languageServerPath": string`, (optional) a path to the `theme-check-language-server` executable. Has higher priority than `shopifyLiquid.shopifyCLIPath`.
+- `"shopifyLiquid.shopifyCLIPath": string`, (optional, Unix-only) a path to the `shopify` executable.
 - `"themeCheck.onlySingleFileChecks": boolean`, (default: `false`) makes it so theme check only runs single file checks for the files that are open.
 
-  Great for performance if can ignore checks that span multiple files during development and otherwise run full theme checks on the CLI or in CI.
+## License
 
-[tc]: https://github.com/Shopify/theme-check
+MIT.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -98,36 +98,6 @@
     "configuration": {
       "title": "Shopify Liquid | Syntax Highlighting & Linter by Shopify",
       "properties": {
-        "shopifyLiquid.shopifyCLIPath": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null,
-          "description": "Path to shopify executable. Defaults to `which shopify` if available on `$PATH`."
-        },
-        "shopifyLiquid.languageServerPath": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null,
-          "description": "Path to theme-check-language-server. Defaults to `which theme-check-language-server` if available on `$PATH`."
-        },
-        "shopifyLiquid.themeCheckNextDevPreview": {
-          "type": [
-            "boolean"
-          ],
-          "description": "When true, will use @shopify/theme-language-server-node instead of the ruby version.",
-          "default": false
-        },
-        "shopifyLiquid.disableWindowsWarning": {
-          "type": [
-            "boolean"
-          ],
-          "description": "When true, theme check won't bug you with the Windows warning anymore.",
-          "default": false
-        },
         "themeCheck.checkOnOpen": {
           "type": [
             "boolean"
@@ -149,12 +119,43 @@
           "description": "When true, theme check runs on file save.",
           "default": true
         },
+        "shopifyLiquid.legacyMode": {
+          "order": 40,
+          "type": [
+            "boolean"
+          ],
+          "description": "When true, will use the language server specified by shopifyLiquid.languageServerPath or shopifyLiquid.shopifyCLIPath",
+          "default": false,
+          "deprecationMessage": "Deprecated: use only if you want to setup the Ruby theme-check-language-server."
+        },
+        "shopifyLiquid.languageServerPath": {
+          "order": 41,
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Path to theme-check-language-server. Defaults to `which theme-check-language-server` if available on `$PATH`.",
+          "deprecationMessage": "Deprecated: use only if you want to setup the Ruby theme-check-language-server with `shopifyLiquid.legacyMode` enabled."
+        },
+        "shopifyLiquid.shopifyCLIPath": {
+          "order": 42,
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Path to shopify executable. Defaults to `which shopify` if available on `$PATH`.",
+          "deprecationMessage": "Deprecated: use only if you want to setup the Ruby theme-check-language-server with `shopifyLiquid.legacyMode` enabled."
+        },
         "themeCheck.onlySingleFileChecks": {
+          "order": 43,
           "type": [
             "boolean"
           ],
           "description": "When true, disables whole theme checks. Can improve performance. (theme-check v1.10.0+)",
-          "default": false
+          "default": false,
+          "deprecationMessage": "Deprecated: only used by the Ruby theme-check-language-server with `shopifyLiquid.legacyMode` enabled"
         }
       }
     },

--- a/packages/vscode-extension/src/formatter.ts
+++ b/packages/vscode-extension/src/formatter.ts
@@ -8,7 +8,7 @@ import {
   Position,
 } from 'vscode';
 import * as prettier from 'prettier';
-import * as LiquidPrettierPlugin from '@shopify/prettier-plugin-liquid';
+import LiquidPrettierPlugin from '@shopify/prettier-plugin-liquid';
 import { LiquidHTMLASTParsingError } from '@shopify/liquid-html-parser';
 
 export default class LiquidFormatter {

--- a/packages/vscode-extension/src/legacyMode.ts
+++ b/packages/vscode-extension/src/legacyMode.ts
@@ -1,0 +1,103 @@
+import * as child_process from 'child_process';
+import { promisify } from 'util';
+import { window } from 'vscode';
+import { ServerOptions } from 'vscode-languageclient/node';
+import { getConfig } from './utils';
+
+const exec = promisify(child_process.exec);
+
+const isWin = process.platform === 'win32';
+
+class CommandNotFoundError extends Error {}
+
+export async function getLegacyModeServerOptions(): Promise<ServerOptions | undefined> {
+  const themeCheckPath = getConfig('shopifyLiquid.languageServerPath') as string | undefined;
+  const shopifyCLIPath = getConfig('shopifyLiquid.shopifyCLIPath') as string | undefined;
+
+  try {
+    const executable: ServerOptions | undefined =
+      (themeCheckPath && (await themeCheckExecutable(themeCheckPath))) ||
+      (shopifyCLIPath && (await shopifyCLIExecutable(shopifyCLIPath))) ||
+      (await getThemeCheckExecutable()) ||
+      (await getShopifyCLIExecutable());
+    if (!executable) {
+      throw new Error('No executable found');
+    }
+    return executable;
+  } catch (e) {
+    if (e instanceof CommandNotFoundError) {
+      window.showErrorMessage(e.message);
+    } else {
+      if (isWin) {
+        window.showWarningMessage(
+          `The 'theme-check-language-server' executable was not found on your $PATH. Was it installed? The path can also be changed via the "shopifyLiquid.languageServerPath" setting.`,
+        );
+      } else {
+        console.error(e);
+        window.showWarningMessage(
+          `The 'shopify' executable was not found on your $PATH. Was it installed? The path can also be changed via the "shopifyLiquid.shopifyCLIPath" setting.`,
+        );
+      }
+    }
+  }
+}
+
+async function getShopifyCLIExecutable(): Promise<ServerOptions | undefined> {
+  try {
+    const path = await which('shopify');
+    return shopifyCLIExecutable(path);
+  } catch (e) {
+    return undefined;
+  }
+}
+
+async function getThemeCheckExecutable(): Promise<ServerOptions | undefined> {
+  try {
+    const path = await which('theme-check-language-server');
+    return themeCheckExecutable(path);
+  } catch (e) {
+    return undefined;
+  }
+}
+
+async function shopifyCLIExecutable(command: string | boolean): Promise<ServerOptions | undefined> {
+  if (isWin || typeof command !== 'string' || command === '') {
+    return;
+  }
+  return {
+    command,
+    args: ['theme', 'language-server'],
+  };
+}
+
+async function themeCheckExecutable(command: string | boolean): Promise<ServerOptions | undefined> {
+  if (typeof command !== 'string' || command === '') {
+    return undefined;
+  }
+  await commandExists(command);
+  return {
+    command,
+  };
+}
+
+async function commandExists(command: string): Promise<void> {
+  try {
+    !isWin && (await exec(`[ -f "${command}" ]`));
+  } catch (e) {
+    throw new CommandNotFoundError(`${command} not found, are you sure this is the correct path?`);
+  }
+}
+
+async function which(command: string) {
+  if (isWin) {
+    const { stdout } = await exec(`where.exe ${command}`);
+    const executables = stdout
+      .replace(/\r/g, '')
+      .split('\n')
+      .filter((exe) => exe.endsWith('bat'));
+    return executables.length > 0 && executables[0];
+  } else {
+    const { stdout } = await exec(`which ${command}`);
+    return stdout.split('\n')[0].replace('\r', '');
+  }
+}

--- a/packages/vscode-extension/src/utils.ts
+++ b/packages/vscode-extension/src/utils.ts
@@ -1,0 +1,6 @@
+import { workspace } from 'vscode';
+
+export function getConfig(path: string) {
+  const [namespace, key] = path.split('.');
+  return workspace.getConfiguration(namespace).get(key);
+}

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -7,6 +7,7 @@
     "rootDir": "src",
     "strict": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "/tmp/vscode-extension-useless-declarations",
     "composite": true,
     "noImplicitAny": false,


### PR DESCRIPTION

## What are you adding in this PR?

- Cleanup package.json homepage, repository and bugs attributes
- Re add CLI info to theme check README
- Remove the developer preview opt-in
  - Remove `shopifyLiquid.themeCheckNextDevPreview`
  - Add `shopifyLiquid.legacyMode`
  - Deprecate `shopifyLiquid.languageServerPath`
  - Deprecate `shopifyLiquid.shopifyCLIPath`
  - Deprecate `shopifyLiquid.onlySingleFileChecks`
  - Shove the legacy mode extension logic into `src/legacyMode.ts`
- Major changeset for theme-check: 2.0.0!
- Major changeset for vscode-extension: batteries included!

This is GA Baby!

## Before you deploy

<!-- Public API changes, new features -->
- [x] I a major bump `changeset`
