### PR TITLE
Example Fix for the liquid-html-parser README.md

### DIFF
--- a/packages/liquid-html-parser/README.md
+++ b/packages/liquid-html-parser/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/Shopify/theme-tools/blob/main/LICENSE.md"><img src="https://img.shields.io/npm/l/@shopify/liquid-html-parser.svg?sanitize=true" alt="License"></a>
   <a href="https://github.com/Shopify/liquid-html-parser-prototype/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Shopify/prettier-plugin-liquid-prototype/actions/workflows/ci.yml/badge.svg"></a>
   <!--
-    <a href="https://npmcharts.com/compare/@shopify/liquid-html-parser?minimal=true"><img src="https://img.shields.io/npm/dm/@shopify/prettier-plugin-liquid.svg?sanitize=true" alt="Downloads"></a>
+    <a href="https://npmcharts.com/compare/@shopify/liquid-html-parser?minimal=true"><img src="https://img.shields.io/npm/dm/@shopify/liquid-html-parser.svg?sanitize=true" alt="Downloads"></a>
   -->
 </p>
 
@@ -31,7 +31,7 @@ yarn add @shopify/liquid-html-parser
 ## Usage
 
 ```ts
-import { toLiquidHtmlAST, LiquidHtmlNode, NodeTypes } from '@shopify/prettier-plugin-liquid';
+import { toLiquidHtmlAST, LiquidHtmlNode, NodeTypes } from '@shopify/liquid-html-parser';
 
 const ast: LiquidHtmlNode = toLiquidHtmlAST(`
 <body>


### PR DESCRIPTION
## What are you adding in this PR?
It seems like the readme for the liquid-html-parser package is a copy-paste from the prettier-plugin-liquid readme, and that a few elements were not changed to reflect that.

- Changed README.md TS example that refers to the wrong package name for the liquid-html-parser package.
- Changed a commented-out npmcharts URL in the README.md for for the liquid-html-parser package that was pointing to the wrong package (prettier-plugin-liquid)

## What's next? Any followup issues?

- README.md: The CI link is wrong and should be updated or removed.
- README.md: The Corrected npmcharts URL should be uncommented or removed.
- README.md: Adding a non-TS example would be nice.

## What did you learn?

I'm not the only one to do copy-paste change omissions. 

## Before you deploy

I'm uncertain if a README change requires a patch bump here. I can add one if necessary.

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
