### PR TITLE
fix: prettier plugin liquid number starting index variable lookup

### DIFF
--- a/.changeset/swift-deers-rhyme.md
+++ b/.changeset/swift-deers-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+---
+
+Fix pretty printing of keys that start with numbers

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -515,9 +515,9 @@ function printNode(
           case NodeTypes.String: {
             const value = lookup.value;
             // We prefer direct access
-            // (for everything but stuff with dashes)
+            // (for everything but stuff with dashes and stuff that starts with a number)
             const isGlobalStringLookup = index === 0 && !node.name;
-            if (!isGlobalStringLookup && /^[a-z0-9_]+\??$/i.test(value)) {
+            if (!isGlobalStringLookup && /^\D/.test(value) && /^[a-z0-9_]+\??$/i.test(value)) {
               return ['.', value];
             }
             return ['[', print(lookupPath), ']'];

--- a/packages/prettier-plugin-liquid/src/test/liquid-drop-variable-lookup/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-drop-variable-lookup/fixed.liquid
@@ -23,6 +23,9 @@ It should support number access
 It should index access strings with spaces
 {{ x.y['hello world'] }}
 
+It should index access strings starting with numbers
+{{ x.y['20back'] }}
+
 It should respect singleQuote
 liquidSingleQuote: false
 {{ x.y["hello world"] }}

--- a/packages/prettier-plugin-liquid/src/test/liquid-drop-variable-lookup/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-drop-variable-lookup/index.liquid
@@ -23,6 +23,9 @@ It should support number access
 It should index access strings with spaces
 {{ x["y"]["hello world"] }}
 
+It should index access strings starting with numbers
+{{ x["y"]["20back"] }}
+
 It should respect singleQuote
 liquidSingleQuote: false
 {{ x["y"]["hello world"] }}


### PR DESCRIPTION
## What are you adding in this PR?

- Reopening #294, so we can validate CI before merging
- fix: prettier plugin liquid number starting index variable lookup
- Add patch changeset

Thank you @BJvdA!

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
