### PR TITLE
Add DocumentHighlight support for HTML tags and Liquid blocks

### DIFF
--- a/.changeset/thick-ravens-peel.md
+++ b/.changeset/thick-ravens-peel.md
@@ -1,0 +1,27 @@
+---
+'@shopify/theme-language-server-common': minor
+'theme-check-vscode': minor
+---
+
+Add tupled highlighting of HTML element names and Liquid blocks
+
+When you hover over a HTML tag open, the close tag is highlighted and vice-versa.
+
+```html
+<div> <!-- this div gets highlighted -->
+   <div></div>
+</div> <!-- with this one-->
+```
+
+When you hover over a Liquid block open, the close block is highlighted (and branches if any).
+
+```liquid
+{% # this if, elsif, else, endif all get highlighted together %}
+{% if cond %}
+
+{% elsif cond %}
+
+{% else %}
+
+{% endif %}
+```

--- a/packages/theme-language-server-common/src/documentHighlights/BaseDocumentHighlightsProvider.ts
+++ b/packages/theme-language-server-common/src/documentHighlights/BaseDocumentHighlightsProvider.ts
@@ -1,0 +1,10 @@
+import { DocumentHighlight, DocumentHighlightParams } from 'vscode-languageserver';
+import { LiquidHtmlNode } from '@shopify/theme-check-common';
+
+export interface BaseDocumentHighlightsProvider {
+  documentHighlights: (
+    node: LiquidHtmlNode,
+    ancestors: LiquidHtmlNode[],
+    params: DocumentHighlightParams,
+  ) => Promise<DocumentHighlight[] | null>;
+}

--- a/packages/theme-language-server-common/src/documentHighlights/DocumentHighlightsProvider.ts
+++ b/packages/theme-language-server-common/src/documentHighlights/DocumentHighlightsProvider.ts
@@ -1,0 +1,54 @@
+import { SourceCodeType } from '@shopify/theme-check-common';
+import { DocumentHighlight, DocumentHighlightParams } from 'vscode-languageserver';
+import { DocumentManager } from '../documents';
+import { findCurrentNode } from '../visitor';
+import { BaseDocumentHighlightsProvider } from './BaseDocumentHighlightsProvider';
+import {
+  HtmlTagNameDocumentHighlightsProvider,
+  LiquidBlockTagDocumentHighlightsProvider,
+} from './providers';
+
+/**
+ * The default behaviour for documentHighlights is to highlight every occurence
+ * of the word under the cursor. We want to prevent that since it doesn't really
+ * make sense in our context. We don't want to highlight every occurence of
+ * `assign` when you put your cursor over it.
+ */
+export const PREVENT_DEFAULT: DocumentHighlight[] = [];
+
+/**
+ * Informs the client to highlight ranges in a document.
+ *
+ * This is a pretty abstract concept, but you could use it to highlight all
+ * instances of a variable in a template, to highlight the matching
+ * opening/closing liquid tags, html tags, etc.
+ */
+export class DocumentHighlightsProvider {
+  private providers: BaseDocumentHighlightsProvider[];
+
+  constructor(public documentManager: DocumentManager) {
+    this.providers = [
+      new HtmlTagNameDocumentHighlightsProvider(documentManager),
+      new LiquidBlockTagDocumentHighlightsProvider(documentManager),
+    ];
+  }
+
+  async documentHighlights(params: DocumentHighlightParams): Promise<DocumentHighlight[] | null> {
+    const document = this.documentManager.get(params.textDocument.uri);
+    if (!document || document.type !== SourceCodeType.LiquidHtml || document.ast instanceof Error) {
+      return PREVENT_DEFAULT;
+    }
+
+    const [currentNode, ancestors] = findCurrentNode(
+      document.ast,
+      document.textDocument.offsetAt(params.position),
+    );
+
+    const promises = this.providers.map((p) =>
+      p.documentHighlights(currentNode, ancestors, params).catch(() => null),
+    );
+    const results = await Promise.all(promises);
+
+    return results.find(Boolean) ?? PREVENT_DEFAULT;
+  }
+}

--- a/packages/theme-language-server-common/src/documentHighlights/index.ts
+++ b/packages/theme-language-server-common/src/documentHighlights/index.ts
@@ -1,0 +1,1 @@
+export { DocumentHighlightsProvider, PREVENT_DEFAULT } from './DocumentHighlightsProvider';

--- a/packages/theme-language-server-common/src/documentHighlights/providers/HtmlTagNameDocumentHighlightsProvider.spec.ts
+++ b/packages/theme-language-server-common/src/documentHighlights/providers/HtmlTagNameDocumentHighlightsProvider.spec.ts
@@ -1,0 +1,94 @@
+import { assert, beforeEach, describe, expect, it } from 'vitest';
+import { DocumentHighlightParams } from 'vscode-languageserver';
+import { Position } from 'vscode-languageserver-protocol';
+import { DocumentHighlightsProvider, PREVENT_DEFAULT } from '../DocumentHighlightsProvider';
+import { DocumentManager } from '../../documents';
+
+describe('Module: HtmlTagNameDocumentHighlightsProvider', () => {
+  let documentManager: DocumentManager;
+  let provider: DocumentHighlightsProvider;
+
+  beforeEach(() => {
+    documentManager = new DocumentManager();
+    provider = new DocumentHighlightsProvider(documentManager);
+  });
+
+  it('should return [] for non-existent documents', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/non-existent-document.liquid' },
+      position: Position.create(0, 0),
+    };
+
+    const result = await provider.documentHighlights(params);
+    expect(result).to.equal(PREVENT_DEFAULT);
+  });
+
+  it('should return [] for non-HTML documents', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 0),
+    };
+
+    documentManager.open(params.textDocument.uri, 'Sample text content', 1);
+
+    const result = await provider.documentHighlights(params);
+    expect(result).to.equal(PREVENT_DEFAULT);
+  });
+
+  it('should return document highlight ranges for HTML tag names', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 3), // position within the tag name
+    };
+
+    documentManager.open(params.textDocument.uri, '<div></div>', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.documentHighlights(params);
+    assert(result);
+    assert(result[0]);
+    assert(result[1]);
+    expect(result[0]).not.to.eql(result[1]);
+
+    const startTagName = document.getText(result[0].range);
+    const endTagName = document.getText(result[1].range);
+
+    expect(startTagName).toBe('div');
+    expect(endTagName).toBe('div');
+  });
+
+  it('should return document highlight ranges for closing HTML tag names', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 16), // position within the closing div tag name
+    };
+
+    documentManager.open(params.textDocument.uri, '<div><img><div></div></div>', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.documentHighlights(params);
+    assert(result);
+    assert(result[0]);
+    assert(result[1]);
+
+    const startTagName = document.getText(result[0].range);
+    const endTagName = document.getText(result[1].range);
+
+    expect(startTagName).toBe('div');
+    expect(endTagName).toBe('div');
+  });
+
+  it('return [] for positions not within HTML tag names', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 0), // position outside the tag name
+    };
+
+    documentManager.open(params.textDocument.uri, '<div></div>', 1);
+
+    const result = await provider.documentHighlights(params);
+    expect(result).to.equal(PREVENT_DEFAULT);
+  });
+});

--- a/packages/theme-language-server-common/src/documentHighlights/providers/HtmlTagNameDocumentHighlightsProvider.ts
+++ b/packages/theme-language-server-common/src/documentHighlights/providers/HtmlTagNameDocumentHighlightsProvider.ts
@@ -1,0 +1,22 @@
+import { LiquidHtmlNode } from '@shopify/liquid-html-parser';
+import { DocumentHighlightParams } from 'vscode-languageserver';
+import { DocumentManager } from '../../documents';
+import { BaseDocumentHighlightsProvider } from '../BaseDocumentHighlightsProvider';
+import { getHtmlElementNameRanges } from '../../utils/htmlTagNames';
+
+export class HtmlTagNameDocumentHighlightsProvider implements BaseDocumentHighlightsProvider {
+  constructor(public documentManager: DocumentManager) {}
+
+  async documentHighlights(
+    node: LiquidHtmlNode,
+    ancestors: LiquidHtmlNode[],
+    params: DocumentHighlightParams,
+  ) {
+    const textDocument = this.documentManager.get(params.textDocument.uri)?.textDocument;
+    if (!textDocument) return null;
+
+    const ranges = getHtmlElementNameRanges(node, ancestors, params, textDocument);
+    if (!ranges) return null;
+    return ranges.map((range) => ({ range }));
+  }
+}

--- a/packages/theme-language-server-common/src/documentHighlights/providers/LiquidBlockTagDocumentHighlightsProvider.spec.ts
+++ b/packages/theme-language-server-common/src/documentHighlights/providers/LiquidBlockTagDocumentHighlightsProvider.spec.ts
@@ -1,0 +1,188 @@
+import { assert, beforeEach, describe, expect, it } from 'vitest';
+import { DocumentHighlightParams } from 'vscode-languageserver';
+import { Position } from 'vscode-languageserver-protocol';
+import { DocumentHighlightsProvider, PREVENT_DEFAULT } from '../DocumentHighlightsProvider';
+import { DocumentManager } from '../../documents';
+
+describe('Module: LiquidBlockTagDocumentHighlightsProvider', () => {
+  let documentManager: DocumentManager;
+  let provider: DocumentHighlightsProvider;
+
+  beforeEach(() => {
+    documentManager = new DocumentManager();
+    provider = new DocumentHighlightsProvider(documentManager);
+  });
+
+  it('should return document highlight ranges for liquid blocks', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 4), // position within the tag name
+    };
+
+    documentManager.open(params.textDocument.uri, '{% form "cart", cart %}...{% endform %}', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.documentHighlights(params);
+    assert(result);
+    assert(result[0]);
+    assert(result[1]);
+    expect(result[0]).not.to.eql(result[1]);
+
+    const startTagName = document.getText(result[0].range);
+    const endTagName = document.getText(result[1].range);
+
+    expect(startTagName).toBe('form');
+    expect(endTagName).toBe('endform');
+  });
+
+  it('should return document highlight ranges for liquid conditionals', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 4),
+    };
+
+    documentManager.open(
+      params.textDocument.uri,
+      '{% if cond %}...{% elsif cond %}...{% else %}...{% endif %}',
+      1,
+    );
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.documentHighlights(params);
+    assert(result);
+    assert(result[0]);
+    assert(result[1]);
+    assert(result[2]);
+    assert(result[3]);
+
+    const startTagName = document.getText(result[0].range);
+    const endTagName = document.getText(result[1].range);
+    const branch1TagName = document.getText(result[2].range);
+    const branch2TagName = document.getText(result[3].range);
+
+    expect(startTagName).toBe('if');
+    expect(endTagName).toBe('endif');
+    expect(branch1TagName).toBe('elsif');
+    expect(branch2TagName).toBe('else');
+  });
+
+  it('should return document highlight ranges for liquid case statements', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 4),
+    };
+
+    documentManager.open(
+      params.textDocument.uri,
+      `{% case thing %}
+         {% when 'foo' %}...
+         {% when 'bar' %}...
+         {% else %}...
+       {% endcase %}`,
+      1,
+    );
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.documentHighlights(params);
+    assert(result);
+    assert(result[0]);
+    assert(result[1]);
+    assert(result[2]);
+    assert(result[3]);
+    assert(result[4]);
+
+    const startTagName = document.getText(result[0].range);
+    const endTagName = document.getText(result[1].range);
+    const branch1TagName = document.getText(result[2].range);
+    const branch2TagName = document.getText(result[3].range);
+    const branch3TagName = document.getText(result[4].range);
+
+    expect(startTagName).toBe('case');
+    expect(endTagName).toBe('endcase');
+    expect(branch1TagName).toBe('when');
+    expect(branch2TagName).toBe('when');
+    expect(branch3TagName).toBe('else');
+  });
+
+  it('should return document highlight ranges for LiquidRawTags tags', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 4),
+    };
+
+    documentManager.open(params.textDocument.uri, '{% raw %}...{% endraw %}', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.documentHighlights(params);
+    assert(result);
+    assert(result[0]);
+    assert(result[1]);
+
+    const startTagName = document.getText(result[0].range);
+    const endTagName = document.getText(result[1].range);
+
+    expect(startTagName).toBe('raw');
+    expect(endTagName).toBe('endraw');
+  });
+
+  it('should return document highlight ranges for liquid comment tags', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 4),
+    };
+
+    documentManager.open(params.textDocument.uri, '{% comment %}...{% endcomment %}', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.documentHighlights(params);
+    assert(result);
+    assert(result[0]);
+    assert(result[1]);
+
+    const startTagName = document.getText(result[0].range);
+    const endTagName = document.getText(result[1].range);
+
+    expect(startTagName).toBe('comment');
+    expect(endTagName).toBe('endcomment');
+  });
+
+  it('should return the correct highlights inside liquid liquid tags', async () => {
+    const params: DocumentHighlightParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(1, 10),
+    };
+
+    documentManager.open(
+      params.textDocument.uri,
+      `{% liquid
+         if cond
+           echo foo
+         else
+           echo bar
+         endif
+       %}`,
+      1,
+    );
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await provider.documentHighlights(params);
+    assert(result);
+    assert(result[0]);
+    assert(result[1]);
+    assert(result[2]);
+
+    const startTagName = document.getText(result[0].range);
+    const endTagName = document.getText(result[1].range);
+    const branch1TagName = document.getText(result[2].range);
+
+    expect(startTagName).toBe('if');
+    expect(endTagName).toBe('endif');
+    expect(branch1TagName).toBe('else');
+  });
+});

--- a/packages/theme-language-server-common/src/documentHighlights/providers/LiquidBlockTagDocumentHighlightsProvider.ts
+++ b/packages/theme-language-server-common/src/documentHighlights/providers/LiquidBlockTagDocumentHighlightsProvider.ts
@@ -1,0 +1,73 @@
+import {
+  LiquidBranch,
+  LiquidHtmlNode,
+  LiquidRawTag,
+  LiquidTag,
+  NodeTypes,
+} from '@shopify/liquid-html-parser';
+import { DocumentHighlightParams, Range } from 'vscode-languageserver';
+import { DocumentManager } from '../../documents';
+import { BaseDocumentHighlightsProvider } from '../BaseDocumentHighlightsProvider';
+
+export class LiquidBlockTagDocumentHighlightsProvider implements BaseDocumentHighlightsProvider {
+  constructor(public documentManager: DocumentManager) {}
+
+  async documentHighlights(
+    node: LiquidHtmlNode,
+    ancestors: LiquidHtmlNode[],
+    params: DocumentHighlightParams,
+  ) {
+    const textDocument = this.documentManager.get(params.textDocument.uri)?.textDocument;
+    if (!textDocument) return null;
+
+    if (isLiquidBranch(node)) {
+      node = ancestors.at(-1)!;
+    }
+
+    if (!isLiquidBlock(node) || !node.blockEndPosition) {
+      return null;
+    }
+
+    const nameOffset = node.source.indexOf(node.name, node.blockStartPosition.start);
+    const endblockNameOffset = node.source.indexOf('end' + node.name, node.blockEndPosition.start);
+
+    const ranges: Range[] = [
+      Range.create(
+        textDocument.positionAt(nameOffset),
+        textDocument.positionAt(nameOffset + node.name.length),
+      ),
+      Range.create(
+        textDocument.positionAt(endblockNameOffset),
+        // "end" is 3 characters, end$name is 3 + node.name.length.
+        textDocument.positionAt(endblockNameOffset + 3 + node.name.length),
+      ),
+    ];
+
+    // highlighting the elsif/else branches as well
+    if (isLiquidTag(node) && node.children && node.children.every(isLiquidBranch)) {
+      for (const branch of node.children.filter((x) => x.name !== null)) {
+        const branchNameOffset = node.source.indexOf(branch.name!, branch.blockStartPosition.start);
+        ranges.push(
+          Range.create(
+            textDocument.positionAt(branchNameOffset),
+            textDocument.positionAt(branchNameOffset + branch.name!.length),
+          ),
+        );
+      }
+    }
+
+    return ranges.map((range) => ({ range }));
+  }
+}
+
+function isLiquidBranch(node: LiquidHtmlNode): node is LiquidBranch {
+  return node.type === NodeTypes.LiquidBranch;
+}
+
+function isLiquidBlock(node: LiquidHtmlNode): node is LiquidTag | LiquidRawTag {
+  return node.type === NodeTypes.LiquidTag || node.type === NodeTypes.LiquidRawTag;
+}
+
+function isLiquidTag(node: LiquidHtmlNode): node is LiquidTag {
+  return node.type === NodeTypes.LiquidTag;
+}

--- a/packages/theme-language-server-common/src/documentHighlights/providers/index.ts
+++ b/packages/theme-language-server-common/src/documentHighlights/providers/index.ts
@@ -1,0 +1,2 @@
+export { HtmlTagNameDocumentHighlightsProvider } from './HtmlTagNameDocumentHighlightsProvider';
+export { LiquidBlockTagDocumentHighlightsProvider } from './LiquidBlockTagDocumentHighlightsProvider';

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -12,6 +12,7 @@ import { Commands, ExecuteCommandProvider } from '../commands';
 import { CompletionsProvider } from '../completions';
 import { GetSnippetNamesForURI } from '../completions/providers/RenderSnippetCompletionProvider';
 import { DiagnosticsManager, makeRunChecks } from '../diagnostics';
+import { DocumentHighlightsProvider } from '../documentHighlights/DocumentHighlightsProvider';
 import { DocumentLinksProvider } from '../documentLinks';
 import { DocumentManager } from '../documents';
 import { OnTypeFormattingProvider } from '../formatting';
@@ -66,6 +67,7 @@ export function startServer(
   const codeActionsProvider = new CodeActionsProvider(documentManager, diagnosticsManager);
   const onTypeFormattingProvider = new OnTypeFormattingProvider(documentManager);
   const linkedEditingRangesProvider = new LinkedEditingRangesProvider(documentManager);
+  const documentHighlightProvider = new DocumentHighlightsProvider(documentManager);
 
   const findThemeRootURI = async (uri: string) => {
     const rootUri = await findConfigurationRootURI(uri);
@@ -206,6 +208,7 @@ export function startServer(
           resolveProvider: false,
           workDoneProgress: false,
         },
+        documentHighlightProvider: true,
         linkedEditingRangeProvider: true,
         executeCommandProvider: {
           commands: [...Commands],
@@ -299,6 +302,10 @@ export function startServer(
 
   connection.onDocumentOnTypeFormatting(async (params) => {
     return onTypeFormattingProvider.onTypeFormatting(params);
+  });
+
+  connection.onDocumentHighlight(async (params) => {
+    return documentHighlightProvider.documentHighlights(params);
   });
 
   connection.languages.onLinkedEditingRange(async (params) => {


### PR DESCRIPTION
## What are you adding in this PR?

- Adds support for paired highlighting of HTML element names and Liquid blocks


https://github.com/user-attachments/assets/20b54ccf-a5e9-40ee-83eb-9cab3204e1e6


When you hover over a HTML tag open, the close tag is highlighted and vice-versa.

```html
<div> <!-- this div gets highlighted -->
   <div></div>
</div> <!-- with this one-->
```

When you hover over a Liquid block open, the close block is highlighted (and branches if any).

```liquid
{% # this if, elsif, else, endif all get highlighted together %}
{% if cond %}

{% elsif cond %}

{% else %}

{% endif %}
```

## How it works

In the language server, we start listening for [Document Highlight `client->server` requests][dh].

When we receive these, we may respond with an array of [`DocumentHighlight`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentHighlight) representing the stuff that should be highlighted together:

- HTML tag open/close pairs
- Liquid block open/branch/close tuples (if/elsif/else/endif, form/endform, etc)

## What's next? Any followup issues?

- Merge https://github.com/Shopify/theme-tools/pull/486 (Linked Editing)
- Add Rename support
- Add codemirror language client support for this feature

## Before you deploy

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

[dh]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentHighlight
