### PR TITLE
Improve completion support in codemirror-language-client

### DIFF
--- a/.changeset/serious-rats-whisper.md
+++ b/.changeset/serious-rats-whisper.md
@@ -1,0 +1,5 @@
+---
+'@shopify/codemirror-language-client': minor
+---
+
+Add snippet completion support

--- a/.changeset/two-llamas-compare.md
+++ b/.changeset/two-llamas-compare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/codemirror-language-client': patch
+---
+
+Respect the trigger characters server capability

--- a/.changeset/witty-items-talk.md
+++ b/.changeset/witty-items-talk.md
@@ -1,0 +1,5 @@
+---
+'@shopify/codemirror-language-client': patch
+---
+
+Add completion context to the completion requests

--- a/packages/codemirror-language-client/package.json
+++ b/packages/codemirror-language-client/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@codemirror/autocomplete": "^6.0.0",
+    "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lint": "^6.2.0",
     "@codemirror/state": "^6.3.0",
     "@codemirror/theme-one-dark": "^6.1.2",

--- a/packages/codemirror-language-client/playground/src/playground.ts
+++ b/packages/codemirror-language-client/playground/src/playground.ts
@@ -1,6 +1,7 @@
 import { basicSetup } from 'codemirror';
 import { EditorView } from '@codemirror/view';
 import { EditorState } from '@codemirror/state';
+import { json } from '@codemirror/lang-json';
 import MarkdownIt from 'markdown-it';
 // import { oneDark } from '@codemirror/theme-one-dark';
 // import { liquid, liquidHighLightStyle } from '@shopify/lang-liquid';
@@ -125,7 +126,7 @@ async function main() {
       doc: JSON.stringify(exampleTranslations, null, 2),
       extensions: [
         basicSetup,
-        // liquid(),
+        json(),
         // liquidHighLightStyle,
         // oneDark,
         client.extension('browser:/locales/en.default.json'),

--- a/packages/codemirror-language-client/src/CodeMirrorLanguageClient.ts
+++ b/packages/codemirror-language-client/src/CodeMirrorLanguageClient.ts
@@ -30,7 +30,10 @@ import { hoverRendererFacet } from './extensions/hover';
 const clientCapabilities: ClientCapabilities = {
   textDocument: {
     completion: {
+      // We send the completion context to the server
+      contextSupport: true,
       completionItem: {
+        snippetSupport: true,
         insertReplaceSupport: true,
         documentationFormat: [MarkupKind.PlainText, MarkupKind.Markdown],
         commitCharactersSupport: false,

--- a/packages/codemirror-language-client/src/CodeMirrorLanguageClient.ts
+++ b/packages/codemirror-language-client/src/CodeMirrorLanguageClient.ts
@@ -3,20 +3,21 @@ import { ClientCapabilities, MarkupKind } from 'vscode-languageserver-protocol';
 
 import { Dependencies, LanguageClient } from './LanguageClient';
 import {
-  clientFacet,
-  fileUriFacet,
-  textDocumentSync,
-  lspLinter,
-  lspComplete,
-  InfoRenderer,
-  infoRendererFacet,
   AutocompleteOptions,
-  LinterOptions,
   DiagnosticRenderer,
-  diagnosticRendererFacet,
-  HoverRenderer,
   HoverOptions,
+  HoverRenderer,
+  InfoRenderer,
+  LinterOptions,
+  clientFacet,
+  diagnosticRendererFacet,
+  fileUriFacet,
+  infoRendererFacet,
+  lspComplete,
   lspHover,
+  lspLinter,
+  serverCapabilitiesFacet,
+  textDocumentSync,
 } from './extensions';
 import { hoverRendererFacet } from './extensions/hover';
 
@@ -152,6 +153,7 @@ export class CodeMirrorLanguageClient {
   ): Extension[] {
     return [
       clientFacet.of(this.client),
+      serverCapabilitiesFacet.of(this.client.serverCapabilities),
       fileUriFacet.of(fileUri),
       textDocumentSync,
       infoRendererFacet.of(this.infoRenderer),

--- a/packages/codemirror-language-client/src/LanguageClient.ts
+++ b/packages/codemirror-language-client/src/LanguageClient.ts
@@ -211,7 +211,7 @@ export class LanguageClient extends EventTarget implements AbstractLanguageClien
     };
     if (params) request.params = params;
 
-    this.log(`Client->Server ${request.method} request [${request.id}]`);
+    this.log(`Client->Server ${request.method} request [${request.id}]`, request);
     this.sendMessage(request);
 
     return new Promise((resolve, reject) => {
@@ -250,7 +250,7 @@ export class LanguageClient extends EventTarget implements AbstractLanguageClien
     const response: ResponseMessage = { jsonrpc: '2.0', id };
     if (result !== undefined) response.result = result;
     if (error !== undefined) response.error = error;
-    this.log(`Client->Server response [${id}]`);
+    this.log(`Client->Server response [${id}]`, response);
     this.sendMessage(response);
   }
 

--- a/packages/codemirror-language-client/src/extensions/client.ts
+++ b/packages/codemirror-language-client/src/extensions/client.ts
@@ -1,6 +1,7 @@
 import { Facet } from '@codemirror/state';
 
 import { AbstractLanguageClient } from '../LanguageClient';
+import { ServerCapabilities } from 'vscode-languageserver-protocol';
 
 export const clientFacet = Facet.define<AbstractLanguageClient, AbstractLanguageClient>({
   combine: (values) => values[0],
@@ -9,4 +10,8 @@ export const clientFacet = Facet.define<AbstractLanguageClient, AbstractLanguage
 
 export const fileUriFacet = Facet.define<string, string>({
   combine: (values) => values[0],
+});
+
+export const serverCapabilitiesFacet = Facet.define<ServerCapabilities | null, ServerCapabilities>({
+  combine: (values) => values[0] ?? {},
 });

--- a/packages/codemirror-language-client/src/extensions/index.ts
+++ b/packages/codemirror-language-client/src/extensions/index.ts
@@ -1,4 +1,4 @@
-export { clientFacet, fileUriFacet } from './client';
+export { clientFacet, fileUriFacet, serverCapabilitiesFacet } from './client';
 export { textDocumentSync, textDocumentField } from './textDocumentSync';
 export {
   AutocompleteOptions,

--- a/packages/codemirror-language-client/src/extensions/snippet.spec.ts
+++ b/packages/codemirror-language-client/src/extensions/snippet.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { translateSnippet } from './snippet';
+
+describe('Module: snippets', () => {
+  describe('Unit: translateSnippet', () => {
+    it('translate $0 to $99', () => {
+      expect(translateSnippet('$0')).to.equal('${99}');
+    });
+
+    it('handles $1, $2, $3 propertly', () => {
+      expect(translateSnippet('def $1, $2, $3, $0 end')).to.equal(
+        'def ${1}, ${2}, ${3}, ${99} end',
+      );
+    });
+
+    it('handles placeholders properly', () => {
+      expect(translateSnippet('def ${1:hi}, ${2:hi}, $0 end')).to.equal(
+        'def ${1:hi}, ${2:hi}, ${99} end',
+      );
+    });
+
+    it('appends $99 at the end of the string if $0 is not present', () => {
+      expect(translateSnippet('def $1 end')).to.equal('def ${1} end${99}');
+    });
+
+    // CodeMirror doesn't support VS Code's ${2:$1} syntax, so we gotta do something about it.
+    it('applies a fallback strategy when placeholders refer to other placeholders', () => {
+      expect(translateSnippet('${1:hi} ${2:oh$1no}')).to.equal('${1:hi} ${2:ohno}${99}');
+    });
+  });
+});

--- a/packages/codemirror-language-client/src/extensions/snippet.ts
+++ b/packages/codemirror-language-client/src/extensions/snippet.ts
@@ -1,0 +1,42 @@
+import { MapMode, RangeSet, RangeValue, StateEffect, StateField, Range } from '@codemirror/state';
+
+/**
+ * Syntax is $1, ${2}, ${3:foo}, $0
+ * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax
+ */
+export type LSPSnippet = string;
+
+/**
+ * Syntax is ${placeholder} or ${1:placeholder} or #{} or ${}
+ * https://codemirror.net/docs/ref/#autocomplete.snippet
+ */
+export type CodeMirrorSnippet = string;
+
+/**
+ * This function takes a snippet from the language server and transforms it
+ * into the format that CodeMirror expects.
+ *
+ * There are small nuances w.r.t. $0 but that shouldn't be too much of a
+ * problem. ($0 is the "end" cursor position in LSP, CM doesn't have that... so
+ * we convert $0 to ${99} :D)
+ */
+export function translateSnippet(snippet: LSPSnippet): CodeMirrorSnippet {
+  let fixed = snippet.replace(/\$(\d)+/g, (_match, index) => {
+    return '${' + (Number(index) === 0 ? '99' : index) + '}';
+  });
+
+  // Remove references to other placeholders in placeholders. CodeMirror doesn't
+  // support those and it's a PITA to implement differently.
+  fixed = fixed.replace(
+    /\$\{(\d+):([^}$]*)(\$\{\d+\})([^}$]*)\}/g,
+    (_match, index, pre, ref, post) => {
+      return '${' + index + ':' + pre + post + '}';
+    },
+  );
+
+  if (fixed.includes('${99}')) {
+    return fixed;
+  } else {
+    return fixed + '${99}';
+  }
+}

--- a/packages/codemirror-language-client/src/test/MockClient.ts
+++ b/packages/codemirror-language-client/src/test/MockClient.ts
@@ -18,7 +18,7 @@ export class MockClient extends EventTarget implements AbstractLanguageClient {
   sendNotification: AbstractLanguageClient['sendNotification'];
   sendRequest: AbstractLanguageClient['sendRequest'];
 
-  private pendingRequest: Promise<any> | null;
+  public pendingRequest: Promise<any> | null;
   private promiseCompletion: PromiseCompletion | null;
 
   constructor(clientCapabilities = {}, serverCapabilities = null, serverInfo = null) {
@@ -53,11 +53,15 @@ export class MockClient extends EventTarget implements AbstractLanguageClient {
   }
 
   resolveRequest(value: any) {
-    this.promiseCompletion!.resolve(value);
+    if (!this.promiseCompletion) throw Error('Expecting a pending request');
+    this.promiseCompletion.resolve(value);
+    this.pendingRequest = null;
   }
 
   rejectRequest(error: any) {
-    this.promiseCompletion!.reject(error);
+    if (!this.promiseCompletion) throw Error('Expecting a pending request');
+    this.promiseCompletion.reject(error);
+    this.pendingRequest = null;
   }
 
   triggerNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params: P) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,6 +256,14 @@
     "@codemirror/view" "^6.0.0"
     "@lezer/common" "^1.1.0"
 
+"@codemirror/lang-json@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz#0a0be701a5619c4b0f8991f9b5e95fe33f462330"
+  integrity sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/json" "^1.0.0"
+
 "@codemirror/language@^6.0.0":
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.9.1.tgz#97e2c3e44cf4ff152add865ed7ecec73868446a4"
@@ -553,10 +561,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@lezer/common@^1.0.0", "@lezer/common@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.1.0.tgz#2e5bfe01d7a2ada6056d93c677bba4f1495e098a"
-  integrity sha512-XPIN3cYDXsoJI/oDWoR2tD++juVrhgIago9xyKhZ7IhGlzdDM9QgC8D8saKNCz5pindGcznFr2HBSsEQSWnSjw==
+"@lezer/common@^1.0.0", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz#198b278b7869668e1bebbe687586e12a42731049"
+  integrity sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==
 
 "@lezer/highlight@^1.0.0":
   version "1.1.6"
@@ -564,6 +572,15 @@
   integrity sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==
   dependencies:
     "@lezer/common" "^1.0.0"
+
+"@lezer/json@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@lezer/json/-/json-1.0.2.tgz#bdc849e174113e2d9a569a5e6fb1a27e2f703eaf"
+  integrity sha512-xHT2P4S5eeCYECyKNPhr4cbEL9tc8w83SPwRC373o9uEdrvGKTZoJVAGxpOsZckMlEh9W23Pc72ew918RWQOBQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
 
 "@lezer/lr@^1.0.0":
   version "1.3.13"
@@ -5116,12 +5133,12 @@ safe-array-concat@^1.0.1:
     has-symbols "^1.0.3"
     isarray "^2.0.5"
 
-safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==


### PR DESCRIPTION


https://github.com/Shopify/theme-tools/assets/4990691/8aad6191-541b-401d-b9cb-87aa30f4db68


## What are you adding in this PR?

- Log request and response objects in CMLC
- Respect ServerCapabilities triggerCharacters in CMLC
- Add `completionItem.snippetSupport` to `@shopify/codemirror-language-client`

Reason being that `vscode-json-languageservice` returns snippets for a
bunch of things and that for the completions to feel good in-browser,
we needed to add support for those types of completions.

Stay tuned for us to add snippet completions to Liquid tags, HTML
elements and attributes in a near future.

## What's next? Any followup issues?

- Ship it in admin along with the JSON schema code completion & hover
  - Note that since we do the keybinds ourselves over there, we'll also need
    to wire up [`@codemirror/autocomplete`'s snippet completion keybinds](https://codemirror.net/docs/ref/#autocomplete.snippetKeymap)

## What did you learn?

- Learned how we do snippet completion in the Language Server Protocol
  - The gist is that's the syntax `TabStop: $1, Placeholder: ${2:default value}, Last Location: $0.`
  - You need to set `insertTextFormat` to `2` in the server response for the client to pick it up as a snippet
  - You can set `insertTextMode` to [adjustIndentation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#insertTextMode) for the client to adjust tabbing correctly
  - You can include a snippet in the `textEdit` or `insertText` part of the [CompletionItem](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem)
- Learned about how to respect [trigger characters](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem:~:text=/**%0A%09%20*%20The%20additional%20characters,be%20listed%20here.%0A%09%20*/)
- Learned about the [completion context](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionContext) (and how `vscode-json-languageservice` uses it)
- Learned about `Range`, `RangeValue`, and `RangeSet` in the CodeMirror API
  - A `Range<RangeValue>` is an "efficient" wrapper over a value that describes where it is in the document. 

    It's designed so that you can change "where" the value is attached independently of its value. Think of diagnostics moving as the user types.
  - A `RangeValue` is a wrapper over a value that informs the framework of how to handle the value if the content that spans its range gets deleted.

    Imagine you delete the text that has the diagnostic, we might then decide to also delete the RangeValue associated with it since it's no longer in the document.
  - A `RangeSet` is an "effecient" data structure that holds a bunch of `Range<RangeValue>`

    In a transaction, you can do `rangeSet.update(tr.changes)` and all the ranges covered by the rangeSet will be updated if they need to be.
- Learned (kind of late) that `@codemirror/autocomplete` has helpers for doing [snippet completion](https://codemirror.net/docs/ref/#autocomplete.snippet)
  - Its syntax is _slightly_ different that the one from the LSP, so internally I "translate" the snippet from the LSP syntax to the one supported by CodeMirror to get the behaviour we want.

## Before you deploy

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
