### PR TITLE
Add CompletionList return type support in completion request handler

### DIFF
--- a/.changeset/tame-spies-relate.md
+++ b/.changeset/tame-spies-relate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/codemirror-language-client': minor
+---
+
+Add `CompletionList` return type support in completion handler

--- a/packages/codemirror-language-client/src/extensions/complete.ts
+++ b/packages/codemirror-language-client/src/extensions/complete.ts
@@ -9,6 +9,7 @@ import {
 import {
   CompletionItem,
   CompletionItemKind,
+  CompletionList,
   CompletionRequest,
   InsertReplaceEdit,
   TextEdit,
@@ -62,12 +63,9 @@ export async function complete(context: CompletionContext): Promise<CompletionRe
   // No results
   if (results === null) return null;
 
-  // CompletionList not supported
-  if (!Array.isArray(results)) return null;
-
   return {
     from: word.from,
-    options: results.map(
+    options: items(results).map(
       (completionItem): Completion => ({
         label: completionItem.insertText ?? completionItem.label,
         displayLabel: completionItem.label,
@@ -193,4 +191,18 @@ function applyEdit(
       insert: newText,
     }),
   });
+}
+
+function isCompletionList(results: CompletionList | CompletionItem[]): results is CompletionList {
+  return (results as CompletionList).isIncomplete !== undefined;
+}
+
+function items(results: CompletionList | CompletionItem[]): CompletionItem[] {
+  if (isCompletionList(results)) {
+    return (results as CompletionList).items.map((item) => ({
+      ...results.itemDefaults,
+      ...item,
+    }));
+  }
+  return results;
 }


### PR DESCRIPTION
## What are you adding in this PR?

The `JSONLanguageService` responds to with `textDocument/completion` requests with `CompletionList`s instead of `CompletionItem[]`.

This PR adds support in `@shopify/codemirror-language-client` for such return values.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
