### PR TITLE
Theme Tools Release: 19-06-24

### DIFF
--- a/.changeset/nice-boats-raise.md
+++ b/.changeset/nice-boats-raise.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-check-common': minor
----
-
-Add new validation for the type of the static block

--- a/.changeset/silly-sheep-happen.md
+++ b/.changeset/silly-sheep-happen.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-check-common': minor
----
-
-Add `UniqueStaticBlockId` check which ensures the uniqueness of ids for static blocks defined in the same section/block file

--- a/packages/theme-check-browser/package.json
+++ b/packages/theme-check-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-browser",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -26,6 +26,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "2.7.0"
+    "@shopify/theme-check-common": "2.8.0"
   }
 }

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-common",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-docs-updater",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Scripts to initialize theme-check data with assets from the theme-liquid-docs repo.",
   "main": "dist/index.js",
   "author": "Albert Chu <albert.chu@shopify.com>",
@@ -30,7 +30,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "^2.7.0",
+    "@shopify/theme-check-common": "^2.8.0",
     "env-paths": "^2.2.1",
     "node-fetch": "^2.6.11"
   },

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-node",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -33,8 +33,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "2.7.0",
-    "@shopify/theme-check-docs-updater": "2.7.0",
+    "@shopify/theme-check-common": "2.8.0",
+    "@shopify/theme-check-docs-updater": "2.8.0",
     "glob": "^8.0.3",
     "yaml": "^2.3.0"
   },

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.11.3",
+    "@shopify/theme-language-server-common": "1.11.4",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.0.3",
-    "@shopify/theme-check-common": "2.7.0",
+    "@shopify/theme-check-common": "2.8.0",
     "@vscode/web-custom-data": "^0.4.6",
     "vscode-json-languageservice": "^5.3.10",
     "vscode-languageserver": "^8.0.2",

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,9 +27,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.11.3",
-    "@shopify/theme-check-node": "^2.7.0",
-    "@shopify/theme-check-docs-updater": "^2.7.0",
+    "@shopify/theme-language-server-common": "1.11.4",
+    "@shopify/theme-check-node": "^2.8.0",
+    "@shopify/theme-check-docs-updater": "^2.8.0",
     "glob": "^8.0.3",
     "node-fetch": "^2.6.11",
     "vscode-languageserver": "^8.0.2",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/shopify/theme-tools/issues"
   },
-  "version": "2.4.0",
+  "version": "2.4.1",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -60,12 +60,12 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.0.3",
     "@shopify/prettier-plugin-liquid": "^1.5.0",
-    "@shopify/theme-language-server-node": "^1.11.3",
+    "@shopify/theme-language-server-node": "^1.11.4",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0"
   },
   "devDependencies": {
-    "@shopify/theme-check-docs-updater": "^2.7.0",
+    "@shopify/theme-check-docs-updater": "^2.8.0",
     "@types/glob": "^8.0.0",
     "@types/node": "16.x",
     "@types/prettier": "^2.4.2",


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `2.4.0` -> `2.4.1`
### Changes:
- Patch bump because it depends on @shopify/theme-language-server-node

## `@shopify/theme-check-common`
Minor incremented `2.7.0` -> `2.8.0`
### Changes:
- Add new validation for the type of the static block
- Add `UniqueStaticBlockId` check which ensures the uniqueness of ids for static blocks defined in the same section/block file

## `@shopify/theme-check-browser`
Minor incremented `2.7.0` -> `2.8.0`

## `@shopify/theme-check-node`
Minor incremented `2.7.0` -> `2.8.0`

## `@shopify/theme-language-server-common`
Patch incremented `1.11.3` -> `1.11.4`

## `@shopify/theme-language-server-browser`
Patch incremented `1.11.3` -> `1.11.4`

## `@shopify/theme-language-server-node`
Patch incremented `1.11.3` -> `1.11.4`

## `@shopify/theme-check-docs-updater`
Minor incremented `2.7.0` -> `2.8.0`

