### PR TITLE
Unify root finding algo for node LS and TC packages

### DIFF
--- a/.changeset/real-phones-give.md
+++ b/.changeset/real-phones-give.md
@@ -1,0 +1,13 @@
+---
+'@shopify/theme-language-server-node': patch
+'@shopify/theme-check-node': patch
+---
+
+Improve root finding of theme app extensions and zipped themes
+
+Folders for which all the following is true are considered a root:
+- have a `snippets/` folder, and
+- don't have a `../.theme-check.yml`,
+- don't have a `../../.theme-check.yml`.
+
+No config file or `.git` folder required.

--- a/.changeset/rude-months-argue.md
+++ b/.changeset/rude-months-argue.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': minor
+---
+
+Add `{findRoot, reusableFindRoot, PathHandler}` to the public API

--- a/.changeset/tough-coats-dream.md
+++ b/.changeset/tough-coats-dream.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-node': patch
+'@shopify/theme-check-node': patch
+---
+
+Unify root finding algorithm for node LS and TC packages

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "typescript": "^4.9.3",
-    "vitest": "^1.3.0",
+    "vitest": "^1.3.1",
     "vscode-languageserver-protocol": "^3.17.3",
     "vscode-languageserver-textdocument": "^1.0.8",
     "webpack": "^5.76.0",

--- a/packages/theme-check-common/src/checks/asset-size-css/index.spec.ts
+++ b/packages/theme-check-common/src/checks/asset-size-css/index.spec.ts
@@ -82,7 +82,8 @@ describe('Module: AssetSizeCSS', () => {
       end: { index: 122 },
     });
   });
-  it('should not report any offenses if CSS is smaller than threshold', async () => {
+
+  it('should not report any offenses if CSS is smaller than threshold 2', async () => {
     const extensionFiles: MockTheme = {
       'assets/theme.css': 'console.log("hello world");',
       'templates/index.liquid': `
@@ -100,7 +101,7 @@ describe('Module: AssetSizeCSS', () => {
     expect(offenses).toHaveLength(0);
   });
 
-  it('should report an offense if CSS is larger than threshold', async () => {
+  it('should report an offense if CSS is larger than threshold 2', async () => {
     const extensionFiles: MockTheme = {
       'assets/theme.css': 'console.log("hello world");',
       'templates/index.liquid': `

--- a/packages/theme-check-node/src/file-utils.ts
+++ b/packages/theme-check-node/src/file-utils.ts
@@ -15,7 +15,9 @@ export const fileSize: NonNullable<Dependencies['fileSize']> = async (path: stri
     const stats = await fs.stat(path);
     return stats.size;
   } catch (error) {
-    console.error(`Failed to get file size: ${error}`);
+    if (process.env.SHOPIFY_FLAG_VERBOSE || process.argv.includes('--verbose')) {
+      console.error(`Failed to get file size: ${error}`);
+    }
     return 0;
   }
 };

--- a/packages/theme-check-node/src/find-root.spec.ts
+++ b/packages/theme-check-node/src/find-root.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import { findRoot } from './find-root';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as mktemp from 'mktemp';
+
+const theme = {
+  locales: {
+    'en.default.json': JSON.stringify({ beverage: 'coffee' }),
+    'fr.json': '{}',
+  },
+  snippets: {
+    'header.liquid': '',
+  },
+};
+
+describe('Unit: findRoot', () => {
+  let workspace: Workspace;
+
+  beforeAll(async () => {
+    // We're intentionally not mocking here because we want to make sure
+    // this works on Windows as well.
+    workspace = await makeTempWorkspace({
+      zipTheme: {
+        ...theme,
+      },
+      gitRootTheme: {
+        '.git': { HEAD: '' },
+        ...theme,
+      },
+      configRootTheme: {
+        '.theme-check.yml': '',
+        ...theme,
+      },
+      multiRootTheme: {
+        '.theme-check.yml': 'root: ./dist',
+        dist: {
+          ...theme,
+        },
+        src: {
+          '.theme-check.yml': '',
+          ...theme,
+        },
+      },
+      appWithThemeAppExtension: {
+        extensions: {
+          myThemeAppExtension: {
+            ...theme,
+            'shopify.extension.toml': '',
+          },
+        },
+      },
+      appWithThemeAppExtensionNoConfig: {
+        extensions: {
+          myThemeAppExtension: {
+            ...theme,
+          },
+        },
+      },
+      taeRootThemeCheckYML: {
+        '.theme-check.yml': '',
+        extensions: {
+          myThemeAppExtension: {
+            ...theme,
+          },
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await workspace.clean();
+  });
+
+  it('finds the root of a zipped theme', async () => {
+    const root = await findRoot(workspace.path('zipTheme'));
+    expect(root).toBe(workspace.path('zipTheme'));
+  });
+
+  it('finds the root of a theme with a .git folder', async () => {
+    const root = await findRoot(workspace.path('gitRootTheme'));
+    expect(root).toBe(workspace.path('gitRootTheme'));
+  });
+
+  it('finds the root of a theme with a .theme-check.yml file', async () => {
+    const root = await findRoot(workspace.path('configRootTheme'));
+    expect(root).toBe(workspace.path('configRootTheme'));
+  });
+
+  it('finds the root of a theme with a .theme-check.yml file in a subdirectory with', async () => {
+    const root = await findRoot(workspace.path('multiRootTheme/dist/snippets/header.liquid'));
+    expect(root).toBe(workspace.path('multiRootTheme'));
+  });
+
+  it('finds the root of a theme with a .theme-check.yml file in a subdirectory', async () => {
+    const root = await findRoot(workspace.path('multiRootTheme/src/snippets/header.liquid'));
+    expect(root).toBe(workspace.path('multiRootTheme/src'));
+  });
+
+  it('finds the root of a theme app extension with a shopify.extension.toml file', async () => {
+    const root = await findRoot(
+      workspace.path('appWithThemeAppExtension/extensions/myThemeAppExtension'),
+    );
+    expect(root).toBe(workspace.path('appWithThemeAppExtension/extensions/myThemeAppExtension'));
+  });
+
+  it('finds the root of a theme app extension without a shopify.extension.toml file', async () => {
+    const root = await findRoot(
+      workspace.path('appWithThemeAppExtensionNoConfig/extensions/myThemeAppExtension'),
+    );
+    expect(root).toBe(
+      workspace.path('appWithThemeAppExtensionNoConfig/extensions/myThemeAppExtension'),
+    );
+  });
+
+  it('finds the root of a theme app extension with a .theme-check.yml file', async () => {
+    const root = await findRoot(
+      workspace.path('taeRootThemeCheckYML/extensions/myThemeAppExtension'),
+    );
+    expect(root).toBe(workspace.path('taeRootThemeCheckYML'));
+  });
+});
+
+type Tree = {
+  [k in string]: Tree | string;
+};
+
+interface Workspace {
+  root: string;
+  path(relativePath: string): string;
+  clean(): Promise<any>;
+}
+
+async function makeTempWorkspace(structure: Tree): Promise<Workspace> {
+  const root = await mktemp.createDir(path.join(__dirname, '..', '.XXXXX'));
+  if (!root) throw new Error('Could not create temp dir for temp workspace');
+
+  await createFiles(structure, [root]);
+
+  return {
+    root,
+    path: (relativePath) => path.join(root, ...relativePath.split('/')),
+    clean: async () => fs.rm(root, { recursive: true, force: true }),
+  };
+
+  function createFiles(tree: Tree, ancestors: string[]): Promise<any> {
+    const promises: Promise<any>[] = [];
+    for (const [pathEl, value] of Object.entries(tree)) {
+      if (typeof value === 'string') {
+        promises.push(fs.writeFile(path.join(...ancestors, pathEl), value, 'utf8'));
+      } else {
+        promises.push(
+          fs
+            .mkdir(path.join(...ancestors, pathEl))
+            .then(() => createFiles(value, ancestors.concat(pathEl))),
+        );
+      }
+    }
+    return Promise.all(promises);
+  }
+}

--- a/packages/theme-check-node/src/find-root.ts
+++ b/packages/theme-check-node/src/find-root.ts
@@ -1,0 +1,89 @@
+import * as path from 'path';
+import { fileExists } from './file-utils';
+import { AbsolutePath } from '@shopify/theme-check-common';
+
+export interface PathHandler<T> {
+  join(base: T, ...paths: (T | string)[]): AbsolutePath;
+  dirname(path: T): T;
+  asPath(path: T): string;
+}
+
+async function isRoot<T>(dir: T, path: PathHandler<T>) {
+  return or(
+    fileExists(path.join(dir, 'shopify.extension.toml')), // for theme-app-extensions
+    fileExists(path.join(dir, '.theme-check.yml')),
+    fileExists(path.join(dir, '.git')),
+
+    // zip files and TAEs might not have config files, but they should have a
+    // snippets directory but in case they do specify a .theme-check.yml a
+    // couple of directories up, we should respect that
+    and(
+      fileExists(path.join(dir, 'snippets')),
+      not(fileExists(path.join(path.dirname(dir), '.theme-check.yml'))),
+      not(fileExists(path.join(path.dirname(path.dirname(dir)), '.theme-check.yml'))),
+    ),
+  );
+}
+
+async function and(...promises: Promise<boolean>[]) {
+  const bools = await Promise.all(promises);
+  return bools.reduce((a, b) => a && b, true);
+}
+
+async function or(...promises: Promise<boolean>[]) {
+  const bools = await Promise.all(promises);
+  return bools.reduce((a, b) => a || b, false);
+}
+
+async function not(ap: Promise<boolean>) {
+  const a = await ap;
+  return !a;
+}
+
+const FilePathHandler: PathHandler<string> = {
+  join(base: string, ...paths: string[]): string {
+    return path.join(base, ...paths);
+  },
+
+  dirname(pathStr: string): string {
+    return path.dirname(pathStr);
+  },
+
+  asPath(pathStr: string): string {
+    return pathStr;
+  },
+};
+
+/**
+ * This more complex version of findRoot is used in the language server so that we can
+ * use URIs instead of strings. It's also used in the CLI.
+ */
+export async function reusableFindRoot<T>(curr: T, path: PathHandler<T>): Promise<T> {
+  const currIsRoot = await isRoot(curr, path);
+  if (currIsRoot) {
+    return curr;
+  }
+
+  const dir = path.dirname(curr);
+  const currIsAbsoluteRoot = dir === curr;
+  if (currIsAbsoluteRoot) {
+    return curr;
+  }
+
+  return reusableFindRoot(dir, path);
+}
+
+/**
+ * Returns the "root" of a theme or theme app extension. The root is the
+ * directory that contains a `.theme-check.yml` file, a `.git` directory, or a
+ * `shopify.extension.toml` file.
+ *
+ * There are cases where .theme-check.yml is not defined and we have to infer the root.
+ * We'll assume that the root is the directory that contains a `snippets` directory.
+ *
+ * So you can think of this function as the function that infers where a .theme-check.yml
+ * should be.
+ */
+export async function findRoot(curr: AbsolutePath): Promise<AbsolutePath> {
+  return reusableFindRoot(curr, FilePathHandler);
+}

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -4,25 +4,26 @@ import {
   LiquidSourceCode,
   Offense,
   Theme,
-  check as coreCheck,
   toSourceCode as commonToSourceCode,
+  check as coreCheck,
   isIgnored,
 } from '@shopify/theme-check-common';
-import { promisify } from 'node:util';
-import path from 'node:path';
-import fs from 'node:fs/promises';
-import glob = require('glob');
 import { ThemeLiquidDocsManager } from '@shopify/theme-check-docs-updater';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import glob = require('glob');
 
-import { fileExists, fileSize } from './file-utils';
-import { loadConfig as resolveConfig, findConfigPath } from './config';
 import { autofix } from './autofix';
+import { findConfigPath, loadConfig as resolveConfig } from './config';
+import { fileExists, fileSize } from './file-utils';
 
 const defaultLocale = 'en';
 const asyncGlob = promisify(glob);
 
 export * from '@shopify/theme-check-common';
 export * from './config/types';
+export { PathHandler, findRoot, reusableFindRoot } from './find-root';
 
 export const loadConfig: typeof resolveConfig = async (configPath, root) => {
   configPath ??= await findConfigPath(root);

--- a/packages/theme-language-server-node/src/dependencies.spec.ts
+++ b/packages/theme-language-server-node/src/dependencies.spec.ts
@@ -140,6 +140,27 @@ describe('Module: dependencies', () => {
     it('should return true for directories', async () => {
       expect(await fileExists(workspace.path('gitRootTheme/snippets'))).to.be.true;
     });
+
+    it('should accurately return whether a file exists in workspace', async () => {
+      // Create a temporary file
+      const tempFilePath = path.join(workspace.root, 'temp.txt');
+      await fs.writeFile(tempFilePath, 'Hello, world!', 'utf8');
+
+      // Use the fileExists function to check if the file exists
+      const exists = await fileExists(tempFilePath);
+
+      // Check that the file exists
+      expect(exists).to.be.true;
+
+      // Delete the file
+      await fs.unlink(tempFilePath);
+
+      // Use the fileExists function to check if the file exists
+      const notExists = await fileExists(tempFilePath);
+
+      // Check that the file does not exist
+      expect(notExists).to.be.false;
+    });
   });
 
   describe('Unit: getDefaultLocale', () => {
@@ -198,29 +219,6 @@ describe('Module: dependencies', () => {
         // If the function throws an error, pass the test
         expect(err.message).to.include('Failed to get file size');
       }
-    });
-  });
-
-  describe('Unit: fileExists', () => {
-    it('should accurately return whether a file exists', async () => {
-      // Create a temporary file
-      const tempFilePath = path.join(workspace.root, 'temp.txt');
-      await fs.writeFile(tempFilePath, 'Hello, world!', 'utf8');
-
-      // Use the fileExists function to check if the file exists
-      const exists = await fileExists(tempFilePath);
-
-      // Check that the file exists
-      expect(exists).to.be.true;
-
-      // Delete the file
-      await fs.unlink(tempFilePath);
-
-      // Use the fileExists function to check if the file exists
-      const notExists = await fileExists(tempFilePath);
-
-      // Check that the file does not exist
-      expect(notExists).to.be.false;
     });
   });
 });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,4 +1,3 @@
-import path from 'path';
 import { defineConfig } from 'vite';
 import { configDefaults } from 'vitest/config';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,44 +1058,44 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
-"@vitest/expect@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@vitest/expect/-/expect-1.3.0.tgz#09b374357b51be44f4fba9336d59024756f902dc"
-  integrity sha512-7bWt0vBTZj08B+Ikv70AnLRicohYwFgzNjFqo9SxxqHHxSlUJGSXmCRORhOnRMisiUryKMdvsi1n27Bc6jL9DQ==
+"@vitest/expect@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/@vitest/expect/-/expect-1.3.1.tgz#d4c14b89c43a25fd400a6b941f51ba27fe0cb918"
+  integrity sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==
   dependencies:
-    "@vitest/spy" "1.3.0"
-    "@vitest/utils" "1.3.0"
+    "@vitest/spy" "1.3.1"
+    "@vitest/utils" "1.3.1"
     chai "^4.3.10"
 
-"@vitest/runner@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@vitest/runner/-/runner-1.3.0.tgz#1fabbe8d13642473e1acc3450b4df67cf40ae9d1"
-  integrity sha512-1Jb15Vo/Oy7mwZ5bXi7zbgszsdIBNjc4IqP8Jpr/8RdBC4nF1CTzIAn2dxYvpF1nGSseeL39lfLQ2uvs5u1Y9A==
+"@vitest/runner@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/@vitest/runner/-/runner-1.3.1.tgz#e7f96cdf74842934782bfd310eef4b8695bbfa30"
+  integrity sha512-5FzF9c3jG/z5bgCnjr8j9LNq/9OxV2uEBAITOXfoe3rdZJTdO7jzThth7FXv/6b+kdY65tpRQB7WaKhNZwX+Kg==
   dependencies:
-    "@vitest/utils" "1.3.0"
+    "@vitest/utils" "1.3.1"
     p-limit "^5.0.0"
     pathe "^1.1.1"
 
-"@vitest/snapshot@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.3.0.tgz#016b34289d87ef0c64f4cdb9173086c2edf1db7b"
-  integrity sha512-swmktcviVVPYx9U4SEQXLV6AEY51Y6bZ14jA2yo6TgMxQ3h+ZYiO0YhAHGJNp0ohCFbPAis1R9kK0cvN6lDPQA==
+"@vitest/snapshot@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.3.1.tgz#193a5d7febf6ec5d22b3f8c5a093f9e4322e7a88"
+  integrity sha512-EF++BZbt6RZmOlE3SuTPu/NfwBF6q4ABS37HHXzs2LUVPBLx2QoY/K0fKpRChSo8eLiuxcbCVfqKgx/dplCDuQ==
   dependencies:
     magic-string "^0.30.5"
     pathe "^1.1.1"
     pretty-format "^29.7.0"
 
-"@vitest/spy@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@vitest/spy/-/spy-1.3.0.tgz#1faab30e364324e9826887d479e71c03299fe77b"
-  integrity sha512-AkCU0ThZunMvblDpPKgjIi025UxR8V7MZ/g/EwmAGpjIujLVV2X6rGYGmxE2D4FJbAy0/ijdROHMWa2M/6JVMw==
+"@vitest/spy@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/@vitest/spy/-/spy-1.3.1.tgz#814245d46d011b99edd1c7528f5725c64e85a88b"
+  integrity sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==
   dependencies:
     tinyspy "^2.2.0"
 
-"@vitest/utils@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@vitest/utils/-/utils-1.3.0.tgz#7d46aa00617c1720b075eaeb4c4979a712d86c8e"
-  integrity sha512-/LibEY/fkaXQufi4GDlQZhikQsPO2entBKtfuyIpr1jV4DpaeasqkeHjhdOhU24vSHshcSuEyVlWdzvv2XmYCw==
+"@vitest/utils@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/@vitest/utils/-/utils-1.3.1.tgz#7b05838654557544f694a372de767fcc9594d61a"
+  integrity sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==
   dependencies:
     diff-sequences "^29.6.3"
     estree-walker "^3.0.3"
@@ -6065,10 +6065,10 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vite-node@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/vite-node/-/vite-node-1.3.0.tgz#618cc26d83545cfbd4e2c3014678257496d2bd00"
-  integrity sha512-D/oiDVBw75XMnjAXne/4feCkCEwcbr2SU1bjAhCcfI5Bq3VoOHji8/wCPAfUkDIeohJ5nSZ39fNxM3dNZ6OBOA==
+vite-node@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/vite-node/-/vite-node-1.3.1.tgz#a93f7372212f5d5df38e945046b945ac3f4855d2"
+  integrity sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==
   dependencies:
     cac "^6.7.14"
     debug "^4.3.4"
@@ -6087,16 +6087,16 @@ vite@^5.0.0:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/vitest/-/vitest-1.3.0.tgz#3b04e2a8270b2db0929829cb8f03df7bffd1b5a2"
-  integrity sha512-V9qb276J1jjSx9xb75T2VoYXdO1UKi+qfflY7V7w93jzX7oA/+RtYE6TcifxksxsZvygSSMwu2Uw6di7yqDMwg==
+vitest@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/vitest/-/vitest-1.3.1.tgz#2d7e9861f030d88a4669392a4aecb40569d90937"
+  integrity sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==
   dependencies:
-    "@vitest/expect" "1.3.0"
-    "@vitest/runner" "1.3.0"
-    "@vitest/snapshot" "1.3.0"
-    "@vitest/spy" "1.3.0"
-    "@vitest/utils" "1.3.0"
+    "@vitest/expect" "1.3.1"
+    "@vitest/runner" "1.3.1"
+    "@vitest/snapshot" "1.3.1"
+    "@vitest/spy" "1.3.1"
+    "@vitest/utils" "1.3.1"
     acorn-walk "^8.3.2"
     chai "^4.3.10"
     debug "^4.3.4"
@@ -6110,7 +6110,7 @@ vitest@^1.3.0:
     tinybench "^2.5.1"
     tinypool "^0.8.2"
     vite "^5.0.0"
-    vite-node "1.3.0"
+    vite-node "1.3.1"
     why-is-node-running "^2.2.2"
 
 vscode-json-languageservice@^5.3.9:


### PR DESCRIPTION

## What are you adding in this PR?

- Unify root finding algorithm used by theme-check-node and language-server-node.

- Consider folders for which all the following is true as a root:
  - have a `snippets/` folder, and
  - don't have a `../.theme-check.yml`,
  - don't have a `../../.theme-check.yml`.

- Add `{findRoot, reusableFindRoot, PathHandler}` to the public API of `@shopify/theme-check-node`

This should make TAE and zipped themes resolve a root automatically. No config required.

Fixes #300

## Before you deploy

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
