### PR TITLE
Theme Tools Release: 15-02-24

### DIFF
--- a/.changeset/wicked-radios-watch.md
+++ b/.changeset/wicked-radios-watch.md
@@ -1,8 +1,0 @@
----
-'@shopify/theme-check-docs-updater': patch
-'theme-check-vscode': patch
----
-
-Include docset fallbacks in the theme-check-docs-updater package
-
-For when a user’s Internet connection is down or https://raw.githubusercontent.com is not accessible.

--- a/packages/theme-check-browser/CHANGELOG.md
+++ b/packages/theme-check-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-check-browser
 
+## 2.0.4
+
+### Patch Changes
+
+- @shopify/theme-check-common@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/theme-check-browser/package.json
+++ b/packages/theme-check-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-browser",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -26,6 +26,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "2.0.3"
+    "@shopify/theme-check-common": "2.0.4"
   }
 }

--- a/packages/theme-check-common/CHANGELOG.md
+++ b/packages/theme-check-common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @shopify/theme-check-common
 
+## 2.0.4
+
 ## 2.0.3
 
 ## 2.0.2

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-common",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/theme-check-docs-updater/CHANGELOG.md
+++ b/packages/theme-check-docs-updater/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @shopify/theme-check-docs-updater
 
+## 2.0.4
+
+### Patch Changes
+
+- 84f9eda: Include docset fallbacks in the theme-check-docs-updater package
+
+  For when a user’s Internet connection is down or https://raw.githubusercontent.com is not accessible.
+
+  - @shopify/theme-check-common@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-docs-updater",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Scripts to initialize theme-check data with assets from the theme-liquid-docs repo.",
   "main": "dist/index.js",
   "author": "Albert Chu <albert.chu@shopify.com>",
@@ -30,7 +30,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "^2.0.3",
+    "@shopify/theme-check-common": "^2.0.4",
     "ajv": "^8.12.0",
     "env-paths": "^2.2.1",
     "node-fetch": "^2.6.11"

--- a/packages/theme-check-node/CHANGELOG.md
+++ b/packages/theme-check-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/theme-check-node
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [84f9eda]
+  - @shopify/theme-check-docs-updater@2.0.4
+  - @shopify/theme-check-common@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-node",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -33,8 +33,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "2.0.3",
-    "@shopify/theme-check-docs-updater": "2.0.3",
+    "@shopify/theme-check-common": "2.0.4",
+    "@shopify/theme-check-docs-updater": "2.0.4",
     "glob": "^8.0.3",
     "yaml": "^2.3.0"
   },

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-language-server-browser
 
+## 1.7.7
+
+### Patch Changes
+
+- @shopify/theme-language-server-common@1.7.7
+
 ## 1.7.6
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.7.6",
+    "@shopify/theme-language-server-common": "1.7.7",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-language-server-common
 
+## 1.7.7
+
+### Patch Changes
+
+- @shopify/theme-check-common@2.0.4
+
 ## 1.7.6
 
 ### Patch Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.0.3",
-    "@shopify/theme-check-common": "2.0.3",
+    "@shopify/theme-check-common": "2.0.4",
     "@vscode/web-custom-data": "^0.4.6",
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.8",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-language-server-node
 
+## 1.7.7
+
+### Patch Changes
+
+- Updated dependencies [84f9eda]
+  - @shopify/theme-check-docs-updater@2.0.4
+  - @shopify/theme-check-node@2.0.4
+  - @shopify/theme-language-server-common@1.7.7
+
 ## 1.7.6
 
 ### Patch Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,9 +27,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.7.6",
-    "@shopify/theme-check-node": "^2.0.3",
-    "@shopify/theme-check-docs-updater": "^2.0.3",
+    "@shopify/theme-language-server-common": "1.7.7",
+    "@shopify/theme-check-node": "^2.0.4",
+    "@shopify/theme-check-docs-updater": "^2.0.4",
     "glob": "^8.0.3",
     "node-fetch": "^2.6.11",
     "vscode-languageserver": "^8.0.2",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## theme-check-vscode
 
+## 2.0.4
+
+### Patch Changes
+
+- 84f9eda: Include docset fallbacks in the theme-check-docs-updater package
+
+  For when a user’s Internet connection is down or https://raw.githubusercontent.com is not accessible.
+
+  - @shopify/theme-language-server-node@1.7.7
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/shopify/theme-tools/issues"
   },
-  "version": "2.0.3",
+  "version": "2.0.4",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -60,12 +60,12 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.0.3",
     "@shopify/prettier-plugin-liquid": "^1.4.3",
-    "@shopify/theme-language-server-node": "^1.7.6",
+    "@shopify/theme-language-server-node": "^1.7.7",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0"
   },
   "devDependencies": {
-    "@shopify/theme-check-docs-updater": "^2.0.3",
+    "@shopify/theme-check-docs-updater": "^2.0.4",
     "@types/glob": "^8.0.0",
     "@types/node": "16.x",
     "@types/prettier": "^2.4.2",


### PR DESCRIPTION
# Releases
## `@shopify/theme-check-docs-updater`
Patch incremented `2.0.3` -> `2.0.4`
### Changes:
- Include docset fallbacks in the theme-check-docs-updater package

For when a user’s Internet connection is down or https://raw.githubusercontent.com is not accessible.

## `theme-check-vscode`
Patch incremented `2.0.3` -> `2.0.4`
### Changes:
- Include docset fallbacks in the theme-check-docs-updater package

For when a user’s Internet connection is down or https://raw.githubusercontent.com is not accessible.

## `@shopify/theme-check-node`
Patch incremented `2.0.3` -> `2.0.4`

## `@shopify/theme-check-browser`
Patch incremented `2.0.3` -> `2.0.4`

## `@shopify/theme-check-common`
Patch incremented `2.0.3` -> `2.0.4`

## `@shopify/theme-language-server-common`
Patch incremented `1.7.6` -> `1.7.7`

## `@shopify/theme-language-server-browser`
Patch incremented `1.7.6` -> `1.7.7`

## `@shopify/theme-language-server-node`
Patch incremented `1.7.6` -> `1.7.7`

