### PR TITLE
Add `UnclosedHTMLElement` check

### DIFF
--- a/.changeset/mean-bears-train.md
+++ b/.changeset/mean-bears-train.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+'@shopify/theme-check-browser': minor
+---
+
+Add `UnclosedHTMLElement` check

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -2,10 +2,16 @@ import { ConfigTarget, JSONCheckDefinition, LiquidCheckDefinition } from '../typ
 
 import { AppBlockValidTags } from './app-block-valid-tags';
 import { AssetPreload } from './asset-preload';
-import { RemoteAsset } from './remote-asset';
+import { AssetSizeAppBlockCSS } from './asset-size-app-block-css';
+import { AssetSizeAppBlockJavaScript } from './asset-size-app-block-javascript';
+import { AssetSizeCSS } from './asset-size-css';
+import { AssetSizeJavaScript } from './asset-size-javascript';
 import { CdnPreconnect } from './cdn-preconnect';
+import { ContentForHeaderModification } from './content-for-header-modification';
 import { DeprecateBgsizes } from './deprecate-bgsizes';
 import { DeprecateLazysizes } from './deprecate-lazysizes';
+import { DeprecatedFilter } from './deprecated-filter';
+import { DeprecatedTag } from './deprecated-tag';
 import { ImgWidthAndHeight } from './img-width-and-height';
 import { JSONSyntaxError } from './json-syntax-error';
 import { LiquidHTMLSyntaxError } from './liquid-html-syntax-error';
@@ -14,20 +20,15 @@ import { MissingAsset } from './missing-asset';
 import { MissingTemplate } from './missing-template';
 import { PaginationSize } from './pagination-size';
 import { ParserBlockingScript } from './parser-blocking-script';
+import { RemoteAsset } from './remote-asset';
 import { RequiredLayoutThemeObject } from './required-layout-theme-object';
 import { TranslationKeyExists } from './translation-key-exists';
+import { UnclosedHTMLElement } from './unclosed-html-element';
+import { UndefinedObject } from './undefined-object';
 import { UnknownFilter } from './unknown-filter';
 import { UnusedAssign } from './unused-assign';
 import { ValidHTMLTranslation } from './valid-html-translation';
 import { ValidSchema } from './valid-schema';
-import { ContentForHeaderModification } from './content-for-header-modification';
-import { AssetSizeAppBlockCSS } from './asset-size-app-block-css';
-import { AssetSizeAppBlockJavaScript } from './asset-size-app-block-javascript';
-import { AssetSizeCSS } from './asset-size-css';
-import { DeprecatedFilter } from './deprecated-filter';
-import { DeprecatedTag } from './deprecated-tag';
-import { AssetSizeJavaScript } from './asset-size-javascript';
-import { UndefinedObject } from './undefined-object';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
@@ -53,6 +54,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   RemoteAsset,
   RequiredLayoutThemeObject,
   TranslationKeyExists,
+  UnclosedHTMLElement,
   UndefinedObject,
   UnknownFilter,
   UnusedAssign,

--- a/packages/theme-check-common/src/checks/unclosed-html-element/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unclosed-html-element/index.spec.ts
@@ -1,0 +1,122 @@
+import { expect, describe, it } from 'vitest';
+import { UnclosedHTMLElement } from '.';
+import { runLiquidCheck, highlightedOffenses } from '../../test';
+
+describe('Module: UnclosedHTMLElement', () => {
+  it('should report an offense for a branch open tag without its close tag', async () => {
+    const file = `
+      <div>
+        {% if cond %}
+          <main>
+        {% endif %}
+      </div>
+    `;
+
+    const offenses = await runLiquidCheck(UnclosedHTMLElement, file);
+
+    expect(offenses).to.have.length(1);
+    expect(offenses).to.containOffense({
+      message: `Opening tag does not have a matching closing tag for condition \`cond\` in HtmlElement 'div'`,
+    });
+    expect(highlightedOffenses(file, offenses)).to.include('<main>');
+  });
+
+  it('should report an offense for a branch close tag without its open tag', async () => {
+    const file = `
+      <div>
+        {% if cond %}
+          </main>
+        {% endif %}
+      </div>
+    `;
+
+    const offenses = await runLiquidCheck(UnclosedHTMLElement, file);
+
+    expect(offenses).to.have.length(1);
+    expect(offenses).to.containOffense({
+      message: `Closing tag does not have a matching opening tag for condition \`cond\` in HtmlElement 'div'`,
+    });
+    expect(highlightedOffenses(file, offenses)).to.include('</main>');
+  });
+
+  it('should report offenses when branches are closed in the wrong order', async () => {
+    const file = `
+      <div>
+        {% if cond %}
+          <details>
+            <summary>
+        {% endif %}
+
+        {% if cond %}
+          </details>
+          </summary>
+        {% endif %}
+      </div>
+    `;
+
+    const offenses = await runLiquidCheck(UnclosedHTMLElement, file);
+
+    expect(offenses).to.have.length(4);
+    expect(offenses).to.containOffense({
+      message: `Closing tag does not have a matching opening tag for condition \`cond\` in HtmlElement 'div'`,
+    });
+    expect(highlightedOffenses(file, offenses)).to.include('<details>');
+    expect(highlightedOffenses(file, offenses)).to.include('<summary>');
+    expect(highlightedOffenses(file, offenses)).to.include('</details>');
+    expect(highlightedOffenses(file, offenses)).to.include('</summary>');
+  });
+
+  it('should report offenses when branches are closed in the wrong node', async () => {
+    const file = `
+      <div>
+        {% if cond %}
+          <details>
+            <summary>
+        {% endif %}
+
+        <div>
+          {% if cond %}
+            </details>
+            </summary>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if cond %}
+        </details>
+        </summary>
+      {% endif %}
+    `;
+
+    const offenses = await runLiquidCheck(UnclosedHTMLElement, file);
+
+    expect(offenses).to.have.length(6);
+    expect(offenses).to.containOffense({
+      message: `Closing tag does not have a matching opening tag for condition \`cond\` in HtmlElement 'div'`,
+    });
+    expect(highlightedOffenses(file, offenses)).to.include('<details>');
+    expect(highlightedOffenses(file, offenses)).to.include('<summary>');
+    expect(highlightedOffenses(file, offenses)).to.include('</details>');
+    expect(highlightedOffenses(file, offenses)).to.include('</summary>');
+  });
+
+  it('should not report for files without unbalanced tags', async () => {
+    const file = `
+      <div>
+        {% if cond %}
+          <details>
+            <summary>
+        {% endif %}
+
+        {% if cond %}
+          </summary>
+          </details>
+        {% endif %}
+      </div>
+    `;
+
+    const offenses = await runLiquidCheck(UnclosedHTMLElement, file);
+
+    expect(offenses).to.have.length(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/unclosed-html-element/index.ts
+++ b/packages/theme-check-common/src/checks/unclosed-html-element/index.ts
@@ -1,0 +1,251 @@
+import {
+  HtmlDanglingMarkerClose,
+  HtmlElement,
+  LiquidBranch,
+  LiquidConditionalExpression,
+  LiquidExpression,
+  LiquidHtmlNode,
+  LiquidTag,
+  LiquidTagIf,
+  NamedTags,
+  NodeTypes,
+} from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { assertNever, findLast, findLastAndIndex, last } from '../../utils';
+import {
+  hasAttributeValueOf,
+  isAttr,
+  isHtmlAttribute,
+  isLiquidBranch,
+  isNodeOfType,
+  isValuedHtmlAttribute,
+} from '../utils';
+
+/** A string representation of a condition */
+type ConditionIdentifer = string;
+
+/** A stack of opening tags without their closing tags */
+type StacksOpen = Map<ConditionIdentifer, HtmlElement[]>;
+
+/** A stack of close tags without their opening tags */
+type StacksClose = Map<ConditionIdentifer, HtmlDanglingMarkerClose[]>;
+
+/**
+ * A Stacks is a collection of dangling opened and close nodes
+ *   If the code is properly balanced, they match 1:1.
+ *   If they do not, then that's an issue with their code!
+ */
+interface Stacks {
+  open: StacksOpen;
+  close: StacksClose;
+  identifiers: Set<ConditionIdentifer>;
+}
+
+export const UnclosedHTMLElement: LiquidCheckDefinition = {
+  meta: {
+    code: 'UnclosedHTMLElement',
+    aliases: ['UnclosedHTMLElement'],
+    name: 'Unclosed HTML Element',
+    docs: {
+      description: 'Warns you of unbalanced HTML tags in branching code',
+      recommended: true,
+      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/unclosed-html-element',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    const stacksByParent = new Map<LiquidHtmlNode, Stacks>();
+
+    return {
+      async HtmlElement(node, ancestors) {
+        if (isClosed(node)) return;
+        const [branch, index] = findLastAndIndex(ancestors, isLiquidBranch);
+        if (!branch) return;
+
+        const parent = ancestors[index - 1];
+        const grandparent = ancestors[index - 2];
+        if (!parent || !grandparent || parent.type !== NodeTypes.LiquidTag) return;
+
+        if (!stacksByParent.has(grandparent)) {
+          stacksByParent.set(grandparent, {
+            open: new Map(),
+            close: new Map(),
+            identifiers: new Set(),
+          });
+        }
+        const stacks = stacksByParent.get(grandparent)!;
+
+        const identifier = getConditionIdentifier(branch, parent);
+        stacks.identifiers.add(identifier);
+
+        if (!stacks.open.has(identifier)) stacks.open.set(identifier, []);
+        stacks.open.get(identifier)!.push(node);
+      },
+
+      async HtmlDanglingMarkerClose(node, ancestors) {
+        const [branch, index] = findLastAndIndex(ancestors, isLiquidBranch);
+        if (!branch) return;
+        const parent = ancestors[index - 1];
+        const grandparent = ancestors[index - 2];
+        // To make typescript happy
+        if (!parent || !grandparent || parent.type !== NodeTypes.LiquidTag) return;
+
+        if (!stacksByParent.has(grandparent)) {
+          stacksByParent.set(grandparent, {
+            open: new Map(),
+            close: new Map(),
+            identifiers: new Set(),
+          });
+        }
+
+        const stacks = stacksByParent.get(grandparent)!;
+        const identifier = getConditionIdentifier(branch, parent);
+        stacks.identifiers.add(identifier);
+
+        if (!stacks.close.has(identifier)) stacks.close.set(identifier, []);
+        stacks.close.get(identifier)!.push(node);
+      },
+
+      async onCodePathEnd(file) {
+        for (const [parentNode, stacks] of stacksByParent) {
+          for (const identifier of stacks.identifiers) {
+            const openNodes = stacks.open.get(identifier) ?? [];
+            const closeNodes = stacks.close.get(identifier) ?? [];
+
+            // if everything is balanced, then open and close should match length and order
+            const nodes = ([] as (HtmlElement | HtmlDanglingMarkerClose)[])
+              .concat(openNodes, closeNodes)
+              .sort((a, b) => a.position.start - b.position.start);
+            const stack = [] as (HtmlElement | HtmlDanglingMarkerClose)[];
+
+            for (const node of nodes) {
+              if (node.type === NodeTypes.HtmlElement) {
+                stack.push(node);
+              } else if (stack.length > 0 && getName(node) === getName(stack.at(-1)!)) {
+                stack.pop();
+              } else {
+                stack.push(node);
+              }
+            }
+
+            for (const node of stack) {
+              if (node.type === NodeTypes.HtmlDanglingMarkerClose) {
+                context.report({
+                  message: `Closing tag does not have a matching opening tag for condition \`${identifier}\` in ${
+                    parentNode.type
+                  } '${getName(parentNode)}'`,
+                  startIndex: node.position.start,
+                  endIndex: node.position.end,
+                });
+              } else {
+                context.report({
+                  message: `Opening tag does not have a matching closing tag for condition \`${identifier}\` in ${
+                    parentNode.type
+                  } '${getName(parentNode)}'`,
+                  startIndex: node.blockStartPosition.start,
+                  endIndex: node.blockStartPosition.end,
+                });
+              }
+            }
+          }
+        }
+      },
+    };
+  },
+};
+
+function isClosed(node: HtmlElement) {
+  return node.blockEndPosition.start !== node.blockEndPosition.end;
+}
+
+function getConditionIdentifier(branch: LiquidBranch, parent: LiquidTag): string {
+  if (branch.name === null) {
+    switch (parent.name) {
+      case NamedTags.if:
+        return getConditionIdentifierForMarkup(parent.markup);
+      case NamedTags.unless:
+        return negateIdentifier(getConditionIdentifierForMarkup(parent.markup));
+      default:
+        return '??';
+    }
+  }
+
+  switch (branch.name) {
+    case 'else':
+      switch (parent.name) {
+        case NamedTags.if:
+          return negateIdentifier(getConditionIdentifierForMarkup(parent.markup));
+        case NamedTags.unless:
+          return getConditionIdentifierForMarkup(parent.markup);
+        case NamedTags.case:
+          return `case ${getConditionIdentifierForMarkup(parent.markup)}`;
+        default:
+          '??';
+      }
+    case NamedTags.elsif:
+      return getConditionIdentifierForMarkup(branch.markup);
+    case NamedTags.when:
+      if (parent.name !== NamedTags.case) return '??';
+      return `case ${getConditionIdentifierForMarkup(
+        parent.markup,
+      )} == ${getConditionIdentifierForWhenMarkup(branch.markup)}`;
+    default:
+      return '??';
+  }
+}
+
+function getConditionIdentifierForWhenMarkup(conditions: string | LiquidExpression[]): string {
+  if (typeof conditions === 'string') return conditions;
+  return conditions.map(getConditionIdentifierForMarkup).join(' or ');
+}
+
+function getConditionIdentifierForMarkup(condition: string | LiquidConditionalExpression): string {
+  if (typeof condition === 'string') return condition;
+  switch (condition.type) {
+    case NodeTypes.String:
+      return `'` + condition.value + `'`;
+    case NodeTypes.LiquidLiteral:
+      return condition.keyword;
+    case NodeTypes.Number:
+      return condition.value;
+    case NodeTypes.VariableLookup:
+    case NodeTypes.Range:
+      return condition.source.slice(condition.position.start, condition.position.end);
+    case NodeTypes.Comparison:
+      return [
+        getConditionIdentifierForMarkup(condition.left),
+        condition.comparator,
+        getConditionIdentifierForMarkup(condition.right),
+      ].join(' ');
+    case NodeTypes.LogicalExpression:
+      return [
+        getConditionIdentifierForMarkup(condition.left),
+        condition.relation,
+        getConditionIdentifierForMarkup(condition.right),
+      ].join(' ');
+    default: {
+      return assertNever(condition);
+    }
+  }
+}
+
+function negateIdentifier(conditionIdentifier: ConditionIdentifer): ConditionIdentifer {
+  return conditionIdentifier.startsWith('-')
+    ? conditionIdentifier.slice(1)
+    : `-${conditionIdentifier}`;
+}
+
+function getName(node: LiquidHtmlNode) {
+  if (node.type === NodeTypes.HtmlElement || node.type === NodeTypes.HtmlDanglingMarkerClose) {
+    if (node.name.length === 0) return '';
+    return node.source.slice(node.name.at(0)!.position.start, node.name.at(-1)!.position.end);
+  } else if (node.type === NodeTypes.LiquidTag) {
+    return node.name;
+  } else {
+    return node.type;
+  }
+}

--- a/packages/theme-check-common/src/checks/utils.ts
+++ b/packages/theme-check-common/src/checks/utils.ts
@@ -8,6 +8,7 @@ import {
   AttrDoubleQuoted,
   AttrUnquoted,
   LiquidHtmlNode,
+  LiquidBranch,
 } from '@shopify/liquid-html-parser';
 import { LiquidHtmlNodeOfType as NodeOfType } from '../types';
 
@@ -20,6 +21,10 @@ export function isNodeOfType<T extends NodeTypes>(
   node?: LiquidHtmlNode,
 ): node is NodeOfType<T> {
   return node?.type === type;
+}
+
+export function isLiquidBranch(node: LiquidHtmlNode): node is LiquidBranch {
+  return isNodeOfType(NodeTypes.LiquidBranch, node);
 }
 
 export function isHtmlTag<T>(

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -257,7 +257,9 @@ export function applySuggestions(
   });
 }
 
-export function highlightedOffenses(theme: MockTheme, offenses: Offense[]) {
+export function highlightedOffenses(themeOrSource: MockTheme | string, offenses: Offense[]) {
+  const theme =
+    typeof themeOrSource === 'string' ? { 'file.liquid': themeOrSource } : themeOrSource;
   return offenses.map((offense) => {
     const relativePath = offense.absolutePath.substring(1);
     const source = theme[relativePath];

--- a/packages/theme-check-common/src/utils/array.ts
+++ b/packages/theme-check-common/src/utils/array.ts
@@ -5,3 +5,27 @@ export function first<T>(arr: T[]): T | undefined {
 export function last<T>(arr: T[], offset: number = 0): T | undefined {
   return arr[arr.length - 1 + offset];
 }
+
+export function findLast<T, NT extends T>(array: T[], pred: (n: T) => n is NT): NT | undefined;
+export function findLast<T>(array: T[], pred: (n: T) => boolean): T | undefined {
+  return array[findLastIndex(array, pred)];
+}
+
+export function findLastIndex<T>(array: T[], pred: (n: T) => boolean): number {
+  for (let i = array.length - 1; i >= 0; i--) {
+    if (pred(array[i])) return i;
+  }
+  return -1;
+}
+
+export function findLastAndIndex<T, NT extends T>(
+  array: T[],
+  pred: (n: T) => n is NT,
+): [NT, number] | [undefined, -1];
+export function findLastAndIndex<T>(
+  array: T[],
+  pred: (n: T) => boolean,
+): [T, number] | [undefined, -1] {
+  const index = findLastIndex(array, pred);
+  return [array[index], index];
+}

--- a/packages/theme-check-common/tsconfig.json
+++ b/packages/theme-check-common/tsconfig.json
@@ -4,16 +4,22 @@
     "./src/**/*.ts",
     "./src/**/*.json"
   ],
-  "exclude": ["./dist"],
+  "exclude": [
+    "./dist"
+  ],
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "paths": {
-      "@shopify/liquid-html-parser": ["../liquid-html-parser/src"]
+      "@shopify/liquid-html-parser": [
+        "../liquid-html-parser/src"
+      ]
     }
   },
   "references": [
-    { "path": "../liquid-html-parser" }
+    {
+      "path": "../liquid-html-parser"
+    }
   ]
 }

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -79,6 +79,9 @@ RequiredLayoutThemeObject:
 TranslationKeyExists:
   enabled: true
   severity: 0
+UnclosedHTMLElement:
+  enabled: true
+  severity: 1
 UndefinedObject:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -60,6 +60,9 @@ RequiredLayoutThemeObject:
 TranslationKeyExists:
   enabled: true
   severity: 0
+UnclosedHTMLElement:
+  enabled: true
+  severity: 1
 UndefinedObject:
   enabled: true
   severity: 1


### PR DESCRIPTION
## What are you adding in this PR?

- Add the `UnclosedHTMLElement` check

  This check warns users of unclosed HTML elements in branching code (or wrongly closed) by making sure that they are opened/closed in the same parent element, condition and stack order.

  Again but slower :sweat_smile:

  - Dangling open/close must be in conditional branches of the same parent
    ```liquid
    no good because the details is closed in the `<p>` and not the `<div>`
    <div>
      {% if cond %}
        <details>
      {% endif %}
      <p>
        {% if cond %}
          </details>
        {% endif %}
      </p>
    </div>
    ```
  - They must open/close in the same conditional branch identifier (same if/unless condition)

    ```liquid
    no good! different conditions open/close the tags!
    <div>
      {% if something %}
        <details>
      {% endif %}

      {% if something_else %}
        </details>
      {% endif %}
    </div>
    ```
    
    - `else` and `unless` evaluate to the negated condition identifier

      ```liquid
      Works! Same condition
      <div>
        {% if cond %}
        {% else %}
          <details>
        {% endif %}

        {% unless cond %}
          </details>
        {% endunless %}
      </div>
      ```

  - They must open/close in the correct order (<details><summary></summary></details>)

    ```liquid
    not good (should close in reverse order)
    <div>
      {% if cond %}
        <details
          <summary>
      {% endif %}

      {% if cond %}
        </details>
        </summary>
      {% endif %}
    </div>
    ```

## What's next? Any followup issues?

- [ ] Add docs for UnclosedHTMLElement

## What did you learn?

Surprised! That wasn't as hard as I thought! It's clever af, but it works!

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn update-configs` and committed the updated configuration files
