### PR TITLE
Fix hover for liquid schema and style tags

### DIFF
--- a/.changeset/big-tables-play.md
+++ b/.changeset/big-tables-play.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Fix hover for liquid schema and style tags

--- a/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.ts
@@ -8,7 +8,11 @@ export class LiquidTagHoverProvider implements BaseHoverProvider {
   constructor(public themeDocset: ThemeDocset) {}
 
   async hover(currentNode: LiquidHtmlNode): Promise<Hover | null> {
-    if (currentNode.type !== NodeTypes.LiquidTag && currentNode.type !== NodeTypes.LiquidBranch) {
+    if (
+      currentNode.type !== NodeTypes.LiquidTag &&
+      currentNode.type !== NodeTypes.LiquidRawTag &&
+      currentNode.type !== NodeTypes.LiquidBranch
+    ) {
       return null;
     }
 


### PR DESCRIPTION
## What are you adding in this PR?

Resolves #132 

Includes `LiquidRawTag` in the provider, so style and schema tags are included. 

### 📸 
<img width="699" alt="image" src="https://github.com/Shopify/theme-tools/assets/88160492/7487bf4b-964d-4225-9afa-05c2c505a5cd">

## What's next? Any followup issues?

### Schema docs❓ 

The image shows that the hover provider is working, but the documentation on this tag is empty so nothing is displayed. How does the `ThemeDocset` get populated in the providers? Is there somewhere else that needs updating for this?

<img width="376" alt="image" src="https://github.com/Shopify/theme-tools/assets/88160492/17eaadbd-2f07-47b0-89eb-e9d4c2674026">

## What did you learn?

First time in this repository; Run and Debug -> Launch Client -> Adding breakpoints is your friend
TypeScript [narrowing](https://www.typescriptlang.org/docs/handbook/2/narrowing.html)

## Before you deploy
- [x] I included a patch bump `changeset`
