### PR TITLE
Fix TAE context inference

### DIFF
--- a/.changeset/cool-flies-drop.md
+++ b/.changeset/cool-flies-drop.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-node': minor
+'theme-check-vscode': minor
+---
+
+Fix Theme App Extension context inference


### PR DESCRIPTION

## What are you adding in this PR?

`*.extension.toml` & `snippets/` = TAE, it doesn't have to be strictly `shopify.extension.toml`. Newer templates don't use the old name.


## What did you learn?

- Your shopify extension file doesn't need to be called `shopify.extension.toml`.

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
