### PR TITLE
Fixed - Theme Check: Issue of 0 files being inspected.

### DIFF
--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -102,7 +102,15 @@ async function getThemeAndConfig(
 }
 
 export async function getTheme(config: Config): Promise<Theme> {
-  const paths = await asyncGlob(path.join(config.root, '**/*.{liquid,json}')).then((result) =>
+
+  // On windows machines - the separator provided by path.join is '\' 
+  // however the glob function fails silently since '\' is used to escape glob charater
+  // as mentioned in the documentation of node-glob
+
+  // the path is normalised and '\' are replaced with '/' and then passed to the glob function
+  const normalized_path = path.normalize(path.join(config.root, '**/*.{liquid,json}')).replace(/\\/g, '/');
+  
+  const paths = await asyncGlob(normalized_path).then((result) =>
     // Global ignored paths should not be part of the theme
     result.filter((filePath) => !isIgnored(filePath, config)),
   );


### PR DESCRIPTION
## What are you adding in this PR?

Fixes shopify/cli#3497

The main issue was that on windows, no liquid or json files were being selected despite `'**/*.{liquid,json}'` as the glob function. 

this happens because in windows, the path separator output by path.join is '\' which conflicts with the glob escape character. 

To solve it, have normalized the path and just replaced '\' with  '/' . This should solve this since it wont have any impact on existing linux paths. 

## What's next? Any followup issues?

N/A - 

## What did you learn?
![image](https://github.com/Shopify/theme-tools/assets/1253625/88093b89-ef1f-4f1d-b117-7b330435f768)

