### PR TITLE
Theme Tools Release: 02-07-24

### DIFF
--- a/.changeset/lucky-students-smash.md
+++ b/.changeset/lucky-students-smash.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-language-server-common': minor
----
-
-Expose the `parseJSON` API in `@shopify/theme-language-server-common`

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-browser
 
+## 1.12.0
+
+### Patch Changes
+
+- Updated dependencies [d7c6204]
+  - @shopify/theme-language-server-common@1.12.0
+
 ## 1.11.3
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.11.4",
+    "@shopify/theme-language-server-common": "1.12.0",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-language-server-common
 
+## 1.12.0
+
+### Minor Changes
+
+- d7c6204: Expose the `parseJSON` API in `@shopify/theme-language-server-common`
+
 ## 1.11.3
 
 ### Patch Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-node
 
+## 1.12.0
+
+### Patch Changes
+
+- Updated dependencies [d7c6204]
+  - @shopify/theme-language-server-common@1.12.0
+
 ## 1.11.3
 
 ### Patch Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "1.11.4",
+    "@shopify/theme-language-server-common": "1.12.0",
     "@shopify/theme-check-node": "^2.8.0",
     "@shopify/theme-check-docs-updater": "^2.8.0",
     "glob": "^8.0.3",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## theme-check-vscode
 
+## 2.4.2
+
+### Patch Changes
+
+- Patch bump because it depends on @shopify/theme-language-server-node
+  - @shopify/theme-language-server-node@1.12.0
+
 ## 2.4.0
 
 ### Minor Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/shopify/theme-tools/issues"
   },
-  "version": "2.4.1",
+  "version": "2.4.2",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -60,7 +60,7 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.0.3",
     "@shopify/prettier-plugin-liquid": "^1.5.0",
-    "@shopify/theme-language-server-node": "^1.11.4",
+    "@shopify/theme-language-server-node": "^1.12.0",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0"
   },


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `2.4.1` -> `2.4.2`
### Changes:
- Patch bump because it depends on @shopify/theme-language-server-node

## `@shopify/theme-language-server-common`
Minor incremented `1.11.4` -> `1.12.0`
### Changes:
- Expose the `parseJSON` API in `@shopify/theme-language-server-common`

## `@shopify/theme-language-server-browser`
Minor incremented `1.11.4` -> `1.12.0`

## `@shopify/theme-language-server-node`
Minor incremented `1.11.4` -> `1.12.0`

