### PR TITLE
Prevent loading the same third party check more than once

### DIFF
--- a/.changeset/flat-shoes-sparkle.md
+++ b/.changeset/flat-shoes-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': patch
+---
+
+Prevent loading the same plugin more than once

--- a/packages/theme-check-node/src/config/load-third-party-checks.ts
+++ b/packages/theme-check-node/src/config/load-third-party-checks.ts
@@ -18,7 +18,7 @@ export function loadThirdPartyChecks(
    * */
   modulePaths: ModulePath[] = [],
 ): CheckDefinition<SourceCodeType>[] {
-  const checks = [];
+  const checks = new Set<CheckDefinition<SourceCodeType>>();
   for (const modulePath of modulePaths) {
     try {
       const moduleValue = require(/* webpackIgnore: true */ modulePath);
@@ -31,7 +31,7 @@ export function loadThirdPartyChecks(
 
       for (const check of moduleChecks) {
         if (isCheckDefinition(check)) {
-          checks.push(check);
+          checks.add(check);
         } else {
           console.error(`Expected ${check} to be a CheckDefinition, but it looks like it isn't`);
         }
@@ -40,7 +40,7 @@ export function loadThirdPartyChecks(
       console.error(`Error loading ${modulePath}, ignoring it.\n${e}`);
     }
   }
-  return checks;
+  return [...checks];
 }
 
 export async function findThirdPartyChecks(nodeModuleRoot: AbsolutePath): Promise<ModulePath[]> {


### PR DESCRIPTION
## What are you adding in this PR?

To prevent accidentally loading the same plugin more than once, which in turn prevents auto fixes from running.

Fixes #336 

## What did you learn?

Not exciting for anyone else, but I learned how the Theme Check config is resolved and loaded.

## Before you deploy

- [x] I included a patch bump `changeset`
