### PR TITLE
Add LinkedEditingRanges support for HTML tag names

### DIFF
--- a/.changeset/blue-mice-kick.md
+++ b/.changeset/blue-mice-kick.md
@@ -1,0 +1,15 @@
+---
+'@shopify/theme-language-server-common': minor
+'theme-check-vscode': minor
+---
+
+Add linked editing support for HTML element names
+
+Just like for [HTML in VS Code](https://code.visualstudio.com/updates/v1_52#_html), this feature is enabled by the `editor.linkedEditing` VS Code setting:
+
+```json
+"editor.linkedEditing": true
+```
+
+
+When enabled, this will make it so you can rename open/close pairs as you are typing.

--- a/packages/theme-language-server-common/src/linkedEditingRanges/BaseLinkedEditingRangesProvider.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/BaseLinkedEditingRangesProvider.ts
@@ -1,0 +1,10 @@
+import { LiquidHtmlNode } from '@shopify/liquid-html-parser';
+import { LinkedEditingRangeParams, LinkedEditingRanges } from 'vscode-languageserver';
+
+export interface BaseLinkedEditingRangesProvider {
+  linkedEditingRanges: (
+    node: LiquidHtmlNode | null,
+    ancestors: LiquidHtmlNode[] | null,
+    params: LinkedEditingRangeParams,
+  ) => Promise<LinkedEditingRanges | null>;
+}

--- a/packages/theme-language-server-common/src/linkedEditingRanges/LinkedEditingRangesProvider.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/LinkedEditingRangesProvider.ts
@@ -1,0 +1,40 @@
+import { LiquidHtmlNode, SourceCodeType } from '@shopify/theme-check-common';
+import { LinkedEditingRangeParams, LinkedEditingRanges } from 'vscode-languageserver';
+import { DocumentManager } from '../documents';
+import { findCurrentNode } from '../visitor';
+import { BaseLinkedEditingRangesProvider } from './BaseLinkedEditingRangesProvider';
+import { EmptyHtmlTagLinkedRangesProvider, HtmlTagNameLinkedRangesProvider } from './providers';
+
+export class LinkedEditingRangesProvider {
+  private providers: BaseLinkedEditingRangesProvider[];
+
+  constructor(public documentManager: DocumentManager) {
+    this.providers = [
+      new HtmlTagNameLinkedRangesProvider(documentManager),
+      new EmptyHtmlTagLinkedRangesProvider(documentManager),
+    ];
+  }
+
+  async linkedEditingRanges(params: LinkedEditingRangeParams): Promise<LinkedEditingRanges | null> {
+    const document = this.documentManager.get(params.textDocument.uri);
+    if (!document || document.type !== SourceCodeType.LiquidHtml) {
+      return null;
+    }
+
+    let currentNode: LiquidHtmlNode | null = null;
+    let ancestors: LiquidHtmlNode[] | null = null;
+
+    if (!(document.ast instanceof Error)) {
+      [currentNode, ancestors] = findCurrentNode(
+        document.ast,
+        document.textDocument.offsetAt(params.position),
+      );
+    }
+
+    const promises = this.providers.map((p) =>
+      p.linkedEditingRanges(currentNode, ancestors, params).catch(() => null),
+    );
+    const results = await Promise.all(promises);
+    return results.find(Boolean) ?? null;
+  }
+}

--- a/packages/theme-language-server-common/src/linkedEditingRanges/index.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/index.ts
@@ -1,0 +1,1 @@
+export { LinkedEditingRangesProvider } from './LinkedEditingRangesProvider';

--- a/packages/theme-language-server-common/src/linkedEditingRanges/providers/EmptyHtmlTagLinkedRangesProvider.spec.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/providers/EmptyHtmlTagLinkedRangesProvider.spec.ts
@@ -1,0 +1,74 @@
+import { describe, beforeEach, it, expect, assert } from 'vitest';
+import { LinkedEditingRangesProvider } from '..';
+import { DocumentManager } from '../../documents';
+import { LinkedEditingRangeParams } from 'vscode-languageserver';
+import { Position } from 'vscode-languageserver-protocol';
+import { htmlElementNameWordPattern } from '../wordPattern';
+
+describe('Module: EmptyHtmlTagLinkedRangesProvider', () => {
+  let documentManager: DocumentManager;
+  let provider: LinkedEditingRangesProvider;
+
+  beforeEach(() => {
+    documentManager = new DocumentManager();
+    provider = new LinkedEditingRangesProvider(documentManager);
+  });
+
+  it('should return null for non-existent documents', async () => {
+    const params: LinkedEditingRangeParams = {
+      textDocument: { uri: 'file:///path/to/non-existent-document.liquid' },
+      position: Position.create(0, 0),
+    };
+
+    const result = await provider.linkedEditingRanges(params);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for non-empty HTML tags', async () => {
+    const params: LinkedEditingRangeParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 0),
+    };
+
+    documentManager.open(params.textDocument.uri, '<div></div>', 1);
+
+    const result = await provider.linkedEditingRanges(params);
+    expect(result).toBeNull();
+  });
+
+  it('should return linked editing ranges for empty HTML tags', async () => {
+    const params: LinkedEditingRangeParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 1), // position within the empty tag
+    };
+
+    documentManager.open(params.textDocument.uri, '<></>', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.linkedEditingRanges(params);
+    assert(result);
+    assert(result.ranges[0]);
+    assert(result.ranges[1]);
+    expect(result.ranges[0]).not.to.eql(result.ranges[1]);
+
+    const startTag = document.getText(result.ranges[0]);
+    const endTag = document.getText(result.ranges[1]);
+
+    expect(startTag).toBe('');
+    expect(endTag).toBe('');
+    expect(result.wordPattern).toBe(htmlElementNameWordPattern);
+  });
+
+  it('should return null for positions not within empty HTML tags', async () => {
+    const params: LinkedEditingRangeParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 0), // position outside the tag
+    };
+
+    documentManager.open(params.textDocument.uri, '<></>', 1);
+
+    const result = await provider.linkedEditingRanges(params);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/theme-language-server-common/src/linkedEditingRanges/providers/EmptyHtmlTagLinkedRangesProvider.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/providers/EmptyHtmlTagLinkedRangesProvider.ts
@@ -1,0 +1,47 @@
+import { LiquidHtmlNode } from '@shopify/liquid-html-parser';
+import {
+  LinkedEditingRangeParams,
+  LinkedEditingRanges,
+  Position,
+  Range,
+} from 'vscode-languageserver';
+import { DocumentManager } from '../../documents';
+import { BaseLinkedEditingRangesProvider } from '../BaseLinkedEditingRangesProvider';
+import { htmlElementNameWordPattern } from '../wordPattern';
+
+export class EmptyHtmlTagLinkedRangesProvider implements BaseLinkedEditingRangesProvider {
+  constructor(public documentManager: DocumentManager) {}
+
+  async linkedEditingRanges(
+    node: LiquidHtmlNode | null,
+    ancestors: LiquidHtmlNode[] | null,
+    { textDocument: { uri }, position }: LinkedEditingRangeParams,
+  ): Promise<LinkedEditingRanges | null> {
+    // We're strictly checking for <></> and cursor in either branch, that's a parse error
+    // ... but it's fine because <></> is rather easy to find.
+    if (node !== null || ancestors !== null) return null;
+    const document = this.documentManager.get(uri);
+    const textDocument = document?.textDocument;
+
+    if (!document || !textDocument) return null;
+    const openRange = Range.create(
+      Position.create(position.line, position.character - 1),
+      Position.create(position.line, position.character + 1),
+    );
+    if (!['<>', '< '].includes(textDocument.getText(openRange))) return null;
+
+    const closeOffset = document.source.indexOf('</>', textDocument.offsetAt(position));
+    if (closeOffset === -1) return null;
+
+    const afterSlashOffset = closeOffset + 2;
+    const afterSlashPosition = textDocument.positionAt(afterSlashOffset);
+
+    return {
+      ranges: [
+        Range.create(position, position),
+        Range.create(afterSlashPosition, afterSlashPosition),
+      ],
+      wordPattern: htmlElementNameWordPattern,
+    };
+  }
+}

--- a/packages/theme-language-server-common/src/linkedEditingRanges/providers/HtmlTagNameLinkedRangesProvider.spec.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/providers/HtmlTagNameLinkedRangesProvider.spec.ts
@@ -1,0 +1,97 @@
+import { describe, beforeEach, it, expect, assert } from 'vitest';
+import { LinkedEditingRangesProvider } from '../LinkedEditingRangesProvider';
+import { DocumentManager } from '../../documents';
+import { LinkedEditingRangeParams } from 'vscode-languageserver';
+import { Position } from 'vscode-languageserver-protocol';
+import { htmlElementNameWordPattern } from '../wordPattern';
+
+describe('Module: HtmlTagNameLinkedRangesProvider', () => {
+  let documentManager: DocumentManager;
+  let provider: LinkedEditingRangesProvider;
+
+  beforeEach(() => {
+    documentManager = new DocumentManager();
+    provider = new LinkedEditingRangesProvider(documentManager);
+  });
+
+  it('should return null for non-existent documents', async () => {
+    const params: LinkedEditingRangeParams = {
+      textDocument: { uri: 'file:///path/to/non-existent-document.liquid' },
+      position: Position.create(0, 0),
+    };
+
+    const result = await provider.linkedEditingRanges(params);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for non-HTML documents', async () => {
+    const params: LinkedEditingRangeParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 0),
+    };
+
+    documentManager.open(params.textDocument.uri, 'Sample text content', 1);
+
+    const result = await provider.linkedEditingRanges(params);
+    expect(result).toBeNull();
+  });
+
+  it('should return linked editing ranges for HTML tag names', async () => {
+    const params: LinkedEditingRangeParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 3), // position within the tag name
+    };
+
+    documentManager.open(params.textDocument.uri, '<div></div>', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.linkedEditingRanges(params);
+    assert(result);
+    assert(result.ranges[0]);
+    assert(result.ranges[1]);
+    expect(result.ranges[0]).not.to.eql(result.ranges[1]);
+
+    const startTagName = document.getText(result.ranges[0]);
+    const endTagName = document.getText(result.ranges[1]);
+
+    expect(startTagName).toBe('div');
+    expect(endTagName).toBe('div');
+    expect(result.wordPattern).toBe(htmlElementNameWordPattern);
+  });
+
+  it('should return linked editing ranges for closing HTML tag names', async () => {
+    const params: LinkedEditingRangeParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 16), // position within the closing div tag name
+    };
+
+    documentManager.open(params.textDocument.uri, '<div><img><div></div></div>', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.linkedEditingRanges(params);
+    assert(result);
+    assert(result.ranges[0]);
+    assert(result.ranges[1]);
+
+    const startTagName = document.getText(result.ranges[0]);
+    const endTagName = document.getText(result.ranges[1]);
+
+    expect(startTagName).toBe('div');
+    expect(endTagName).toBe('div');
+    expect(result.wordPattern).toBe(htmlElementNameWordPattern);
+  });
+
+  it('should return null for positions not within HTML tag names', async () => {
+    const params: LinkedEditingRangeParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 0), // position outside the tag name
+    };
+
+    documentManager.open(params.textDocument.uri, '<div></div>', 1);
+
+    const result = await provider.linkedEditingRanges(params);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/theme-language-server-common/src/linkedEditingRanges/providers/HtmlTagNameLinkedRangesProvider.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/providers/HtmlTagNameLinkedRangesProvider.ts
@@ -1,0 +1,28 @@
+import { LiquidHtmlNode } from '@shopify/liquid-html-parser';
+import { LinkedEditingRangeParams } from 'vscode-languageserver';
+import { DocumentManager } from '../../documents';
+import { BaseLinkedEditingRangesProvider } from '../BaseLinkedEditingRangesProvider';
+import { getHtmlElementNameRanges } from '../../utils/htmlTagNames';
+import { htmlElementNameWordPattern } from '../wordPattern';
+
+export class HtmlTagNameLinkedRangesProvider implements BaseLinkedEditingRangesProvider {
+  constructor(public documentManager: DocumentManager) {}
+
+  async linkedEditingRanges(
+    node: LiquidHtmlNode | null,
+    ancestors: LiquidHtmlNode[] | null,
+    params: LinkedEditingRangeParams,
+  ) {
+    if (!node || !ancestors) return null;
+
+    const textDocument = this.documentManager.get(params.textDocument.uri)?.textDocument;
+    if (!textDocument) return null;
+
+    const ranges = getHtmlElementNameRanges(node, ancestors, params, textDocument);
+    if (!ranges) return null;
+    return {
+      ranges,
+      wordPattern: htmlElementNameWordPattern,
+    };
+  }
+}

--- a/packages/theme-language-server-common/src/linkedEditingRanges/providers/index.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/providers/index.ts
@@ -1,0 +1,2 @@
+export { EmptyHtmlTagLinkedRangesProvider } from './EmptyHtmlTagLinkedRangesProvider';
+export { HtmlTagNameLinkedRangesProvider } from './HtmlTagNameLinkedRangesProvider';

--- a/packages/theme-language-server-common/src/linkedEditingRanges/wordPattern.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/wordPattern.ts
@@ -1,0 +1,3 @@
+const nameCharStart = '[a-zA-Z]';
+const nameChar = '[a-zA-Z0-9-]';
+export const htmlElementNameWordPattern = `${nameCharStart}${nameChar}*`;

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -17,10 +17,11 @@ import { DocumentManager } from '../documents';
 import { OnTypeFormattingProvider } from '../formatting';
 import { HoverProvider } from '../hover';
 import { JSONLanguageService } from '../json/JSONLanguageService';
+import { LinkedEditingRangesProvider } from '../linkedEditingRanges/LinkedEditingRangesProvider';
 import {
   GetTranslationsForURI,
-  useBufferOrInjectedTranslations,
   useBufferOrInjectedSchemaTranslations,
+  useBufferOrInjectedTranslations,
 } from '../translations';
 import { Dependencies } from '../types';
 import { debounce } from '../utils';
@@ -64,6 +65,7 @@ export function startServer(
   const documentLinksProvider = new DocumentLinksProvider(documentManager);
   const codeActionsProvider = new CodeActionsProvider(documentManager, diagnosticsManager);
   const onTypeFormattingProvider = new OnTypeFormattingProvider(documentManager);
+  const linkedEditingRangesProvider = new LinkedEditingRangesProvider(documentManager);
 
   const findThemeRootURI = async (uri: string) => {
     const rootUri = await findConfigurationRootURI(uri);
@@ -204,6 +206,7 @@ export function startServer(
           resolveProvider: false,
           workDoneProgress: false,
         },
+        linkedEditingRangeProvider: true,
         executeCommandProvider: {
           commands: [...Commands],
         },
@@ -296,6 +299,10 @@ export function startServer(
 
   connection.onDocumentOnTypeFormatting(async (params) => {
     return onTypeFormattingProvider.onTypeFormatting(params);
+  });
+
+  connection.languages.onLinkedEditingRange(async (params) => {
+    return linkedEditingRangesProvider.linkedEditingRanges(params);
   });
 
   // These notifications could cause a MissingSnippet check to be invalidated

--- a/packages/theme-language-server-common/src/utils/htmlTagNames.ts
+++ b/packages/theme-language-server-common/src/utils/htmlTagNames.ts
@@ -1,0 +1,54 @@
+import { LiquidHtmlNode, HtmlElement, NodeTypes } from '@shopify/liquid-html-parser';
+import { TextDocumentPositionParams, Range } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { isCovered } from './isCovered';
+
+export function getHtmlElementNameRanges(
+  node: LiquidHtmlNode,
+  ancestors: LiquidHtmlNode[],
+  params: TextDocumentPositionParams,
+  textDocument: TextDocument,
+): Range[] | null {
+  let htmlElementNode: HtmlElement | null = null;
+
+  // Try parent node as HTML Element
+  // <name> case
+  const parentNode = ancestors.at(-1);
+  if (
+    parentNode &&
+    parentNode.type === NodeTypes.HtmlElement &&
+    parentNode.name.length > 0 &&
+    isCovered(textDocument.offsetAt(params.position), {
+      start: parentNode.name[0].position.start,
+      end: parentNode.name.at(-1)!.position.end,
+    })
+  ) {
+    htmlElementNode = parentNode;
+  }
+
+  // </name> case
+  if (
+    node.type === NodeTypes.HtmlElement &&
+    node.name.length > 0 &&
+    isCovered(textDocument.offsetAt(params.position), node.blockEndPosition)
+  ) {
+    htmlElementNode = node;
+  }
+
+  if (!htmlElementNode) return null;
+
+  const nameNodes = htmlElementNode.name;
+  const firstNode = nameNodes.at(0)!;
+  const lastNode = nameNodes.at(-1)!;
+  const startRange = Range.create(
+    textDocument.positionAt(firstNode.position.start),
+    textDocument.positionAt(lastNode.position.end),
+  );
+  const endRange = Range.create(
+    // </ means offset 2 characters
+    textDocument.positionAt(htmlElementNode.blockEndPosition.start + 2),
+    textDocument.positionAt(htmlElementNode.blockEndPosition.end - 1),
+  );
+
+  return [startRange, endRange];
+}

--- a/packages/theme-language-server-common/src/utils/index.ts
+++ b/packages/theme-language-server-common/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './debounce';
 export * from './paths';
 export * from './array';
 export * from './node';
+export * from './isCovered';

--- a/packages/theme-language-server-common/src/utils/isCovered.ts
+++ b/packages/theme-language-server-common/src/utils/isCovered.ts
@@ -1,0 +1,3 @@
+export function isCovered(offset: number, range: { start: number; end: number }): boolean {
+  return range.start <= offset && offset <= range.end;
+}


### PR DESCRIPTION
## What are you adding in this PR?

- Add [linked editing](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_linkedEditingRange) support for HTML element names

https://github.com/user-attachments/assets/0b53f4c2-6f09-405b-9047-d157cd4620fd




Just like for [HTML in VS Code](https://code.visualstudio.com/updates/v1_52#_html), this feature is enabled by the `editor.linkedEditing` VS Code setting:

```json
"editor.linkedEditing": true
```

When enabled, this will make it so you can rename open/close pairs as you are typing.

## How it works

VS Code and other language clients can send `client->server` [Linked Editing Range][ler] requests
to language servers to figure out what pieces of content should change together.

Our job in the language server is to provide those ranges when they are requested for.

## What's next? Any followup issues?

- Add DocumentHighlight support
- Add Rename and PrepareRename support
- Add codemirror language client support

## Before you deploy

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

[ler]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_linkedEditingRange
