### PR TITLE
Fix required optional setting validation

### DIFF
--- a/.changeset/metal-weeks-lie.md
+++ b/.changeset/metal-weeks-lie.md
@@ -1,0 +1,8 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+'@shopify/liquid-html-parser': patch
+'@shopify/theme-check-node': patch
+'@shopify/theme-check-common': patch
+---
+
+Fix config validation problem that required optional settings

--- a/packages/theme-check-node/configs/nothing.yml
+++ b/packages/theme-check-node/configs/nothing.yml
@@ -1,0 +1,3 @@
+extends: []
+ignore:
+  - node_modules/**

--- a/packages/theme-check-node/src/config/load-config.spec.ts
+++ b/packages/theme-check-node/src/config/load-config.spec.ts
@@ -49,6 +49,12 @@ describe('Unit: loadConfig', () => {
     expect(config.checks).to.be.empty;
   });
 
+  it('loads the nothing config', async () => {
+    const configPath = await createMockConfigFile(tempDir, `extends: nothing`);
+    const config = await loadConfig(configPath, tempDir);
+    expect(config.checks).to.eql([]);
+  });
+
   it('loads the recommended config', async () => {
     const configPath = await createMockConfigFile(tempDir, `extends: theme-check:recommended`);
     const config = await loadConfig(configPath, tempDir);

--- a/packages/theme-check-node/src/config/resolve/read-yaml.spec.ts
+++ b/packages/theme-check-node/src/config/resolve/read-yaml.spec.ts
@@ -154,7 +154,7 @@ describe('Unit: readYamlConfigDescription', () => {
         {
           testCase: 'translates legacy [`:nothing`] to []',
           extendsValue: [':nothing'],
-          expected: [],
+          expected: ['theme-check:nothing'],
         },
       ];
 

--- a/packages/theme-check-node/src/config/resolve/resolve-config.spec.ts
+++ b/packages/theme-check-node/src/config/resolve/resolve-config.spec.ts
@@ -109,7 +109,11 @@ SomeCheck:
     for (const modernIdentifier of ModernIdentifiers) {
       const filePath = await createMockYamlFile(`extends: ${modernIdentifier}`);
       const config = await resolveConfig(filePath);
-      expect(config.checkSettings.ParserBlockingScript!.enabled).to.be.true;
+      if (modernIdentifier === 'theme-check:nothing') {
+        expect(config.checkSettings.ParserBlockingScript).not.to.exist;
+      } else {
+        expect(config.checkSettings.ParserBlockingScript!.enabled).to.be.true;
+      }
     }
   });
 

--- a/packages/theme-check-node/src/config/types.ts
+++ b/packages/theme-check-node/src/config/types.ts
@@ -27,6 +27,7 @@ export interface ConfigFragment {
 export type ConfigDescription = Omit<ConfigFragment, 'extends'> & { extends: [] };
 
 export const ModernIdentifiers = [
+  'theme-check:nothing',
   'theme-check:recommended',
   'theme-check:theme-app-extension',
   'theme-check:all',
@@ -37,7 +38,7 @@ export type ModernIdentifier = (typeof ModernIdentifiers)[number];
 export const LegacyIdentifiers = new Map(
   Object.entries({
     default: 'theme-check:recommended',
-    nothing: undefined,
+    nothing: 'theme-check:nothing',
     theme_app_extensions: 'theme-check:theme-app-extension',
   }),
 );

--- a/packages/theme-check-node/src/config/validation.ts
+++ b/packages/theme-check-node/src/config/validation.ts
@@ -48,7 +48,7 @@ function validateValue(key: string, value: unknown, schemaProp: SchemaProp<any>)
   const { type, optional, defaultValue, properties, itemType } = schemaProp.options;
 
   if (value === undefined) {
-    if (optional !== true) {
+    if (optional !== true && defaultValue === undefined) {
       throw new Error(`Missing required setting: ${key}`);
     }
     return;


### PR DESCRIPTION
Weird thing happened where core accepts undefined but not the validation rule because of a branch in our code.

Also found out that --config is required for the CLI... what?

Fixes #276

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
