### PR TITLE
We should have HTML attribute snippet completion of the =""

### DIFF
--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.ts
@@ -45,9 +45,13 @@ function getOptions(partial: string, parentNodeName: string): Attribute[] {
 }
 
 function toCompletionItem(tag: Attribute): CompletionItem {
+  const plainText = !tag.valueSet || tag.valueSet !== 'v';
+
   return {
     label: tag.name,
     kind: CompletionItemKind.Value,
+    insertText: plainText ? `${tag.name}="$1"` : tag.name,
+    insertTextFormat: plainText ? 2 : 1,
     documentation: {
       kind: 'markdown',
       value: renderHtmlEntry(tag),


### PR DESCRIPTION
## What are you adding in this PR?
HTML attribute autocompletion (`=""`)

<!-- Describe your changes. Provide enough context so that someone new can understand the 'why' behind this change. -->
- `insertText` to add the right SnippetString
- `insertTextFormat` to determine if it's a snippet or plain text

<!-- Remember to use `fixes` or `solves` keywords to close issues automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->
closes #345

## What did you learn?

<!-- Totally optional. But... If you learned something interesting, why not share it? -->
Struggled quite some time to get the tab stops working. Went back to the original issue where @charlespwd already mentioned something about the `insertTextFormat`. Forgot about it, but then (little late) it came up again.

I was already familiar with snippets and extensions, but the Shopify theme-tools repo can be quite overwhelming.

If someone has good knowledge about testing/debugging extension (F5), please let me know how to make change (e.g. add a console) without the need to fully restart everything, let me know :)