### PR TITLE
Add capture static blocks check

### DIFF
--- a/packages/theme-check-common/src/checks/capture-on-content-for-block/index.spec.ts
+++ b/packages/theme-check-common/src/checks/capture-on-content-for-block/index.spec.ts
@@ -1,0 +1,42 @@
+import { expect, describe, it } from 'vitest';
+import { highlightedOffenses, runLiquidCheck } from '../../test';
+import { CaptureOnContentForBlock } from './index';
+
+describe('Module: ContentForHeaderModification', () => {
+  it('reports offense with the use of capture', async () => {
+    const sourceCode = `
+      {% capture x %}
+        {% content_for "block", type: "text", id:"static-block-id" %}
+      {% endcapture %}
+    `;
+
+    const offenses = await runLiquidCheck(CaptureOnContentForBlock, sourceCode);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual('Do not capture `content_for "block"`');
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual(['{% content_for "block", type: "text", id:"static-block-id" %}']);
+  });
+
+  it('does not report an offense with normal use', async () => {
+    const sourceCode = '{% content_for "block", type: "text", id:"static-block-id" %}';
+
+    const offenses = await runLiquidCheck(CaptureOnContentForBlock, sourceCode);
+    expect(offenses).toHaveLength(0);
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toHaveLength(0);
+  });
+
+  it('does not report an offense with content_for "blocks"', async () => {
+    const sourceCode = `
+      {% capture x %}
+        {% content_for "blocks" %}
+      {% endcapture %}
+    `;
+
+    const offenses = await runLiquidCheck(CaptureOnContentForBlock, sourceCode);
+    expect(offenses).toHaveLength(0);
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/capture-on-content-for-block/index.ts
+++ b/packages/theme-check-common/src/checks/capture-on-content-for-block/index.ts
@@ -1,0 +1,62 @@
+import {
+  LiquidTag,
+  LiquidTagCapture,
+  NodeTypes,
+  Position,
+} from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { isContentForBlock } from '../../utils/markup';
+import { isNodeOfType } from '../utils';
+  
+  function isLiquidTagCapture(node: LiquidTag): node is LiquidTagCapture {
+    return node.name === 'capture' && typeof node.markup !== 'string';
+  }
+  
+  export const CaptureOnContentForBlock: LiquidCheckDefinition = {
+    meta: {
+      code: 'CaptureOnContentForBlock',
+      name: 'Do not capture `content_for "block"`',
+      docs: {
+        description:
+          'Capture of content_for "block" is restricted to enforce static block rendering at its expected location.',
+        url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/content_for_block',
+        recommended: true,
+      },
+      type: SourceCodeType.LiquidHtml,
+      severity: Severity.ERROR,
+      schema: {},
+      targets: [],
+    },
+  
+    create(context) {
+      function checkContentForBlock(node: any, position: Position) {
+        if (isNodeOfType(NodeTypes.LiquidTag, node) && node.name === 'content_for' && isContentForBlock(node.markup)) {
+          context.report({
+            message: 'Do not capture `content_for "block"`',
+            startIndex: position.start,
+            endIndex: position.end,
+          });
+        }
+      }
+  
+      return {
+        async LiquidTag(node) {
+          if (isLiquidTagCapture(node) && node.children) {
+            for (const child of node.children) {
+              if (child.type === NodeTypes.LiquidTag && typeof child.markup == 'string') {
+                checkContentForBlock(child, child.position);
+              }
+            }
+          }
+        },
+        async LiquidVariableOutput(node) {
+          if (typeof node.markup === 'string') return;
+  
+          if (node.markup.filters.length) {
+            checkContentForBlock(node.markup.expression, node.position);
+          }
+        },
+      };
+    },
+  };
+  

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -7,6 +7,7 @@ import { AssetSizeAppBlockJavaScript } from './asset-size-app-block-javascript';
 import { AssetSizeCSS } from './asset-size-css';
 import { AssetSizeJavaScript } from './asset-size-javascript';
 import { CdnPreconnect } from './cdn-preconnect';
+import { CaptureOnContentForBlock } from './capture-on-content-for-block';
 import { ContentForHeaderModification } from './content-for-header-modification';
 import { DeprecateBgsizes } from './deprecate-bgsizes';
 import { DeprecateLazysizes } from './deprecate-lazysizes';
@@ -41,12 +42,13 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AssetSizeAppBlockJavaScript,
   AssetSizeCSS,
   AssetSizeJavaScript,
+  CaptureOnContentForBlock,
   CdnPreconnect,
   ContentForHeaderModification,
   DeprecateBgsizes,
-  DeprecateLazysizes,
   DeprecatedFilter,
   DeprecatedTag,
+  DeprecateLazysizes,
   ImgWidthAndHeight,
   JSONSyntaxError,
   LiquidHTMLSyntaxError,
@@ -60,14 +62,14 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   TranslationKeyExists,
   UnclosedHTMLElement,
   UndefinedObject,
+  UniqueStaticBlockId,
   UnknownFilter,
   UnusedAssign,
   ValidHTMLTranslation,
-  ValidSchema,
   ValidJSON,
-  VariableName,
+  ValidSchema,
   ValidStaticBlockType,
-  UniqueStaticBlockId,
+  VariableName,
 ];
 
 /**

--- a/packages/theme-check-common/src/checks/valid-static-block-type/index.ts
+++ b/packages/theme-check-common/src/checks/valid-static-block-type/index.ts
@@ -1,5 +1,6 @@
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { doesFileExist } from '../../utils/file-utils';
+import { isContentForBlock } from '../../utils/markup';
 
 export const ValidStaticBlockType: LiquidCheckDefinition = {
   meta: {
@@ -26,9 +27,7 @@ export const ValidStaticBlockType: LiquidCheckDefinition = {
           return;
         }
 
-        const [blockType] = node.markup.split(',');
-
-        if (blockType.replace(/["']/g, '') !== 'block') {
+        if(!isContentForBlock(node.markup)) {
           return;
         }
 
@@ -43,6 +42,7 @@ export const ValidStaticBlockType: LiquidCheckDefinition = {
         const fileExists = await doesFileExist(context, relativePath);
 
         if (!fileExists) {
+          const [blockType] = node.markup.split(',')
           const nodeInSource = node.source.substring(node.position.start);
           const contentForBlockStartIndex = nodeInSource.indexOf(blockType);
 

--- a/packages/theme-check-common/src/utils/markup.ts
+++ b/packages/theme-check-common/src/utils/markup.ts
@@ -1,0 +1,7 @@
+export function isContentForBlock(nodeMarkup: string) {
+  const [blockType] = nodeMarkup.split(',')
+  if (blockType.replace(/["']/g, '') !== 'block') {
+    return false;
+  }
+  return true;
+}

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -25,6 +25,9 @@ AssetSizeJavaScript:
   enabled: true
   severity: 0
   thresholdInBytes: 10000
+CaptureOnContentForBlock:
+  enabled: true
+  severity: 0
 CdnPreconnect:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -6,6 +6,9 @@ ignore:
 AssetPreload:
   enabled: true
   severity: 1
+CaptureOnContentForBlock:
+  enabled: true
+  severity: 0
 CdnPreconnect:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?

This resolves "Linter on the use of Capture tag with static blocks (static blocks used in 'capture')" on the list of [Theme Checks for Static Blocks](https://github.com/Shopify/shopify/issues/500006)

## What's next? Any followup issues?

No

## What did you learn?

First theme check, so I learned a lot of introductory things :)

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
