### PR TITLE
Add logging to ThemeLiquidDocsManager

### DIFF
--- a/.changeset/olive-vans-raise.md
+++ b/.changeset/olive-vans-raise.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-docs-updater': patch
+'@shopify/theme-check-node': patch
+---
+
+Add logging support to the docs loader

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release": "yarn workspace release-orchestrator run start",
     "reset": "find . -name \"node_modules\" -type d -prune -exec rm -rf '{}' +",
     "test": "vitest",
+    "theme-check": "node packages/theme-check-node/dist/cli.js",
     "type-check": "yarn workspaces run type-check"
   },
   "devDependencies": {

--- a/packages/theme-check-common/src/checks/asset-size-javascript/index.spec.ts
+++ b/packages/theme-check-common/src/checks/asset-size-javascript/index.spec.ts
@@ -1,7 +1,16 @@
-import { expect, describe, it } from 'vitest';
+import { expect, describe, it, afterEach, vi } from 'vitest';
 import { AssetSizeJavaScript } from '.';
 import { check, MockTheme } from '../../test';
 import { SchemaProp } from '../../types';
+import { hasRemoteAssetSizeExceededThreshold } from '../../utils/file-utils';
+
+vi.mock('../../utils/file-utils', async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    hasRemoteAssetSizeExceededThreshold: vi.fn(),
+  };
+});
 
 describe('Module: AssetSizeJavaScript', () => {
   const theme: MockTheme = {
@@ -25,6 +34,10 @@ describe('Module: AssetSizeJavaScript', () => {
     `,
   };
 
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should not find file size for invalid URLs', async () => {
     const invalidUrls = [
       'https://{{ settings.url }}',
@@ -42,6 +55,7 @@ describe('Module: AssetSizeJavaScript', () => {
   });
 
   it('should report a warning when the JavaScript http request exceeds the threshold', async () => {
+    vi.mocked(hasRemoteAssetSizeExceededThreshold).mockReturnValue(Promise.resolve(true));
     const CustomAssetSizeJavaScript = {
       ...AssetSizeJavaScript,
       meta: {

--- a/packages/theme-check-docs-updater/scripts/cli.js
+++ b/packages/theme-check-docs-updater/scripts/cli.js
@@ -2,10 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const { downloadThemeLiquidDocs, root } = require(path.resolve(
-  __dirname,
-  '../dist',
-));
+const { downloadThemeLiquidDocs, root } = require(path.resolve(__dirname, '../dist'));
 
 // Get the command line arguments
 const args = process.argv.slice(2);
@@ -32,7 +29,7 @@ switch (args[0]) {
     }
     console.log('Downloading docs...');
 
-    downloadThemeLiquidDocs(args[1]);
+    downloadThemeLiquidDocs(args[1], console.error.bind(console));
 
     break;
 

--- a/packages/theme-check-docs-updater/src/themeLiquidDocsDownloader.ts
+++ b/packages/theme-check-docs-updater/src/themeLiquidDocsDownloader.ts
@@ -3,6 +3,7 @@ import envPaths from 'env-paths';
 import fetch from 'node-fetch';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { Logger, noop, tap } from './utils';
 
 const paths = envPaths('theme-liquid-docs');
 export const root = paths.cache;
@@ -36,25 +37,39 @@ const THEME_LIQUID_DOCS: Record<Resource | 'latest', string> = {
   manifest_theme_app_extension: 'schemas/manifest_theme_app_extension.json',
 };
 
-export async function downloadSchema(relativeUri: string, destination: string = root) {
+export async function downloadSchema(
+  relativeUri: string,
+  destination: string = root,
+  log: Logger = noop,
+) {
   const remotePath = schemaUrl(relativeUri);
   const localPath = schemaPath(relativeUri, destination);
-  const text = await download(remotePath);
-  fs.writeFile(localPath, text, 'utf8');
+  const text = await download(remotePath, log);
+  await fs.writeFile(localPath, text, 'utf8');
   return text;
 }
 
-export async function downloadResource(resource: Resource | 'latest', destination: string = root) {
+export async function downloadResource(
+  resource: Resource | 'latest',
+  destination: string = root,
+  log: Logger = noop,
+) {
   const remotePath = resourceUrl(resource);
   const localPath = resourcePath(resource, destination);
-  const text = await download(remotePath);
-  fs.writeFile(localPath, text, 'utf8');
+  const text = await download(remotePath, log);
+  await fs.writeFile(localPath, text, 'utf8');
   return text;
 }
 
-export async function download(path: string) {
+export async function download(path: string, log: Logger) {
   if (path.startsWith('file:')) {
-    return await fs.readFile(path.replace(/^file:/, ''), 'utf8');
+    return await fs
+      .readFile(path.replace(/^file:/, ''), 'utf8')
+      .then(tap(() => log(`Using local file: ${path}`)))
+      .catch((error) => {
+        log(`Failed to read local file: ${path}`);
+        throw error;
+      });
   } else {
     const res = await fetch(path);
     return res.text();
@@ -93,15 +108,34 @@ export async function exists(path: string) {
   }
 }
 
-export async function downloadThemeLiquidDocs(destination = root) {
+export async function downloadThemeLiquidDocs(destination: string, log: Logger) {
   if (!(await exists(destination))) {
     await fs.mkdir(destination);
   }
 
-  const resources = ['latest'].concat(Resources);
+  const resources = ['latest'].concat(Resources) as (Resource | 'latest')[];
   const resourceContents = await Promise.all(
     resources.map((file) => {
-      return downloadResource(file as Resource | 'latest', destination);
+      return downloadResource(file, destination, log)
+        .then(
+          tap(() =>
+            log(
+              `Successfully downloaded latest resource:\n\t${resourceUrl(file)}\n\t> ${resourcePath(
+                file,
+                destination,
+              )}`,
+            ),
+          ),
+        )
+        .catch((error) => {
+          log(
+            `Failed to download latest resource:\n\t${resourceUrl(file)} to\n\t${resourcePath(
+              file,
+              destination,
+            )}\n${error}`,
+          );
+          throw error;
+        });
     }),
   );
 
@@ -114,7 +148,25 @@ export async function downloadThemeLiquidDocs(destination = root) {
     manifest.schemas.map((schema: { uri: string }) => schema.uri),
   );
 
-  await Promise.all(unique(relativeUris).map((uri) => downloadSchema(uri, destination)));
+  await Promise.all(
+    unique(relativeUris).map((uri) =>
+      downloadSchema(uri, destination, log)
+        .then(
+          tap(() =>
+            log(
+              `Successfully downloaded schema:\n\t${schemaUrl(uri)}\n\t> ${schemaPath(
+                uri,
+                destination,
+              )}`,
+            ),
+          ),
+        )
+        .catch((error) => {
+          log(`Failed to download schema: ${uri}, ${error}`);
+          throw error;
+        }),
+    ),
+  );
 }
 
 function unique<T>(array: T[]): T[] {

--- a/packages/theme-check-docs-updater/src/themeLiquidDocsManager.spec.ts
+++ b/packages/theme-check-docs-updater/src/themeLiquidDocsManager.spec.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it, beforeEach, afterEach, vi, assert } from 'vitest';
 import { ThemeLiquidDocsManager } from './themeLiquidDocsManager';
 import { downloadResource, Resources } from './themeLiquidDocsDownloader';
+import { noop } from './utils';
 
 vi.mock('./themeLiquidDocsDownloader', async (importOriginal) => {
   const actual: any = await importOriginal();
@@ -58,7 +59,12 @@ describe('Module: ThemeLiquidDocsManager', async () => {
 
   it('should not download remote files if the revision is stable', async () => {
     await Promise.all([manager.filters(), manager.objects(), manager.tags()]);
-    expect(vi.mocked(downloadResource)).toHaveBeenNthCalledWith(1, 'latest');
+    expect(vi.mocked(downloadResource)).toHaveBeenNthCalledWith(
+      1,
+      'latest',
+      'MOCKED_CACHE/theme-liquid-docs',
+      noop,
+    );
     expect(vi.mocked(downloadResource)).toHaveBeenCalledTimes(1);
     for (const resource of Resources) {
       expect(vi.mocked(downloadResource)).not.toHaveBeenCalledWith(resource, expect.any(String));

--- a/packages/theme-check-docs-updater/src/utils.ts
+++ b/packages/theme-check-docs-updater/src/utils.ts
@@ -1,7 +1,16 @@
 import { Resource, downloadResource } from './themeLiquidDocsDownloader';
 import { root } from './themeLiquidDocsDownloader';
 
+export type Logger = (message: string) => void;
 export const noop = () => {};
+
+export const identity = <T>(x: T): T => x;
+export const tap = <T>(tappingFunction: (x: T) => void) => {
+  return (x: T) => {
+    tappingFunction(x);
+    return x;
+  };
+};
 
 /** Returns a cached version of a function. Only caches one result. */
 export function memo<F extends (...args: any[]) => any>(

--- a/packages/theme-check-node/src/cli.ts
+++ b/packages/theme-check-node/src/cli.ts
@@ -4,7 +4,11 @@ import path from 'node:path';
 async function main(): Promise<void> {
   const root = path.resolve(process.argv[2]);
   const configPath = process.argv[3] ? path.resolve(process.argv[3]) : undefined;
-  const { theme, config, offenses } = await themeCheckRun(root, configPath);
+  const { theme, config, offenses } = await themeCheckRun(
+    root,
+    configPath,
+    console.error.bind(console),
+  );
   console.log(JSON.stringify(offenses, null, 2));
   console.log(JSON.stringify(config, null, 2));
   console.log(

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -66,7 +66,8 @@ export async function themeCheckRun(root: string, configPath?: string): Promise<
     sc.absolutePath.endsWith('default.schema.json'),
   );
   const defaultSchemaTranslations = parseJSON(defaultSchemaTranslationsFile?.source ?? '{}', {});
-  const themeLiquidDocsManager = new ThemeLiquidDocsManager();
+  const logger = process.env.SHOPIFY_FLAG_VERBOSE ? console.error.bind(console) : () => {};
+  const themeLiquidDocsManager = new ThemeLiquidDocsManager(logger);
 
   const offenses = await coreCheck(theme, config, {
     fileExists,

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -58,6 +58,8 @@ export async function checkAndAutofix(root: string, configPath?: string) {
   await autofix(theme, offenses);
 }
 
+const useDebugLogging = () => process.env.SHOPIFY_FLAG_VERBOSE || process.env.ACTIONS_RUNNER_DEBUG;
+
 export async function themeCheckRun(root: string, configPath?: string): Promise<ThemeCheckRun> {
   const { theme, config } = await getThemeAndConfig(root, configPath);
   const defaultTranslationsFile = theme.find((sc) => sc.absolutePath.endsWith('default.json'));
@@ -66,7 +68,7 @@ export async function themeCheckRun(root: string, configPath?: string): Promise<
     sc.absolutePath.endsWith('default.schema.json'),
   );
   const defaultSchemaTranslations = parseJSON(defaultSchemaTranslationsFile?.source ?? '{}', {});
-  const logger = process.env.SHOPIFY_FLAG_VERBOSE ? console.error.bind(console) : () => {};
+  const logger = useDebugLogging() ? console.error.bind(console) : () => {};
   const themeLiquidDocsManager = new ThemeLiquidDocsManager(logger);
 
   const offenses = await coreCheck(theme, config, {

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -58,9 +58,11 @@ export async function checkAndAutofix(root: string, configPath?: string) {
   await autofix(theme, offenses);
 }
 
-const useDebugLogging = () => process.env.SHOPIFY_FLAG_VERBOSE || process.env.ACTIONS_RUNNER_DEBUG;
-
-export async function themeCheckRun(root: string, configPath?: string): Promise<ThemeCheckRun> {
+export async function themeCheckRun(
+  root: string,
+  configPath?: string,
+  log: (message: string) => void = () => {},
+): Promise<ThemeCheckRun> {
   const { theme, config } = await getThemeAndConfig(root, configPath);
   const defaultTranslationsFile = theme.find((sc) => sc.absolutePath.endsWith('default.json'));
   const defaultTranslations = parseJSON(defaultTranslationsFile?.source ?? '{}', {});
@@ -68,8 +70,7 @@ export async function themeCheckRun(root: string, configPath?: string): Promise<
     sc.absolutePath.endsWith('default.schema.json'),
   );
   const defaultSchemaTranslations = parseJSON(defaultSchemaTranslationsFile?.source ?? '{}', {});
-  const logger = useDebugLogging() ? console.error.bind(console) : () => {};
-  const themeLiquidDocsManager = new ThemeLiquidDocsManager(logger);
+  const themeLiquidDocsManager = new ThemeLiquidDocsManager(log);
 
   const offenses = await coreCheck(theme, config, {
     fileExists,


### PR DESCRIPTION
And potentially fix the problem with CI.

We weren't waiting on `fs.writeFile`, which mean we _might_ have ran into a race issue with the `downloadThemeLiquidDocs` terminating early.

It's awfully weird that the `fallback` docs weren't loaded though. That I can't explain...

Hopefully this will let us debug this issue.

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
