### PR TITLE
The comment object should be available in section files

### DIFF
--- a/.changeset/eighty-jobs-remember.md
+++ b/.changeset/eighty-jobs-remember.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+The comment object should be available to section files

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -286,6 +286,7 @@ describe('Module: UndefinedObject', () => {
       ['section', 'sections/section.liquid'],
       ['predictive_search', 'sections/predictive-search.liquid'],
       ['recommendations', 'sections/recommendations.liquid'],
+      ['comment', 'sections/main-article.liquid'],
       ['block', 'blocks/theme-app-extension.liquid'],
       ['app', 'blocks/theme-app-extension.liquid'],
       ['app', 'snippets/theme-app-extension.liquid'],

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -187,7 +187,7 @@ function getContextualObjects(relativePath: string): string[] {
     ];
   }
   if (relativePath.startsWith('sections/')) {
-    return ['section', 'predictive_search', 'recommendations'];
+    return ['section', 'predictive_search', 'recommendations', 'comment'];
   }
 
   if (relativePath.startsWith('blocks/')) {

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -189,6 +189,14 @@ export async function check(
               template: [],
             },
           },
+          {
+            name: 'comment',
+            access: {
+              global: false,
+              parents: [],
+              template: [],
+            },
+          },
         ];
       },
       async tags() {

--- a/packages/theme-language-server-common/src/TypeSystem.spec.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.spec.ts
@@ -59,6 +59,11 @@ describe('Module: TypeSystem', () => {
             return_type: [],
           },
           {
+            name: 'comment',
+            access: { global: false, parents: [], template: [] },
+            return_type: [],
+          },
+          {
             name: 'recommendations',
             access: { global: false, parents: [], template: [] },
             return_type: [],
@@ -307,6 +312,7 @@ describe('Module: TypeSystem', () => {
     let inferredType: string | ArrayType;
     const contexts: [string, string][] = [
       ['section', 'sections/my-section.liquid'],
+      ['comment', 'sections/main-article.liquid'],
       ['block', 'blocks/my-block.liquid'],
       ['predictive_search', 'sections/predictive-search.liquid'],
       ['recommendations', 'sections/recommendations.liquid'],

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -257,7 +257,7 @@ function getContextualEntries(uri: string): string[] {
     ];
   }
   if (SECTION_FILE_REGEX.test(absolutePath)) {
-    return ['section', 'predictive_search', 'recommendations'];
+    return ['section', 'predictive_search', 'recommendations', 'comment'];
   }
   if (BLOCK_FILE_REGEX.test(absolutePath)) {
     return ['app', 'section', 'block'];


### PR DESCRIPTION
It's a bit of poorly documented lore. But when you post a
`new_comment` form, the `comment` object becomes available globally.

https://shopify.dev/docs/themes/architecture/templates/article#paginate-article-comments:~:text=When%20a%20customer%20posts%20a%20comment%2C%20your%20code%20should%20provide%20feedback%20indicating%20whether%20it%20was%20posted%20successfully%2C%20or%20if%20there%20were%20any%20errors

Fixes #351 

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
