### PR TITLE
Add parser support for trailing commas

### DIFF
--- a/.changeset/rude-beers-crash.md
+++ b/.changeset/rude-beers-crash.md
@@ -1,0 +1,13 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+'@shopify/liquid-html-parser': patch
+'@shopify/theme-check-browser': patch
+'@shopify/theme-check-common': patch
+'@shopify/theme-check-node': patch
+'@shopify/theme-language-server-browser': patch
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-language-server-node': patch
+'theme-check-vscode': patch
+---
+
+Add parser support for trailing commas at the end of Liquid tags and filters

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -128,7 +128,7 @@ Liquid <: Helpers {
   liquidTagInclude = liquidTagRule<"include", liquidTagRenderMarkup>
   liquidTagRender = liquidTagRule<"render", liquidTagRenderMarkup>
   liquidTagRenderMarkup =
-    snippetExpression renderVariableExpression? renderAliasExpression? (argumentSeparatorOptionalComma tagArguments) space*
+    snippetExpression renderVariableExpression? renderAliasExpression? (argumentSeparatorOptionalComma tagArguments) (space* ",")? space*
   snippetExpression = liquidString<delimTag> | variableSegmentAsLookup
   renderVariableExpression = space+ ("for" | "with") space+ liquidExpression<delimTag>
   renderAliasExpression = space+ "as" space+ variableSegment
@@ -136,13 +136,13 @@ Liquid <: Helpers {
   liquidTagOpenBaseCase = liquidTagOpenRule<blockName, tagMarkup>
 
   liquidTagOpenForm = liquidTagOpenRule<"form", liquidTagOpenFormMarkup>
-  liquidTagOpenFormMarkup = arguments<delimTag> space*
+  liquidTagOpenFormMarkup = arguments<delimTag> (space* ",")? space*
 
   liquidTagOpenFor = liquidTagOpenRule<"for", liquidTagOpenForMarkup>
   liquidTagOpenForMarkup =
     variableSegment space* "in" space* liquidExpression<delimTag>
     (space* "reversed")? argumentSeparatorOptionalComma
-    tagArguments space*
+    tagArguments (space* ",")? space*
 
   // It's the same, the difference is support for different named arguments<delim>
   liquidTagOpenTablerow = liquidTagOpenRule<"tablerow", liquidTagOpenForMarkup>
@@ -178,7 +178,7 @@ Liquid <: Helpers {
 
   liquidTagOpenPaginate = liquidTagOpenRule<"paginate", liquidTagOpenPaginateMarkup>
   liquidTagOpenPaginateMarkup =
-    liquidExpression<delimTag> space+ "by" space+ liquidExpression<delimTag> argumentSeparatorOptionalComma tagArguments space*
+    liquidExpression<delimTag> space+ "by" space+ liquidExpression<delimTag> argumentSeparatorOptionalComma tagArguments (space* ",")? space*
 
   liquidDrop = "{{" "-"? space* liquidDropCases "-"? "}}"
   liquidDropCases = liquidVariable<delimVO> | liquidDropBaseCase
@@ -250,7 +250,7 @@ Liquid <: Helpers {
   indexLookup<delim> = space* "[" space* liquidExpression<delim> space* "]"
   dotLookup = space* "." space* identifier
 
-  liquidFilter<delim> = space* "|" space* identifier (space* ":" space* arguments<delim>)?
+  liquidFilter<delim> = space* "|" space* identifier (space* ":" space* arguments<delim> (space* ",")?)?
 
   arguments<delim> = nonemptyOrderedListOf<positionalArgument<delim>, namedArgument<delim>, argumentSeparator>
   argumentSeparator = space* "," space*

--- a/packages/liquid-html-parser/src/grammar.spec.ts
+++ b/packages/liquid-html-parser/src/grammar.spec.ts
@@ -42,6 +42,11 @@ describe('Unit: liquidHtmlGrammar', () => {
         expectMatchSucceeded(`{% style %}{% endstyle %}`).to.be.true;
         expectMatchSucceeded(`{% stylesheet %}{% endstylesheet %}`).to.be.true;
         expectMatchSucceeded(`{% assign variable_name = value %}`).to.be.true;
+        expectMatchSucceeded(`{% render "product", %}`).to.be.true;
+        expectMatchSucceeded(`{% render "product", product: product, %}`).to.be.true;
+        expectMatchSucceeded(`{% render "product" with foo as bar, %}`).to.be.true;
+        expectMatchSucceeded(`{% echo "product" | split: '', %}`).to.be.true;
+        expectMatchSucceeded(`{{ "product" | split: '', }}`).to.be.true;
         expectMatchSucceeded(`
           {% capture variable %}
             value

--- a/packages/prettier-plugin-liquid/src/test/liquid-drop-filters/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-drop-filters/fixed.liquid
@@ -79,3 +79,6 @@ It should support all types of named arguments, and add spaces
 
 It should support spaces or lack of thereof erywhere
 {{ x | f: a: b, range: (a..b) }}
+
+It should strip trailing commas by default
+{{ x | split: '' }}

--- a/packages/prettier-plugin-liquid/src/test/liquid-drop-filters/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-drop-filters/index.liquid
@@ -53,3 +53,6 @@ It should support spaces or lack of thereof erywhere
 a    :  b  , range
 : ( a .. b)
 }}
+
+It should strip trailing commas by default
+{{x|split:'',}}

--- a/packages/prettier-plugin-liquid/src/test/liquid-tag-render/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-tag-render/fixed.liquid
@@ -51,3 +51,8 @@ It should not require commas (as per syntax) but add them when pretty printed
 
 It should not require spaces (as per syntax) but add them when pretty printed
 {% render 'foo/bar', key1: val1, key2: (0..1) %}
+
+It should strip trailing commas by default
+{% render 'foo' %}
+{% render 'foo', product: product %}
+{% render 'foo' with foo as bar %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-tag-render/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-tag-render/index.liquid
@@ -36,3 +36,8 @@ It should not require commas (as per syntax) but add them when pretty printed
 
 It should not require spaces (as per syntax) but add them when pretty printed
 {%render "foo/bar",key1:val1,key2:(0..1)%}
+
+It should strip trailing commas by default
+{% render "foo", %}
+{% render "foo",product:product, %}
+{% render "foo" with foo as bar, %}


### PR DESCRIPTION
Partially fixes #285

## What are you adding in this PR?

- Add parser trailing comma support for render, echo, form, and Liquid filters
- Prettier behaviour is to not include them
- Fixes document links for tags that didn't parse before this

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
