### PR TITLE
Fix number formatting

### DIFF
--- a/packages/theme-check-common/src/checks/variable-name/index.ts
+++ b/packages/theme-check-common/src/checks/variable-name/index.ts
@@ -62,10 +62,9 @@ export const VariableName: LiquidCheckDefinition<typeof schema> = {
         };
       }
 
-      const suggestion = formatTypes[context.settings.format as FormatTypes].call(
-        null,
-        node.markup.name,
-      );
+      const suggestion = formatTypes[context.settings.format as FormatTypes]
+        .call(null, node.markup.name)
+        .replace(/(\d+)[-_]((?=[a-z]))/g, '$1');
 
       return {
         valid: node.markup.name === suggestion,


### PR DESCRIPTION
## What are you adding in this PR?

Changes the formatter handling of `VariableName` check, to default to more regular standards, based on general theme developers naming of variables.

Related to this issue: https://github.com/Shopify/theme-tools/issues/397

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
