### PR TITLE
Theme Tools Release: 07-05-24

### DIFF
--- a/.changeset/eighty-jobs-remember.md
+++ b/.changeset/eighty-jobs-remember.md
@@ -1,6 +1,0 @@
----
-'@shopify/theme-language-server-common': patch
-'@shopify/theme-check-common': patch
----
-
-The comment object should be available to section files

--- a/.changeset/flat-shoes-sparkle.md
+++ b/.changeset/flat-shoes-sparkle.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-check-node': patch
----
-
-Prevent loading the same plugin more than once

--- a/.changeset/olive-vans-raise.md
+++ b/.changeset/olive-vans-raise.md
@@ -1,6 +1,0 @@
----
-'@shopify/theme-check-docs-updater': patch
-'@shopify/theme-check-node': patch
----
-
-Add logging support to the docs loader

--- a/packages/theme-check-browser/CHANGELOG.md
+++ b/packages/theme-check-browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-check-browser
 
+## 2.5.1
+
+### Patch Changes
+
+- Updated dependencies [ec1fbd7]
+  - @shopify/theme-check-common@2.5.1
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/theme-check-browser/package.json
+++ b/packages/theme-check-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-browser",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -26,6 +26,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "2.5.0"
+    "@shopify/theme-check-common": "2.5.1"
   }
 }

--- a/packages/theme-check-common/CHANGELOG.md
+++ b/packages/theme-check-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-check-common
 
+## 2.5.1
+
+### Patch Changes
+
+- ec1fbd7: The comment object should be available to section files
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-common",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/theme-check-docs-updater/CHANGELOG.md
+++ b/packages/theme-check-docs-updater/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/theme-check-docs-updater
 
+## 2.5.1
+
+### Patch Changes
+
+- 312d804: Add logging support to the docs loader
+- Updated dependencies [ec1fbd7]
+  - @shopify/theme-check-common@2.5.1
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-docs-updater",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Scripts to initialize theme-check data with assets from the theme-liquid-docs repo.",
   "main": "dist/index.js",
   "author": "Albert Chu <albert.chu@shopify.com>",
@@ -30,7 +30,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "^2.5.0",
+    "@shopify/theme-check-common": "^2.5.1",
     "env-paths": "^2.2.1",
     "node-fetch": "^2.6.11"
   },

--- a/packages/theme-check-node/CHANGELOG.md
+++ b/packages/theme-check-node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @shopify/theme-check-node
 
+## 2.5.1
+
+### Patch Changes
+
+- 0dc03a9: Prevent loading the same plugin more than once
+- 312d804: Add logging support to the docs loader
+- Updated dependencies [ec1fbd7]
+- Updated dependencies [312d804]
+  - @shopify/theme-check-common@2.5.1
+  - @shopify/theme-check-docs-updater@2.5.1
+
 ## 2.5.0
 
 ### Minor Changes

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-node",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -33,8 +33,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "2.5.0",
-    "@shopify/theme-check-docs-updater": "2.5.0",
+    "@shopify/theme-check-common": "2.5.1",
+    "@shopify/theme-check-docs-updater": "2.5.1",
     "glob": "^8.0.3",
     "yaml": "^2.3.0"
   },

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-browser
 
+## 1.11.1
+
+### Patch Changes
+
+- Updated dependencies [ec1fbd7]
+  - @shopify/theme-language-server-common@1.11.1
+
 ## 1.11.0
 
 ### Minor Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.11.0",
+    "@shopify/theme-language-server-common": "1.11.1",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @shopify/theme-language-server-common
 
+## 1.11.1
+
+### Patch Changes
+
+- ec1fbd7: The comment object should be available to section files
+- Updated dependencies [ec1fbd7]
+  - @shopify/theme-check-common@2.5.1
+
 ## 1.11.0
 
 ### Minor Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.0.3",
-    "@shopify/theme-check-common": "2.5.0",
+    "@shopify/theme-check-common": "2.5.1",
     "@vscode/web-custom-data": "^0.4.6",
     "vscode-json-languageservice": "^5.3.10",
     "vscode-languageserver": "^8.0.2",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @shopify/theme-language-server-node
 
+## 1.11.1
+
+### Patch Changes
+
+- Updated dependencies [ec1fbd7]
+- Updated dependencies [0dc03a9]
+- Updated dependencies [312d804]
+  - @shopify/theme-language-server-common@1.11.1
+  - @shopify/theme-check-node@2.5.1
+  - @shopify/theme-check-docs-updater@2.5.1
+
 ## 1.11.0
 
 ### Minor Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,9 +27,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.11.0",
-    "@shopify/theme-check-node": "^2.5.0",
-    "@shopify/theme-check-docs-updater": "^2.5.0",
+    "@shopify/theme-language-server-common": "1.11.1",
+    "@shopify/theme-check-node": "^2.5.1",
+    "@shopify/theme-check-docs-updater": "^2.5.1",
     "glob": "^8.0.3",
     "node-fetch": "^2.6.11",
     "vscode-languageserver": "^8.0.2",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## theme-check-vscode
 
+## 2.3.1
+
+### Patch Changes
+
+- Patch bump because it depends on @shopify/theme-language-server-node
+  - @shopify/theme-language-server-node@1.11.1
+
 ## 2.3.0
 
 ### Minor Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/shopify/theme-tools/issues"
   },
-  "version": "2.3.0",
+  "version": "2.3.1",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -60,12 +60,12 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.0.3",
     "@shopify/prettier-plugin-liquid": "^1.4.4",
-    "@shopify/theme-language-server-node": "^1.11.0",
+    "@shopify/theme-language-server-node": "^1.11.1",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0"
   },
   "devDependencies": {
-    "@shopify/theme-check-docs-updater": "^2.5.0",
+    "@shopify/theme-check-docs-updater": "^2.5.1",
     "@types/glob": "^8.0.0",
     "@types/node": "16.x",
     "@types/prettier": "^2.4.2",


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `2.3.0` -> `2.3.1`
### Changes:
- Patch bump because it depends on @shopify/theme-language-server-node

## `@shopify/theme-language-server-common`
Patch incremented `1.11.0` -> `1.11.1`
### Changes:
- The comment object should be available to section files

## `@shopify/theme-check-common`
Patch incremented `2.5.0` -> `2.5.1`
### Changes:
- The comment object should be available to section files

## `@shopify/theme-check-node`
Patch incremented `2.5.0` -> `2.5.1`
### Changes:
- Prevent loading the same plugin more than once
- Add logging support to the docs loader

## `@shopify/theme-check-docs-updater`
Patch incremented `2.5.0` -> `2.5.1`
### Changes:
- Add logging support to the docs loader

## `@shopify/theme-language-server-browser`
Patch incremented `1.11.0` -> `1.11.1`

## `@shopify/theme-language-server-node`
Patch incremented `1.11.0` -> `1.11.1`

## `@shopify/theme-check-browser`
Patch incremented `2.5.0` -> `2.5.1`

