### PR TITLE
Add CodeMirror support for LSP Document Highlight Requests

### DIFF
--- a/.changeset/rare-singers-sip.md
+++ b/.changeset/rare-singers-sip.md
@@ -1,0 +1,5 @@
+---
+'@shopify/codemirror-language-client': minor
+---
+
+Add support for LSP Document Highlight requests

--- a/packages/codemirror-language-client/README.md
+++ b/packages/codemirror-language-client/README.md
@@ -13,6 +13,7 @@ This repo serves as a CodeMirror Language Client. Feed it a Language Server and 
 - [x] Diagnostics (aka Linting)
 - [x] Completions
 - [x] Hover
+- [x] Document Highlights
 - [ ] Document Links
 - [ ] Workspace Edits (aka Refactorings, Quickfix, etc.)
 
@@ -84,7 +85,7 @@ main();
 
    -  [`vscode-languageserver-types`](https://github.com/microsoft/vscode-languageserver-node/tree/main/types)
 
-      This library is useful to get the types of specific parts of the Protocol. 
+      This library is useful to get the types of specific parts of the Protocol.
 
       Examples: `Diagnostic`, `URI`, `TextDocument`, `Position`, `Range`, `LocationLink`, etc.
 

--- a/packages/codemirror-language-client/playground/src/playground.ts
+++ b/packages/codemirror-language-client/playground/src/playground.ts
@@ -15,6 +15,7 @@ import { MarkedString, MarkupContent } from 'vscode-languageserver-protocol';
 const md = new MarkdownIt();
 
 const exampleTemplate = `{% # sections/title.liquid %}
+{% # mod-alt-v for vim mode %}
 <section>
   <h2>{{ section.settings.title }}</h2>
   {% echo 'hi' | upcase %}

--- a/packages/codemirror-language-client/src/CodeMirrorLanguageClient.ts
+++ b/packages/codemirror-language-client/src/CodeMirrorLanguageClient.ts
@@ -14,6 +14,7 @@ import {
   fileUriFacet,
   infoRendererFacet,
   lspComplete,
+  lspDocumentHighlights,
   lspHover,
   lspLinter,
   serverCapabilitiesFacet,
@@ -29,6 +30,9 @@ import { hoverRendererFacet } from './extensions/hover';
  */
 const clientCapabilities: ClientCapabilities = {
   textDocument: {
+    documentHighlight: {
+      dynamicRegistration: false,
+    },
     completion: {
       // We send the completion context to the server
       contextSupport: true,
@@ -106,6 +110,7 @@ export class CodeMirrorLanguageClient {
   private readonly linterExtension: Extension;
   private readonly hoverRenderer: HoverRenderer | undefined;
   private readonly hoverExtension: Extension;
+  private readonly documentHighlightsExtension: Extension;
 
   constructor(
     private readonly worker: Worker,
@@ -132,6 +137,8 @@ export class CodeMirrorLanguageClient {
 
     this.hoverRenderer = hoverRenderer;
     this.hoverExtension = lspHover(hoverOptions);
+
+    this.documentHighlightsExtension = lspDocumentHighlights();
   }
 
   public async start() {
@@ -162,6 +169,7 @@ export class CodeMirrorLanguageClient {
       infoRendererFacet.of(this.infoRenderer),
       diagnosticRendererFacet.of(this.diagnosticRenderer),
       hoverRendererFacet.of(this.hoverRenderer),
+      this.documentHighlightsExtension,
     ]
       .concat(shouldLint ? this.linterExtension : [])
       .concat(shouldComplete ? this.autocompleteExtension : [])

--- a/packages/codemirror-language-client/src/extensions/documentHighlights.spec.ts
+++ b/packages/codemirror-language-client/src/extensions/documentHighlights.spec.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { EditorState, Extension, Range, RangeSet, RangeValue } from '@codemirror/state';
+import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
+import { assert, beforeEach, describe, expect, it } from 'vitest';
+import { DocumentHighlight } from 'vscode-languageserver-protocol';
+import { MockClient } from '../test/MockClient';
+import { clientFacet, fileUriFacet } from './client';
+import { getDecorations, highlightDeco, lspDocumentHighlights } from './documentHighlights';
+import { textDocumentSync } from './textDocumentSync';
+
+describe('Module: documentHighlights', () => {
+  const fileUri = 'browser://input.liquid';
+  let client: MockClient;
+  let extensions: Extension;
+  let view: EditorView;
+  let hoverRenderer: any;
+
+  beforeEach(() => {
+    client = new MockClient({}, { documentHighlightProvider: true });
+    extensions = [
+      clientFacet.of(client),
+      fileUriFacet.of(fileUri),
+      textDocumentSync,
+      lspDocumentHighlights(),
+    ];
+    view = new EditorView({
+      state: EditorState.create({
+        doc: 'hello world',
+        extensions,
+      }),
+    });
+  });
+
+  it('should translate LSP Document Highlights into a CodeMirror DecorationSet', async () => {
+    const promise = getDecorations(view);
+    const highlightsResponse: DocumentHighlight[] = [
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+      },
+    ];
+
+    client.resolveRequest(highlightsResponse);
+    const result = await promise;
+    const actual = toArray(result);
+    const expected = toArray(Decoration.set([highlightDeco.range(0, 5)]));
+    expect(actual).to.eql(expected);
+  });
+
+  it('should sort the decorations', async () => {
+    const promise = getDecorations(view);
+    const highlightsResponse: DocumentHighlight[] = [
+      {
+        range: {
+          start: { line: 0, character: 5 },
+          end: { line: 0, character: 10 },
+        },
+      },
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+      },
+    ];
+
+    client.resolveRequest(highlightsResponse);
+    const result = await promise;
+    expect(toArray(result)).to.eql(
+      toArray(Decoration.set([highlightDeco.range(0, 5), highlightDeco.range(5, 10)])),
+    );
+  });
+
+  it('should return a Decoration.none DecorationSet', async () => {
+    const promise = getDecorations(view);
+    client.resolveRequest(null);
+    const result = await promise;
+    expect(toArray(result)).to.eql(toArray(Decoration.none));
+  });
+
+  /**
+   * I wish CM didn't think that their implementation of iterators was better
+   * than the built-in one. Makes testing that stuff really hard for what seems
+   * like an obscure reason.
+   *
+   * > A range cursor is an object that moves to the next range every time you
+   * > call next on it. Note that, unlike ES6 iterators, these start out pointing
+   * > at the first element, so you should call next only after reading the first
+   * > range (if any).
+   *
+   * Also, RangeSet.eq doesn't seem to work. Which is why I decided to take this
+   * approach.
+   */
+  function* toIterator(decoSet: DecorationSet): Iterable<Range<Decoration>> {
+    let iter = decoSet.iter();
+    if (iter.value === null) {
+      return;
+    }
+
+    do {
+      yield { from: iter.from, to: iter.to, value: iter.value };
+      iter.next();
+    } while (iter.value !== null);
+  }
+
+  function toArray(decoSet: DecorationSet): Range<Decoration>[] {
+    return Array.from(toIterator(decoSet));
+  }
+});

--- a/packages/codemirror-language-client/src/extensions/documentHighlights.ts
+++ b/packages/codemirror-language-client/src/extensions/documentHighlights.ts
@@ -1,0 +1,91 @@
+/**
+ * This extension requests LSP Document Highlights [1] when the user types or
+ * change its code selection.
+ *
+ * Those are then transformed into CodeMirror decorations and applied to the editor.
+ *
+ * [1]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentHighlight
+ */
+import { Extension, Prec, StateEffect, StateField } from '@codemirror/state';
+import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
+import { DocumentHighlightRequest } from 'vscode-languageserver-protocol';
+import { clientFacet, fileUriFacet } from './client';
+import { textDocumentField } from './textDocumentSync';
+
+// We will use this CSS class to decorate all document highlights
+export const documentHighlightsClass = 'cmlc-document-highlights';
+export const highlightDeco = Decoration.mark({ class: documentHighlightsClass });
+const highlightStyles = Prec.low(
+  EditorView.theme({
+    [`.${documentHighlightsClass}`]: {
+      // Set background color to a light gray that matches a subtle highlight on
+      // a light theme
+      'background-color': 'rgba(0,0,0,0.1)',
+    },
+  }),
+);
+
+const setDocumentHighlights = StateEffect.define<DecorationSet>();
+const documentHighlightsStateField = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+  update(value, tr) {
+    let updatedValue = value;
+
+    for (const effect of tr.effects) {
+      if (effect.is(setDocumentHighlights)) {
+        updatedValue = effect.value;
+      }
+    }
+
+    return updatedValue;
+  },
+  // This is some CM obscure API shit that registers this state field
+  // into the CM state and makes it so CM will show the decorations
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+export async function getDecorations(view: EditorView): Promise<DecorationSet> {
+  const client = view.state.facet(clientFacet.reader);
+  const uri = view.state.facet(fileUriFacet.reader);
+  const textDocument = view.state.field(textDocumentField);
+
+  // If the client doesn't support those requests, don't ask for them.
+  if (!client.serverCapabilities?.documentHighlightProvider) {
+    return Decoration.none;
+  }
+
+  const results = await client.sendRequest(DocumentHighlightRequest.type, {
+    textDocument: { uri },
+    position: textDocument.positionAt(view.state.selection.main.from),
+  });
+
+  if (!results) {
+    return Decoration.none;
+  }
+
+  const decorations = results
+    .map((highlight) => ({
+      from: textDocument.offsetAt(highlight.range.start),
+      to: textDocument.offsetAt(highlight.range.end),
+    }))
+    .sort((a, b) => a.from - b.from) // CM wants them sorted ascending or else it freaks out
+    .map(({ from, to }) => highlightDeco.range(from, to));
+
+  return Decoration.set(decorations);
+}
+
+export function lspDocumentHighlights(): Extension {
+  const decorationHandler = EditorView.updateListener.of((update) => {
+    // We only want to query the language server for document highlights
+    // the document has changed or the selection has moved
+    if (update.docChanged || update.selectionSet) {
+      getDecorations(update.view).then((deco) => {
+        update.view.dispatch({
+          effects: setDocumentHighlights.of(deco),
+        });
+      });
+    }
+  });
+
+  return [documentHighlightsStateField, decorationHandler, highlightStyles];
+}

--- a/packages/codemirror-language-client/src/extensions/index.ts
+++ b/packages/codemirror-language-client/src/extensions/index.ts
@@ -1,5 +1,4 @@
 export { clientFacet, fileUriFacet, serverCapabilitiesFacet } from './client';
-export { textDocumentSync, textDocumentField } from './textDocumentSync';
 export {
   AutocompleteOptions,
   InfoRenderer,
@@ -7,6 +6,7 @@ export {
   infoRendererFacet,
   lspComplete,
 } from './complete';
+export { documentHighlightsClass, lspDocumentHighlights } from './documentHighlights';
 export { HoverOptions, HoverRenderer, hover, lspHover } from './hover';
 export {
   DiagnosticRenderer,
@@ -16,3 +16,4 @@ export {
   lspDiagnosticsField,
   lspLinter,
 } from './lspLinter';
+export { textDocumentField, textDocumentSync } from './textDocumentSync';

--- a/packages/codemirror-language-client/src/extensions/lspLinter.ts
+++ b/packages/codemirror-language-client/src/extensions/lspLinter.ts
@@ -1,14 +1,15 @@
-import { StateEffect, StateField, Extension, StateEffectType, Facet } from '@codemirror/state';
-import { PluginValue, EditorView, ViewPlugin } from '@codemirror/view';
-import { linter, Diagnostic as CodeMirrorDiagnostic } from '@codemirror/lint';
-import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Diagnostic as CodeMirrorDiagnostic, linter } from '@codemirror/lint';
+import { Extension, Facet, StateEffect } from '@codemirror/state';
+import { EditorView, PluginValue, ViewPlugin } from '@codemirror/view';
 import {
-  Diagnostic as LSPDiagnostic,
   Disposable,
-  PublishDiagnosticsNotification,
+  Diagnostic as LSPDiagnostic,
   DiagnosticSeverity as LSPSeverity,
+  PublishDiagnosticsNotification,
 } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 
+import { simpleStateField } from '../utils/simpleStateField';
 import { clientFacet, fileUriFacet } from './client';
 import { textDocumentField } from './textDocumentSync';
 
@@ -150,21 +151,4 @@ function lspToCodeMirrorDiagnostic(
     severity: lspToCodeMirrorSeverity(severity),
     renderMessage: diagnosticRenderer ? () => diagnosticRenderer(lspDiagnostic) : undefined,
   };
-}
-
-function simpleStateField<T>(stateEffect: StateEffectType<T>, defaultValue: T): StateField<T> {
-  return StateField.define<T>({
-    create: () => defaultValue,
-    update(value, tr) {
-      let updatedValue = value;
-
-      for (const effect of tr.effects) {
-        if (effect.is(stateEffect)) {
-          updatedValue = effect.value;
-        }
-      }
-
-      return updatedValue;
-    },
-  });
 }

--- a/packages/codemirror-language-client/src/index.spec.ts
+++ b/packages/codemirror-language-client/src/index.spec.ts
@@ -1,8 +1,0 @@
-import { expect, describe, it } from 'vitest';
-import { CodeMirrorLanguageClient } from './index';
-
-describe('Module: CodeMirrorLanguageClient', () => {
-  it('should exist', () => {
-    expect(CodeMirrorLanguageClient).to.exist;
-  });
-});

--- a/packages/codemirror-language-client/src/test/MockClient.ts
+++ b/packages/codemirror-language-client/src/test/MockClient.ts
@@ -4,6 +4,7 @@ import {
   ProtocolNotificationType,
   CancellationTokenSource,
   CancellationToken,
+  ServerCapabilities,
 } from 'vscode-languageserver-protocol';
 import { PromiseCompletion, AbstractLanguageClient, disposable } from '../LanguageClient';
 
@@ -21,7 +22,11 @@ export class MockClient extends EventTarget implements AbstractLanguageClient {
   public pendingRequest: Promise<any> | null;
   private promiseCompletion: PromiseCompletion | null;
 
-  constructor(clientCapabilities = {}, serverCapabilities = null, serverInfo = null) {
+  constructor(
+    clientCapabilities = {},
+    serverCapabilities: AbstractLanguageClient['serverCapabilities'] = null,
+    serverInfo = null,
+  ) {
     super();
     this.clientCapabilities = clientCapabilities;
     this.serverCapabilities = serverCapabilities;

--- a/packages/codemirror-language-client/src/utils/simpleStateField.ts
+++ b/packages/codemirror-language-client/src/utils/simpleStateField.ts
@@ -1,0 +1,22 @@
+import { StateEffectType, StateField } from '@codemirror/state';
+
+/** Sometimes you don't want to repeat yourself for a simple state field. */
+export function simpleStateField<T>(
+  stateEffect: StateEffectType<T>,
+  defaultValue: T,
+): StateField<T> {
+  return StateField.define<T>({
+    create: () => defaultValue,
+    update(value, tr) {
+      let updatedValue = value;
+
+      for (const effect of tr.effects) {
+        if (effect.is(stateEffect)) {
+          updatedValue = effect.value;
+        }
+      }
+
+      return updatedValue;
+    },
+  });
+}


### PR DESCRIPTION
## What are you adding in this PR?

- Add CodeMirror support for LSP Document Highlight requests

  When the user types or changes selection, we'll request the language
  server for document highlights.

  If there are document highlights, we'll let CodeMirror add a
  specific CSS class to the ranges returned.

https://github.com/user-attachments/assets/7011a680-58db-4b19-8079-079792694f23




## What's next? Any followup issues?

- Add CodeMirror support for Rename requests
- Add CodeMirror support for LinkedEditing

## What did you learn?

- Not new, but the CM API is extremely unintuitive. Mapping our problem to a CodeMirror extension model that makes sense was 80% of the work.

## Before you deploy

<!-- Check changes -->
- [x] I included a minor bump `changeset`
