### PR TITLE
[Fix] - Improve parsing of whitespace stripping characters in Liquid tags and variables

### DIFF
--- a/.changeset/perfect-wasps-crash.md
+++ b/.changeset/perfect-wasps-crash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+Fix bug where whitespace stripping character was assigned to variable

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -259,7 +259,7 @@ Liquid <: Helpers {
   namedArgument<delim> = variableSegment space* ":" space* liquidExpression<delim>
   tagArguments = listOf<namedArgument<delimTag>, argumentSeparatorOptionalComma>
 
-  variableSegment = (letter | "_") identifierCharacter*
+  variableSegment = (letter | "_") (~endOfTagName identifierCharacter)*
   variableSegmentAsLookup = variableSegment
   identifier = variableSegment "?"?
 

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -108,6 +108,32 @@ describe('Unit: Stage 1 (CST)', () => {
         name: string | undefined;
       }
 
+      it('correctly parses the whitespace stripping behaviour as part of LiquidVariableOutput and not the variable name', () => {
+        for (const { toCST, expectPath } of testCases) {
+          cst = toCST(`{{somevarname-}}`);
+          expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
+          expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          expectPath(cst, '0.whitespaceStart').to.equal(null);
+          expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
+          expectPath(cst, '0.markup.expression.type').to.equal('VariableLookup');
+          expectPath(cst, '0.markup.expression.name').to.equal('somevarname');
+          expectPath(cst, '0.markup.expression.lookups').to.eql([]);
+        }
+      });
+
+      it('correctly parses whitespace stripping character as part of LiquidTag and not the variable name', () => {
+        for (const { toCST, expectPath } of testCases) {
+          cst = toCST(`{%echo somevarname-%}`);
+          expectPath(cst, '0.type').to.equal('LiquidTag');
+          expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          expectPath(cst, '0.whitespaceStart').to.equal(null);
+          expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
+          expectPath(cst, '0.markup.expression.type').to.equal('VariableLookup');
+          expectPath(cst, '0.markup.expression.name').to.equal('somevarname');
+          expectPath(cst, '0.markup.expression.lookups').to.eql([]);
+        }
+      });
+
       it('should parse variable lookups', () => {
         const v = (name: string, lookups: (string | number | Lookup)[] = []): Lookup => ({
           type: 'VariableLookup',

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -108,32 +108,6 @@ describe('Unit: Stage 1 (CST)', () => {
         name: string | undefined;
       }
 
-      it('correctly parses the whitespace stripping behaviour as part of LiquidVariableOutput and not the variable name', () => {
-        for (const { toCST, expectPath } of testCases) {
-          cst = toCST(`{{somevarname-}}`);
-          expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
-          expectPath(cst, '0.whitespaceEnd').to.equal('-');
-          expectPath(cst, '0.whitespaceStart').to.equal(null);
-          expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
-          expectPath(cst, '0.markup.expression.type').to.equal('VariableLookup');
-          expectPath(cst, '0.markup.expression.name').to.equal('somevarname');
-          expectPath(cst, '0.markup.expression.lookups').to.eql([]);
-        }
-      });
-
-      it('correctly parses whitespace stripping character as part of LiquidTag and not the variable name', () => {
-        for (const { toCST, expectPath } of testCases) {
-          cst = toCST(`{%echo somevarname-%}`);
-          expectPath(cst, '0.type').to.equal('LiquidTag');
-          expectPath(cst, '0.whitespaceEnd').to.equal('-');
-          expectPath(cst, '0.whitespaceStart').to.equal(null);
-          expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
-          expectPath(cst, '0.markup.expression.type').to.equal('VariableLookup');
-          expectPath(cst, '0.markup.expression.name').to.equal('somevarname');
-          expectPath(cst, '0.markup.expression.lookups').to.eql([]);
-        }
-      });
-
       it('should parse variable lookups', () => {
         const v = (name: string, lookups: (string | number | Lookup)[] = []): Lookup => ({
           type: 'VariableLookup',
@@ -317,6 +291,19 @@ describe('Unit: Stage 1 (CST)', () => {
             expectPath(cst, '0.whitespaceEnd').to.equal(null);
           }
         });
+      });
+
+      it('correctly parses the whitespace stripping behaviour as part of LiquidVariableOutput and not the variable name', () => {
+        for (const { toCST, expectPath } of testCases) {
+          cst = toCST(`{{somevarname-}}`);
+          expectPath(cst, '0.type').to.equal('LiquidVariableOutput');
+          expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          expectPath(cst, '0.whitespaceStart').to.equal(null);
+          expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
+          expectPath(cst, '0.markup.expression.type').to.equal('VariableLookup');
+          expectPath(cst, '0.markup.expression.name').to.equal('somevarname');
+          expectPath(cst, '0.markup.expression.lookups').to.eql([]);
+        }
       });
     });
 
@@ -585,6 +572,19 @@ describe('Unit: Stage 1 (CST)', () => {
             }
           },
         );
+      });
+
+      it('correctly parses whitespace stripping character as part of LiquidTag and not the variable name', () => {
+        for (const { toCST, expectPath } of testCases) {
+          cst = toCST(`{%echo somevarname-%}`);
+          expectPath(cst, '0.type').to.equal('LiquidTag');
+          expectPath(cst, '0.whitespaceEnd').to.equal('-');
+          expectPath(cst, '0.whitespaceStart').to.equal(null);
+          expectPath(cst, '0.markup.type').to.equal('LiquidVariable');
+          expectPath(cst, '0.markup.expression.type').to.equal('VariableLookup');
+          expectPath(cst, '0.markup.expression.name').to.equal('somevarname');
+          expectPath(cst, '0.markup.expression.lookups').to.eql([]);
+        }
       });
     });
 


### PR DESCRIPTION
## What are you adding in this PR?
Fixes https://github.com/Shopify/theme-tools/issues/189

## What did you learn?

Learned that this is intentionally valid: `{% echo 'a' -%}`.

This will strip whitespace on the RHS of the output. This can be useful if used inside of whitespace sensitive HTML such as a `<span>{% echo 'a' -%}</span>`


### Demo
Input: `{%-echo someVariableName-%}`
### Before
![image](https://github.com/user-attachments/assets/86d78a43-7e91-4fd2-8482-c7fc3085cb0b)

### After
![image](https://github.com/user-attachments/assets/0447285b-441c-4f10-aa71-307c5e581610)


## Before you deploy
- [x] I included a patch bump `changeset`