### PR TITLE
Fix completion in tags nested in a liquid LiquidTag.

### DIFF
--- a/.changeset/angry-cobras-check.md
+++ b/.changeset/angry-cobras-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Fix completion of variables inside `{% liquid %}` tag expressions

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
@@ -177,6 +177,11 @@ describe('Module: LiquidCompletionParams', async () => {
           `{% liquid
             echo a█
            %}`,
+          `{% liquid
+            if x == 'string'
+              echo a█
+            endif
+           %}`,
           `{% for x in (1..a█) %}`,
           // `{% paginate a█ by 50 %}`,
           `<a-{{ a█ }}`,

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -219,8 +219,9 @@ function findCurrentNode(
 
       case NodeTypes.LiquidTag: {
         if (
-          isLiquidLiquidTag(finder.parent) ||
-          isCoveredExcluded(cursor, current.blockStartPosition)
+          isLiquidLiquidTag(finder.current) ||
+          isCoveredExcluded(cursor, current.blockStartPosition) || // wouldn't want to complete {% if cond %} after the }.
+          (isInLiquidLiquidTagContext(finder) && isCovered(cursor, current.blockStartPosition))
         ) {
           if (hasNonNullProperty(current, 'markup') && typeof current.markup !== 'string') {
             finder.current = Array.isArray(current.markup) ? current.markup.at(-1) : current.markup;
@@ -433,6 +434,10 @@ function hasNonEmptyArrayProperty<K extends PropertyKey>(
     Array.isArray(thing[property]) &&
     !isEmpty(thing[property])
   );
+}
+
+function isInLiquidLiquidTagContext(finder: Finder): boolean {
+  return finder.stack.some(isLiquidLiquidTag);
 }
 
 function isLiquidLiquidTag(


### PR DESCRIPTION
Fixes #484

## What are you adding in this PR?

- Fixing completion when inside a `{% liquid %}` tag. It's probably
easier to just look at the unit tests that were failing before the
change was made.

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
