### PR TITLE
Expose the `parseJSON` API in `@shopify/theme-language-server-common`

### DIFF
--- a/.changeset/lucky-students-smash.md
+++ b/.changeset/lucky-students-smash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Expose the `parseJSON` API in `@shopify/theme-language-server-common`

--- a/packages/theme-language-server-common/src/index.ts
+++ b/packages/theme-language-server-common/src/index.ts
@@ -5,6 +5,6 @@ import {
 } from '@shopify/theme-check-common';
 
 export * from './types';
-export { debounce, memo, ArgumentTypes } from './utils';
+export { debounce, memo, parseJSON, ArgumentTypes } from './utils';
 export { startServer } from './server';
 export { ThemeCheckConfig, recommendedChecks, allChecks };

--- a/packages/theme-language-server-common/src/utils/index.ts
+++ b/packages/theme-language-server-common/src/utils/index.ts
@@ -4,6 +4,7 @@ export {
   WithRequired,
   memo,
   memoize,
+  parseJSON,
 } from '@shopify/theme-check-common';
 export * from './debounce';
 export * from './paths';


### PR DESCRIPTION
## What are you adding in this PR?

This PR exposes the `parseJSON` utility along with other functions in `@shopify/theme-language-server-common`.

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
