### PR TITLE
Adds new check for usage of valid types

### DIFF
--- a/.changeset/nice-boats-raise.md
+++ b/.changeset/nice-boats-raise.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/theme-check-common': major
+'@shopify/theme-check-common': minor
 ---
 
 Add new validation for the type of the static block

--- a/.changeset/nice-boats-raise.md
+++ b/.changeset/nice-boats-raise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': major
+---
+
+Add new validation for the type of the static block

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -31,6 +31,7 @@ import { ValidHTMLTranslation } from './valid-html-translation';
 import { ValidSchema } from './valid-schema';
 import { ValidJSON } from './valid-json';
 import { VariableName } from './variable-name';
+import { ValidStaticBlockType } from './valid-static-block-type';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
@@ -64,6 +65,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   ValidSchema,
   ValidJSON,
   VariableName,
+  ValidStaticBlockType,
 ];
 
 /**

--- a/packages/theme-check-common/src/checks/valid-static-block-type/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-static-block-type/index.spec.ts
@@ -1,0 +1,40 @@
+import { expect, describe, it } from 'vitest';
+import { check, MockTheme, runLiquidCheck } from '../../test';
+import { SchemaProp } from '../../types';
+
+describe('Module: ValidStaticBlockType', () => {
+  const genericThemeBlock = {
+    'blocks/valid.liquid': 'Hello world!',
+  };
+
+  const validTypeBlock = {
+    'blocks/file.liquid': '{% content_for "block", type: "valid", id: "static-block" %}',
+  };
+
+  const invalidTypeBlock = {
+    'blocks/file.liquid': '{% content_for "block", type: "invalid", id: "static-block" %}',
+  };
+
+  const validExtensionFiles: MockTheme = {
+    ...genericThemeBlock,
+    ...validTypeBlock,
+  };
+
+  const invalidExtensionFiles: MockTheme = {
+    ...genericThemeBlock,
+    ...invalidTypeBlock,
+  };
+
+  it('should not report any offenses if type is valid', async () => {
+    const offenses = await check(validExtensionFiles);
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should report a offense if type is invalid', async () => {
+    const offenses = await check(invalidExtensionFiles);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).to.equal(
+      "The type 'invalid' is not valid, use a type that exists in the blocks directory",
+    );
+  });
+});

--- a/packages/theme-check-common/src/checks/valid-static-block-type/index.ts
+++ b/packages/theme-check-common/src/checks/valid-static-block-type/index.ts
@@ -8,7 +8,7 @@ export const ValidStaticBlockType: LiquidCheckDefinition = {
     docs: {
       description:
         'This check is aimed at preventing the use of an invalid type for blocks rendered statically.',
-      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks',
+      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/valid-static-block-type',
       recommended: true,
     },
     type: SourceCodeType.LiquidHtml,

--- a/packages/theme-check-common/src/checks/valid-static-block-type/index.ts
+++ b/packages/theme-check-common/src/checks/valid-static-block-type/index.ts
@@ -1,0 +1,64 @@
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { doesFileExist } from '../../utils/file-utils';
+
+export const ValidStaticBlockType: LiquidCheckDefinition = {
+  meta: {
+    code: 'ValidStaticBlockType',
+    name: 'Prevent use of type that is not valid for static blocks',
+    docs: {
+      description:
+        'This check is aimed at preventing the use of an invalid type for blocks rendered statically.',
+      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks',
+      recommended: true,
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    const typeRegex = /type:\s*["'](\S+)["']/;
+
+    return {
+      async LiquidTag(node) {
+        if (node.name !== 'content_for') {
+          return;
+        }
+
+        const [blockType] = node.markup.split(',');
+
+        if (blockType.replace(/["']/g, '') !== 'block') {
+          return;
+        }
+
+        const typeValueMatch = typeRegex.exec(node.markup);
+
+        if (typeValueMatch == null) {
+          return;
+        }
+        const [entireTypeTerm, filteredTypeValue] = typeValueMatch;
+
+        const relativePath = `blocks/${filteredTypeValue}.liquid`;
+        const fileExists = await doesFileExist(context, relativePath);
+
+        if (!fileExists) {
+          const nodeInSource = node.source.substring(node.position.start);
+          const contentForBlockStartIndex = nodeInSource.indexOf(blockType);
+
+          const typeParamIndex = typeValueMatch.index + contentForBlockStartIndex;
+          const typeParamValueLength = entireTypeTerm.length;
+
+          const typeParamValueEndIndex = typeParamIndex + typeParamValueLength;
+
+          context.report({
+            message: `The type '${filteredTypeValue}' is not valid, use a type that exists in the blocks directory`,
+            startIndex: node.position.start + typeParamIndex,
+            endIndex: node.position.start + typeParamValueEndIndex,
+            suggest: [],
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -100,6 +100,9 @@ ValidJSON:
 ValidSchema:
   enabled: true
   severity: 0
+ValidStaticBlockType:
+  enabled: true
+  severity: 0
 VariableName:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -81,6 +81,9 @@ ValidJSON:
 ValidSchema:
   enabled: true
   severity: 0
+ValidStaticBlockType:
+  enabled: true
+  severity: 0
 VariableName:
   enabled: true
   severity: 1


### PR DESCRIPTION
## What are you adding in this PR?

Adds a new check to make sure that a static block is using a valid block type, one that exists in the directory of blocks.

Read more https://docs.google.com/document/d/1d1EpwfhbgSubLjEqMePZ30ZWJovuCt2mJQslgWSwex0/edit#heading=h.8i0fnctjpka9

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
