### PR TITLE
Theme Tools Release: 08-02-24

### DIFF
--- a/.changeset/hungry-chairs-cheat.md
+++ b/.changeset/hungry-chairs-cheat.md
@@ -1,6 +1,0 @@
----
-'@shopify/prettier-plugin-liquid': patch
-'@shopify/liquid-html-parser': patch
----
-
-Fix parsing of `}}` inside `{% %}` and vice-versa

--- a/.changeset/sweet-parrots-cheer.md
+++ b/.changeset/sweet-parrots-cheer.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-check-common': patch
----
-
-Bump lodash deps

--- a/packages/liquid-html-parser/CHANGELOG.md
+++ b/packages/liquid-html-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/liquid-html-parser
 
+## 2.0.2
+
+### Patch Changes
+
+- fa02f1b: Fix parsing of `}}` inside `{% %}` and vice-versa
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/liquid-html-parser/package.json
+++ b/packages/liquid-html-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/liquid-html-parser",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Liquid HTML parser by Shopify",
   "author": "CP Clermont <cp.clermont@shopify.com>",
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/liquid-html-parser#readme",

--- a/packages/prettier-plugin-liquid/CHANGELOG.md
+++ b/packages/prettier-plugin-liquid/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/prettier-plugin-liquid
 
+## 1.4.2
+
+### Patch Changes
+
+- fa02f1b: Fix parsing of `}}` inside `{% %}` and vice-versa
+- Updated dependencies [fa02f1b]
+  - @shopify/liquid-html-parser@2.0.2
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/prettier-plugin-liquid/package.json
+++ b/packages/prettier-plugin-liquid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/prettier-plugin-liquid",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Prettier Liquid/HTML plugin by Shopify",
   "author": "CP Clermont <cp.clermont@shopify.com>",
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/prettier-plugin-liquid#readme",
@@ -59,7 +59,7 @@
     "tsconfig-paths": "^3.14.1"
   },
   "dependencies": {
-    "@shopify/liquid-html-parser": "^2.0.1",
+    "@shopify/liquid-html-parser": "^2.0.2",
     "html-styles": "^1.0.0"
   }
 }

--- a/packages/theme-check-browser/CHANGELOG.md
+++ b/packages/theme-check-browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-check-browser
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [8f19b87]
+  - @shopify/theme-check-common@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/theme-check-browser/package.json
+++ b/packages/theme-check-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-browser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -26,6 +26,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "2.0.0"
+    "@shopify/theme-check-common": "2.0.1"
   }
 }

--- a/packages/theme-check-common/CHANGELOG.md
+++ b/packages/theme-check-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-check-common
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix parsing of `}}` inside `{% %}` and vice-versa
+- 8f19b87: Bump lodash deps
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-common",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,7 +26,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/liquid-html-parser": "2.0.1",
+    "@shopify/liquid-html-parser": "2.0.2",
     "cross-fetch": "^4.0.0",
     "json-to-ast": "^2.1.0",
     "line-column": "^1.0.2",

--- a/packages/theme-check-docs-updater/CHANGELOG.md
+++ b/packages/theme-check-docs-updater/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-check-docs-updater
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [8f19b87]
+  - @shopify/theme-check-common@2.0.1
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-docs-updater",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Scripts to initialize theme-check data with assets from the theme-liquid-docs repo.",
   "main": "dist/index.js",
   "author": "Albert Chu <albert.chu@shopify.com>",
@@ -29,7 +29,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "^2.0.0",
+    "@shopify/theme-check-common": "^2.0.1",
     "ajv": "^8.12.0",
     "env-paths": "^2.2.1",
     "node-fetch": "^2.6.11"

--- a/packages/theme-check-node/CHANGELOG.md
+++ b/packages/theme-check-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/theme-check-node
 
+## 2.0.1
+
+### Patch Changes
+
+- Updated dependencies [8f19b87]
+  - @shopify/theme-check-common@2.0.1
+  - @shopify/theme-check-docs-updater@2.0.1
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-node",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -33,8 +33,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "2.0.0",
-    "@shopify/theme-check-docs-updater": "2.0.0",
+    "@shopify/theme-check-common": "2.0.1",
+    "@shopify/theme-check-docs-updater": "2.0.1",
     "glob": "^8.0.3",
     "yaml": "^2.3.0"
   },

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-language-server-browser
 
+## 1.7.4
+
+### Patch Changes
+
+- @shopify/theme-language-server-common@1.7.4
+
 ## 1.7.3
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.7.3",
+    "@shopify/theme-language-server-common": "1.7.4",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-language-server-common
 
+## 1.7.4
+
+### Patch Changes
+
+- Updated dependencies [fa02f1b]
+- Updated dependencies [8f19b87]
+  - @shopify/liquid-html-parser@2.0.2
+  - @shopify/theme-check-common@2.0.1
+
 ## 1.7.3
 
 ### Patch Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,8 +27,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/liquid-html-parser": "^2.0.1",
-    "@shopify/theme-check-common": "2.0.0",
+    "@shopify/liquid-html-parser": "^2.0.2",
+    "@shopify/theme-check-common": "2.0.1",
     "@vscode/web-custom-data": "^0.4.6",
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.8",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/theme-language-server-node
 
+## 1.7.4
+
+### Patch Changes
+
+- @shopify/theme-check-node@2.0.1
+- @shopify/theme-language-server-common@1.7.4
+- @shopify/theme-check-docs-updater@2.0.1
+
 ## 1.7.3
 
 ### Patch Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,9 +27,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.7.3",
-    "@shopify/theme-check-node": "^2.0.0",
-    "@shopify/theme-check-docs-updater": "^2.0.0",
+    "@shopify/theme-language-server-common": "1.7.4",
+    "@shopify/theme-check-node": "^2.0.1",
+    "@shopify/theme-check-docs-updater": "^2.0.1",
     "glob": "^8.0.3",
     "node-fetch": "^2.6.11",
     "vscode-languageserver": "^8.0.2",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## theme-check-vscode
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix parsing of `}}` inside `{% %}` and vice-versa
+- Bump lodash version
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/shopify/theme-tools/issues"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -58,14 +58,14 @@
     "vscode": "^1.74.0"
   },
   "dependencies": {
-    "@shopify/liquid-html-parser": "^2.0.1",
-    "@shopify/prettier-plugin-liquid": "^1.4.1",
-    "@shopify/theme-language-server-node": "^1.7.3",
+    "@shopify/liquid-html-parser": "^2.0.2",
+    "@shopify/prettier-plugin-liquid": "^1.4.2",
+    "@shopify/theme-language-server-node": "^1.7.4",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0"
   },
   "devDependencies": {
-    "@shopify/theme-check-docs-updater": "^2.0.0",
+    "@shopify/theme-check-docs-updater": "^2.0.1",
     "@types/glob": "^8.0.0",
     "@types/node": "16.x",
     "@types/prettier": "^2.4.2",


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `2.0.0` -> `2.0.1`
### Changes:
- Patch bump because it depends on:
 - @shopify/liquid-html-parser
 - @shopify/prettier-plugin-liquid
 - @shopify/theme-language-server-node

## `@shopify/prettier-plugin-liquid`
Patch incremented `1.4.1` -> `1.4.2`
### Changes:
- Fix parsing of `}}` inside `{% %}` and vice-versa

## `@shopify/liquid-html-parser`
Patch incremented `2.0.1` -> `2.0.2`
### Changes:
- Fix parsing of `}}` inside `{% %}` and vice-versa

## `@shopify/theme-check-common`
Patch incremented `2.0.0` -> `2.0.1`
### Changes:
- Bump lodash deps

## `@shopify/theme-check-browser`
Patch incremented `2.0.0` -> `2.0.1`

## `@shopify/theme-check-node`
Patch incremented `2.0.0` -> `2.0.1`

## `@shopify/theme-language-server-common`
Patch incremented `1.7.3` -> `1.7.4`

## `@shopify/theme-language-server-browser`
Patch incremented `1.7.3` -> `1.7.4`

## `@shopify/theme-language-server-node`
Patch incremented `1.7.3` -> `1.7.4`

## `@shopify/theme-check-docs-updater`
Patch incremented `2.0.0` -> `2.0.1`

