### PR TITLE
Fix broken parsing of liquid attribute names

### DIFF
--- a/.changeset/wicked-balloons-reply.md
+++ b/.changeset/wicked-balloons-reply.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+Fix broken parsing of liquid attribute names

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -430,7 +430,7 @@ LiquidHTML <: Liquid {
   AttrList = Attr*
 
   Attr =
-    liquidNode | AttrSingleQuoted | AttrDoubleQuoted | AttrUnquoted | attrEmpty
+    AttrSingleQuoted | AttrDoubleQuoted | AttrUnquoted | liquidNode | attrEmpty
 
   attrEmpty = attrName
 

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1107,6 +1107,19 @@ describe('Unit: Stage 1 (CST)', () => {
         });
       });
 
+      it('should parse liquid attribute names', () => {
+        cst = toLiquidHtmlCST('<img {{ data-name }}="{{ data-value }}"/>');
+        expectPath(cst, '0.name').to.equal('img');
+        expectPath(cst, '0.type').to.equal('HtmlVoidElement');
+        expectPath(cst, '0.attrList.0.type').to.equal('AttrDoubleQuoted');
+        expectPath(cst, '0.attrList.0.name.0.type').to.equal('LiquidVariableOutput');
+        expectPath(cst, '0.attrList.0.name.0.markup.expression.type').to.equal('VariableLookup');
+        expectPath(cst, '0.attrList.0.name.0.markup.expression.name').to.equal('data-name');
+        expectPath(cst, '0.attrList.0.value.0.type').to.equal('LiquidVariableOutput');
+        expectPath(cst, '0.attrList.0.value.0.markup.expression.type').to.equal('VariableLookup');
+        expectPath(cst, '0.attrList.0.value.0.markup.expression.name').to.equal('data-value');
+      });
+
       it(`should parse quoted attributes`, () => {
         [
           { type: 'AttrSingleQuoted', name: 'single', quote: "'" },


### PR DESCRIPTION
## What are you adding in this PR?

Resolves #335 

This was occurring because the liquid variable was being parsed as a liquid node, rather than a double quoted attribute. 

## What did you learn?

@charlespwd Gave a great explanation on how ohmjs is used to build the CST prior to parsing things into an AST. He also showed me how to use https://ohmjs.org/editor/ to debug issues with the CST parsing. Thank you!

![image](https://github.com/user-attachments/assets/8aa8b801-ac94-45ca-8f2d-8f4e3c5ea8e0)


## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
