### PR TITLE
Update VariableName docs url

### DIFF
--- a/packages/theme-check-common/src/checks/variable-name/index.ts
+++ b/packages/theme-check-common/src/checks/variable-name/index.ts
@@ -45,7 +45,7 @@ export const VariableName: LiquidCheckDefinition<typeof schema> = {
     name: 'Invalid variable naming format',
     docs: {
       description: 'This check is aimed at using certain variable naming conventions',
-      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/variable-name',
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/variable-name',
       recommended: true,
     },
     type: SourceCodeType.LiquidHtml,


### PR DESCRIPTION
## What are you adding in this PR?

The previous link to the VariableName docs in Shopify theme check is going to a 404 page in /docs/themes/. I've updated it to the correct link in /docs/storefronts/.

## What's next? Any followup issues?

There are many other /docs/themes/ urls that should be updated to their new location on the /docs/storefronts/.