### PR TITLE
Handle JSON files as JSONC in themes

### DIFF
--- a/.changeset/giant-vans-drive.md
+++ b/.changeset/giant-vans-drive.md
@@ -1,0 +1,5 @@
+---
+'theme-check-vscode': minor
+---
+
+Remove the trailing comma warning in those files, and associate theme JSON files with JSONC

--- a/packages/vscode-extension/allowCommentsSchema.json
+++ b/packages/vscode-extension/allowCommentsSchema.json
@@ -1,0 +1,3 @@
+{
+  "allowTrailingCommas": true
+}

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -164,6 +164,18 @@
         "editor.formatOnType": true
       }
     },
+    "jsonValidation": [
+      {
+        "fileMatch": [
+          "assets/*.json",
+          "config/*.json",
+          "locales/*.json",
+          "sections/*.json",
+          "templates/**/*.json"
+        ],
+        "url": "./allowCommentsSchema.json"
+      }
+    ],
     "languages": [
       {
         "id": "liquid",
@@ -195,6 +207,16 @@
         "extensions": [
           ".scss.liquid",
           ".sass.liquid"
+        ]
+      },
+      {
+        "id": "jsonc",
+        "filenamePatterns": [
+          "**/assets/*.json",
+          "**/config/*.json",
+          "**/locales/*.json",
+          "**/sections/*.json",
+          "**/templates/**/*.json"
         ]
       }
     ],

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -88,6 +88,7 @@ async function startServer(context: ExtensionContext) {
       { scheme: 'file', language: 'css' },
       { scheme: 'file', language: 'scss' },
       { scheme: 'file', language: 'json' },
+      { scheme: 'file', language: 'jsonc' },
     ],
   };
 


### PR DESCRIPTION
## What are you adding in this PR?

- Remove the trailing comma warning in those files
- Associate theme JSON files with JSONC

Fixes Shopify/develop-advanced-edits#174

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn update-configs` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
