### PR TITLE
The loadConfig export should do the default findConfigPath

### DIFF
--- a/.changeset/healthy-rules-stare.md
+++ b/.changeset/healthy-rules-stare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': patch
+---
+
+Fix loadConfig export to automatically select .theme-check.yml if present

--- a/packages/theme-check-node/src/config/load-config.spec.ts
+++ b/packages/theme-check-node/src/config/load-config.spec.ts
@@ -79,7 +79,7 @@ describe('Unit: loadConfig', () => {
       tempDir,
       `extends: theme-check:theme-app-extension`,
     );
-    const config = await loadConfig(configPath);
+    const config = await loadConfig(configPath, path.dirname(configPath));
 
     const ParserBlockingScript = check('ParserBlockingScript')!;
     expect(config.checks).to.include(ParserBlockingScript);
@@ -90,7 +90,7 @@ describe('Unit: loadConfig', () => {
 
   it('loads a compound config, with overrides', async () => {
     const configPath = path.resolve(__dirname, 'fixtures/theme-app-extension-with-overrides.yml');
-    const config = await loadConfig(configPath);
+    const config = await loadConfig(configPath, path.dirname(configPath));
 
     const ParserBlockingScript = check('ParserBlockingScript')!;
     expect(config.checks).not.to.include(ParserBlockingScript);
@@ -102,7 +102,7 @@ describe('Unit: loadConfig', () => {
 
   it('loads a multi-compound config, with overrides', async () => {
     const configPath = path.resolve(__dirname, 'fixtures/multi-compound.yml');
-    const config = await loadConfig(configPath);
+    const config = await loadConfig(configPath, path.dirname(configPath));
 
     expect(config.settings.ImgWidthAndHeight!.ignore).to.eql(['snippets/**']);
 
@@ -119,7 +119,7 @@ describe('Unit: loadConfig', () => {
 
   it('merges the ignore attribute with the default one', async () => {
     const configPath = path.resolve(__dirname, 'fixtures/with-ignore.yml');
-    const config = await loadConfig(configPath);
+    const config = await loadConfig(configPath, path.dirname(configPath));
     expect(config.ignore).to.include('node_modules/**');
     expect(config.ignore).to.include('src/**');
   });

--- a/packages/theme-check-node/src/config/load-config.ts
+++ b/packages/theme-check-node/src/config/load-config.ts
@@ -19,9 +19,7 @@ export async function loadConfig(
   /** The absolute path of config file */
   configPath: AbsolutePath | ModernIdentifier | undefined,
   /** The root of the theme */
-  root: AbsolutePath | undefined = configPath && !ModernIdentifiers.includes(configPath as any)
-    ? path.dirname(configPath)
-    : undefined,
+  root: AbsolutePath,
 ): Promise<Config> {
   if (!root) throw new Error('loadConfig cannot be called without a root argument');
   const configDescription = await resolveConfig(configPath ?? 'theme-check:recommended', true);

--- a/packages/theme-check-node/src/index.spec.ts
+++ b/packages/theme-check-node/src/index.spec.ts
@@ -1,8 +1,0 @@
-import { describe, it, expect } from 'vitest';
-import { check } from './index';
-
-describe('Module: check', () => {
-  it('should exist', () => {
-    expect(check).to.exist;
-  });
-});

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -15,7 +15,7 @@ import glob = require('glob');
 import { ThemeLiquidDocsManager } from '@shopify/theme-check-docs-updater';
 
 import { fileExists, fileSize } from './file-utils';
-import { loadConfig, findConfigPath } from './config';
+import { loadConfig as resolveConfig, findConfigPath } from './config';
 import { autofix } from './autofix';
 
 const defaultLocale = 'en';
@@ -23,7 +23,11 @@ const asyncGlob = promisify(glob);
 
 export * from '@shopify/theme-check-common';
 export * from './config/types';
-export { loadConfig };
+
+export const loadConfig: typeof resolveConfig = async (configPath, root) => {
+  configPath ??= await findConfigPath(root);
+  return resolveConfig(configPath, root);
+};
 
 export type ThemeCheckRun = {
   theme: Theme;
@@ -88,7 +92,6 @@ async function getThemeAndConfig(
   root: string,
   configPath?: string,
 ): Promise<{ theme: Theme; config: Config }> {
-  configPath = configPath ?? (await findConfigPath(root));
   const config = await loadConfig(configPath, root);
   const theme = await getTheme(config);
   return {


### PR DESCRIPTION
## What are you adding in this PR?

- Fixes a bug in the CLI where `.theme-check.yml` isn't picked up automatically by `--print` and `--list`.

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
