### PR TITLE
Add a prettier configuration option for captureWhitespace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "syntaxes"]
 	path = packages/vscode-extension/syntaxes
-	url = git@github.com:Shopify/liquid-tm-grammar.git
+	url = https://github.com/Shopify/liquid-tm-grammar.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "syntaxes"]
 	path = packages/vscode-extension/syntaxes
-	url = https://github.com/Shopify/liquid-tm-grammar.git
+	url = git@github.com:Shopify/liquid-tm-grammar.git

--- a/packages/prettier-plugin-liquid/README.md
+++ b/packages/prettier-plugin-liquid/README.md
@@ -75,6 +75,7 @@ Prettier for Liquid supports the following options.
 | `liquidSingleQuote`         | `true`    | Use single quotes instead of double quotes in Liquid tag and objects (since v0.2.0).                                                                                     |
 | `embeddedSingleQuote`       | `true`    | Use single quotes instead of double quotes in embedded languages (JavaScript, CSS, TypeScript inside `<script>`, `<style>` or Liquid equivalent) (since v0.4.0).         |
 | `htmlWhitespaceSensitivity` | `css`     | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#html-whitespace-sensitivity))                                                          |
+| `captureWhitespace`         | `strict`  | Specify the global whitespace sensitivity for the capture tag                                                          |
 | `singleLineLinkTags`        | `false`   | If set to `true`, will print `<link>` tags on a single line to remove clutter                                                                                            |
 | `indentSchema`              | `false`   | If set to `true`, will indent the contents of the `{% schema %}` tag                                                                                                     |
 
@@ -116,6 +117,14 @@ Examples:
 
 {% # here we alter its white-space property so that we allow pretty printing of its body %}
 {% # white-space: normal %}
+{% capture _ %}
+  <div>
+    {% render 'snip' %}
+  </div>
+{% endcapture %}
+
+{% # this will prevent prettier from formatting it %}
+{% # white-space: pre %}
 {% capture _ %}
   <div>
     {% render 'snip' %}

--- a/packages/prettier-plugin-liquid/src/plugin.ts
+++ b/packages/prettier-plugin-liquid/src/plugin.ts
@@ -19,7 +19,7 @@ const options: SupportOptions = {
     type: 'string',
     category: 'LIQUID',
     default: 'strict',
-    description: 'Use single quotes instead of double quotes in Liquid tags and objects.',
+    description: 'Specify the global whitespace sensitivity for the capture tag.',
     since: '0.2.0',
   },
   liquidSingleQuote: {

--- a/packages/prettier-plugin-liquid/src/plugin.ts
+++ b/packages/prettier-plugin-liquid/src/plugin.ts
@@ -15,6 +15,13 @@ const languages: SupportLanguage[] = [
 ];
 
 const options: SupportOptions = {
+  captureWhitespace: {
+    type: 'string',
+    category: 'LIQUID',
+    default: 'strict',
+    description: 'Use single quotes instead of double quotes in Liquid tags and objects.',
+    since: '0.2.0',
+  },
   liquidSingleQuote: {
     type: 'boolean',
     category: 'LIQUID',

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -134,7 +134,10 @@ function getCssDisplay(node: AugmentedNode<WithSiblings>, options: LiquidParserO
   }
 }
 
-function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
+function getNodeCssStyleWhiteSpace(
+  node: AugmentedNode<WithSiblings>,
+  options: LiquidParserOptions,
+): string {
   if (node.prev && node.prev.type === NodeTypes.HtmlComment) {
     // <!-- white-space: normal -->
     const whitespace = getCssWhitespaceFromComment(node.prev.body);
@@ -177,7 +180,13 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
       return 'pre';
 
     case NodeTypes.LiquidTag:
-      return CSS_WHITE_SPACE_LIQUID_TAGS[node.name] || CSS_WHITE_SPACE_DEFAULT;
+      console.log(options.captureWhitespace);
+      switch (options.captureWhitespace) {
+        case 'strict':
+          return CSS_WHITE_SPACE_LIQUID_TAGS[node.name] || 'pre';
+        case 'ignore':
+          return CSS_WHITE_SPACE_LIQUID_TAGS[node.name] || 'normal';
+      }
 
     case NodeTypes.LiquidBranch:
     case NodeTypes.LiquidVariableOutput:
@@ -222,7 +231,7 @@ function getNodeCssStyleWhiteSpace(node: AugmentedNode<WithSiblings>): string {
 export const augmentWithCSSProperties: Augment<WithSiblings> = (options, node) => {
   const augmentations: WithCssProperties = {
     cssDisplay: getCssDisplay(node, options),
-    cssWhitespace: getNodeCssStyleWhiteSpace(node),
+    cssWhitespace: getNodeCssStyleWhiteSpace(node, options),
   };
 
   Object.assign(node, augmentations);

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -180,15 +180,11 @@ function getNodeCssStyleWhiteSpace(
       return 'pre';
 
     case NodeTypes.LiquidTag:
-      console.log('LiquidTag', NodeTypes.LiquidTag);
-      console.log('captureWhitespace', options.captureWhitespace);
-      console.log(node.name, CSS_WHITE_SPACE_LIQUID_TAGS[node.name]);
-      console.log('---');
       switch (options.captureWhitespace) {
         case 'strict':
-          return CSS_WHITE_SPACE_LIQUID_TAGS[node.name] || 'pre';
+          return (node.name === 'capture') ? 'pre' : 'normal';
         case 'ignore':
-          return CSS_WHITE_SPACE_LIQUID_TAGS[node.name] || 'normal';
+          return (node.name === 'capture') ? 'normal' : 'pre';
       }
 
     case NodeTypes.LiquidBranch:

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -180,7 +180,10 @@ function getNodeCssStyleWhiteSpace(
       return 'pre';
 
     case NodeTypes.LiquidTag:
-      console.log(options.captureWhitespace);
+      console.log('LiquidTag', NodeTypes.LiquidTag);
+      console.log('captureWhitespace', options.captureWhitespace);
+      console.log(node.name, CSS_WHITE_SPACE_LIQUID_TAGS[node.name]);
+      console.log('---');
       switch (options.captureWhitespace) {
         case 'strict':
           return CSS_WHITE_SPACE_LIQUID_TAGS[node.name] || 'pre';

--- a/packages/prettier-plugin-liquid/src/printer/utils/node.ts
+++ b/packages/prettier-plugin-liquid/src/printer/utils/node.ts
@@ -20,7 +20,7 @@ export function isScriptLikeTag(node: { type: NodeTypes }) {
 }
 
 export function isPreLikeNode(node: { cssWhitespace: string }) {
-  console.log('cssWhitespace', node.cssWhitespace);
+  // console.log('cssWhitespace', node.cssWhitespace);
   return node.cssWhitespace.startsWith('pre');
 }
 

--- a/packages/prettier-plugin-liquid/src/printer/utils/node.ts
+++ b/packages/prettier-plugin-liquid/src/printer/utils/node.ts
@@ -20,7 +20,6 @@ export function isScriptLikeTag(node: { type: NodeTypes }) {
 }
 
 export function isPreLikeNode(node: { cssWhitespace: string }) {
-  // console.log('cssWhitespace', node.cssWhitespace);
   return node.cssWhitespace.startsWith('pre');
 }
 

--- a/packages/prettier-plugin-liquid/src/printer/utils/node.ts
+++ b/packages/prettier-plugin-liquid/src/printer/utils/node.ts
@@ -20,6 +20,7 @@ export function isScriptLikeTag(node: { type: NodeTypes }) {
 }
 
 export function isPreLikeNode(node: { cssWhitespace: string }) {
+  console.log('cssWhitespace', node.cssWhitespace);
   return node.cssWhitespace.startsWith('pre');
 }
 

--- a/packages/prettier-plugin-liquid/src/test/liquid-tag-capture-whitespace/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-tag-capture-whitespace/fixed.liquid
@@ -1,0 +1,40 @@
+It should never break on capture var name
+printWidth: 1
+{% capture varName %}{% endcapture %}
+{% capture varName %}{% endcapture %}
+{% capture varName %}{% endcapture %}
+{%- capture varName -%}{% endcapture %}
+
+It should be indentation sensitive
+<p>
+  {% capture var %}
+    # heading
+
+    - list
+      * elem
+  {% endcapture %}
+</p>
+
+It should behave like a pre tag if the capture tag is set to white-space: pre
+printWidth: 1
+<!-- white-space: pre -->
+{% capture var %}
+  <div>
+    {{ x }}
+  </div>
+{% endcapture %}
+
+It should behave like a pre tag if the capture tag is set white-space pre (Liquid)
+printWidth: 1
+{% # white-space: pre %}
+{% capture var %}
+  <div>
+    {{ x }}
+  </div>
+{% endcapture %}
+
+It should print as is without the white-space pre comment
+printWidth: 1
+{% capture var %}
+  <div>{{ x }}</div>
+{% endcapture %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-tag-capture-whitespace/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-tag-capture-whitespace/index.liquid
@@ -1,0 +1,37 @@
+It should never break on capture var name
+printWidth: 1
+{% capture varName %}{% endcapture %}
+{%   capture   varName   %}{% endcapture %}
+{%capture varName %}{% endcapture %}
+{%- capture
+varName
+-%}{% endcapture %}
+
+It should be indentation sensitive
+<p>{% capture var %}
+    # heading
+
+    - list
+      * elem
+  {% endcapture %}
+</p>
+
+It should behave like a pre tag if the capture tag is set white-space pre
+printWidth: 1
+<!-- white-space: pre -->
+{% capture var %}
+      <div>{{ x }}</div>
+{% endcapture %}
+
+It should behave like a pre tag if the capture tag is set white-space pre (Liquid)
+printWidth: 1
+{% # white-space: pre %}
+{% capture var %}
+      <div>{{ x }}</div>
+{% endcapture %}
+
+It should print as is without the white-space pre comment
+printWidth: 1
+{% capture var %}
+      <div>{{ x }}</div>
+{% endcapture %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-tag-capture-whitespace/index.spec.ts
+++ b/packages/prettier-plugin-liquid/src/test/liquid-tag-capture-whitespace/index.spec.ts
@@ -1,0 +1,7 @@
+import { test } from 'vitest';
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+test('Unit: liquid-tag-capture', async () => {
+  await assertFormattedEqualsFixed(__dirname);
+});

--- a/packages/prettier-plugin-liquid/src/types.ts
+++ b/packages/prettier-plugin-liquid/src/types.ts
@@ -23,6 +23,7 @@ export type LiquidParserOptions = ParserOptions<LiquidHtmlNode> & {
   liquidSingleQuote: boolean;
   embeddedSingleQuote: boolean;
   indentSchema: boolean;
+  captureWhitespace: string;
 };
 export type LiquidPrinterArgs = {
   leadingSpaceGroupId?: symbol[] | symbol;


### PR DESCRIPTION
## What are you adding in this PR?

This PR closes #348. You can now add `"captureWhitespace": "ignore|strict"` to the prettier config to set the global whitespace sensitivity.

## What's next? Any followup issues?

Fix the HTML attribute snippet completion (`=""`) - ([345](https://github.com/Shopify/theme-tools/issues/345))

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [x ] I ran `yarn build` and committed the updated configuration files

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [x ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
