### PR TITLE
Add HTML Element close tag auto-insertion support

### DIFF
--- a/.changeset/gentle-news-deny.md
+++ b/.changeset/gentle-news-deny.md
@@ -1,0 +1,15 @@
+---
+'theme-check-vscode': minor
+---
+
+Add proper HTML tag `onEnterRules`
+
+```liquid
+{% # type this, then press enter %}
+<div>|</div>
+
+{% # you get this, with cursor at | %}
+<div>
+  |
+</div>
+```

--- a/.changeset/gentle-rocks-rule.md
+++ b/.changeset/gentle-rocks-rule.md
@@ -4,3 +4,10 @@
 ---
 
 Add support for HTML Element close tag auto-insertion
+
+```liquid
+{% # type this %}
+<div>
+{% # get this, with cursor at | %}
+<div>|</div>
+```

--- a/.changeset/gentle-rocks-rule.md
+++ b/.changeset/gentle-rocks-rule.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': minor
+'theme-check-vscode': minor
+---
+
+Add support for HTML Element close tag auto-insertion

--- a/.changeset/sixty-gorillas-rule.md
+++ b/.changeset/sixty-gorillas-rule.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+(Internal) Add `unclosed` node information to LiquidHTMLASTError

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -5,7 +5,8 @@ The theme-language-server project incorporates third party material from the pro
 1. vscode-languageserver-node (https://github.com/microsoft/vscode-languageserver-node)
 2. @yetoapp/jsonc (https://github.com/yettoapp/lezer-jsonc)
 3. @lezer/json (https://github.com/lezer-parser/json)
-3. @codemirror/lang-json (https://github.com/codemirror/lang-json)
+4. @codemirror/lang-json (https://github.com/codemirror/lang-json)
+5. monaco-editor (https://github.com/microsoft/monaco-editor)
 
 %% vscode-languageserver-node NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================
@@ -106,3 +107,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 =========================================
 END OF @codemirror/lang-json NOTICES, INFORMATION, AND LICENSE
+
+%% monaco-editor NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 - present Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+=========================================
+END OF monaco-editor NOTICES, INFORMATION, AND LICENSE

--- a/packages/liquid-html-parser/src/errors.ts
+++ b/packages/liquid-html-parser/src/errors.ts
@@ -1,5 +1,6 @@
-import { MatchResult } from 'ohm-js';
 import lineColumn from 'line-column';
+import { MatchResult } from 'ohm-js';
+import { NodeTypes, Position } from './types';
 
 interface LineColPosition {
   line: number;
@@ -35,12 +36,22 @@ export class LiquidHTMLCSTParsingError extends SyntaxError {
   }
 }
 
+export type UnclosedNode = { type: NodeTypes; name: string; blockStartPosition: Position };
+
 export class LiquidHTMLASTParsingError extends SyntaxError {
   loc?: { start: LineColPosition; end: LineColPosition };
+  unclosed: UnclosedNode | null;
 
-  constructor(message: string, source: string, startIndex: number, endIndex: number) {
+  constructor(
+    message: string,
+    source: string,
+    startIndex: number,
+    endIndex: number,
+    unclosed?: UnclosedNode,
+  ) {
     super(message);
     this.name = 'LiquidHTMLParsingError';
+    this.unclosed = unclosed ?? null;
 
     const lc = lineColumn(source);
     const start = lc.fromIndex(startIndex);

--- a/packages/theme-language-server-common/src/ClientCapabilities.ts
+++ b/packages/theme-language-server-common/src/ClientCapabilities.ts
@@ -27,6 +27,10 @@ export class ClientCapabilities {
     return !!this.capabilities?.workspace?.didChangeConfiguration?.dynamicRegistration;
   }
 
+  get hasShowDocumentSupport() {
+    return !!this.capabilities?.window?.showDocument;
+  }
+
   initializationOption<T>(key: string, defaultValue: T): T {
     // { 'themeCheck.checkOnSave': true }
     const direct = this.initializationOptions?.[key];

--- a/packages/theme-language-server-common/src/documents/DocumentManager.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.ts
@@ -3,7 +3,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-languageserver-types';
 import { toAbsolutePath } from '../utils';
 
-export type AugmentedSourceCode = SourceCode<SourceCodeType> & {
+export type AugmentedSourceCode<SCT extends SourceCodeType = SourceCodeType> = SourceCode<SCT> & {
   textDocument: TextDocument;
   uri: URI;
 };

--- a/packages/theme-language-server-common/src/formatting/OnTypeFormattingProvider.spec.ts
+++ b/packages/theme-language-server-common/src/formatting/OnTypeFormattingProvider.spec.ts
@@ -1,9 +1,8 @@
-import { describe, beforeEach, it, expect, assert } from 'vitest';
-import { OnTypeFormattingProvider } from './OnTypeFormattingProvider';
-import { DocumentManager } from '../documents';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { DocumentOnTypeFormattingParams } from 'vscode-languageserver';
-import { Position, TextEdit, Range } from 'vscode-languageserver-protocol';
-import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { DocumentManager } from '../documents';
+import { OnTypeFormattingProvider } from './OnTypeFormattingProvider';
 
 const options: DocumentOnTypeFormattingParams['options'] = {
   insertSpaces: true,
@@ -57,74 +56,6 @@ describe('Module: OnTypeFormattingProvider', () => {
 
     const result = await onTypeFormattingProvider.onTypeFormatting(params);
     expect(result).toBeNull();
-  });
-
-  it('should return a TextEdit to insert a space after "{{" in "{{ }}"', async () => {
-    const params: DocumentOnTypeFormattingParams = {
-      textDocument: { uri: 'file:///path/to/document.liquid' },
-      position: Position.create(0, 2),
-      ch: '{',
-      options,
-    };
-
-    documentManager.open(params.textDocument.uri, '{{ }}', 1);
-    const document = documentManager.get(params.textDocument.uri)?.textDocument;
-    assert(document);
-
-    const result = await onTypeFormattingProvider.onTypeFormatting(params);
-    assert(result);
-    expect(TextDocument.applyEdits(document, result)).to.equal('{{  }}');
-  });
-
-  it('should return a TextEdit to insert a space after "{%" in "{% %}"', async () => {
-    const params: DocumentOnTypeFormattingParams = {
-      textDocument: { uri: 'file:///path/to/document.liquid' },
-      position: Position.create(0, 2),
-      ch: '%',
-      options,
-    };
-
-    documentManager.open(params.textDocument.uri, '{% %}', 1);
-    const document = documentManager.get(params.textDocument.uri)?.textDocument;
-    assert(document);
-
-    const result = await onTypeFormattingProvider.onTypeFormatting(params);
-    assert(result);
-    expect(TextDocument.applyEdits(document, result)).to.equal('{%  %}');
-  });
-
-  it('should return a TextEdit to replace and insert characters in "{{ - }}"', async () => {
-    const params: DocumentOnTypeFormattingParams = {
-      textDocument: { uri: 'file:///path/to/document.liquid' },
-      position: Position.create(0, 4),
-      ch: '-',
-      options,
-    };
-
-    documentManager.open(params.textDocument.uri, '{{ - }}', 1);
-    const document = documentManager.get(params.textDocument.uri)?.textDocument;
-    assert(document);
-
-    const result = await onTypeFormattingProvider.onTypeFormatting(params);
-    assert(result);
-    expect(TextDocument.applyEdits(document, result)).to.equal('{{-  -}}');
-  });
-
-  it('should return a TextEdit to replace and insert characters in "{% - %}"', async () => {
-    const params: DocumentOnTypeFormattingParams = {
-      textDocument: { uri: 'file:///path/to/document.liquid' },
-      position: Position.create(0, 4),
-      ch: '-',
-      options,
-    };
-
-    documentManager.open(params.textDocument.uri, '{% - %}', 1);
-    const document = documentManager.get(params.textDocument.uri)?.textDocument;
-    assert(document);
-
-    const result = await onTypeFormattingProvider.onTypeFormatting(params);
-    assert(result);
-    expect(TextDocument.applyEdits(document, result)).to.equal('{%-  -%}');
   });
 
   it('should return null for characters not matching any case', async () => {

--- a/packages/theme-language-server-common/src/formatting/OnTypeFormattingProvider.ts
+++ b/packages/theme-language-server-common/src/formatting/OnTypeFormattingProvider.ts
@@ -1,110 +1,19 @@
-import { DocumentManager } from '../documents';
 import { DocumentOnTypeFormattingParams } from 'vscode-languageserver';
-import { Range, Position, TextEdit } from 'vscode-languageserver-protocol';
+import { DocumentManager } from '../documents';
+import { BaseOnTypeFormattingProvider } from './types';
+import { BracketsAutoclosingOnTypeFormattingProvider } from './providers/BracketsAutoclosingOnTypeFormattingProvider';
 
 export class OnTypeFormattingProvider {
-  constructor(public documentManager: DocumentManager) {}
+  private providers: BaseOnTypeFormattingProvider[];
 
-  /**
-   * This very complex piece of code here exists to provide a good autoclosing UX.
-   *
-   * The story is kind of long so here goes...
-   *
-   * What we want:
-   * 1. Basic autoclosing of {{, {% with the corresponding pair (and spaces)
-   *   - user types: {{
-   *   - user sees: {{ | }} (with cursor position at |)
-   * 2. Autoclosing of {{- with -}}, {%- with -%}
-   *   - user types: {{-
-   *   - user sees: {{- | -}} (with cursor at |)
-   * 3. User adds whitespace stripping on one side of the braces of an existing tag
-   *   - user types: - at | in `{{| drop }}`
-   *   - user sees: {{- drop }}
-   *
-   * Why we can't do it with autoclosingPairs:
-   *   - VS Code's settings accepts autoclosingPairs and autocloseBefore
-   *     - autoclosingPairs is a set of pairs that should be autoclosed (e.g. ['{%', '%}'])
-   *     - autocloseBefore is a character set of 'allowed next characters' that would cause a closing pair
-   *   - If we put a space (' ') the autoclosingPairs set, then (3) from above becomes funky:
-   *     - assume autoclosingPairs = {|}, {{|}}, {{ | }}
-   *     - user types: a space at | in `{{| drop }}`
-   *     - user sees: {{   }}drop }}
-   *   - This happens because the space is an autocloseBefore character, it sees a space after the cursor
-   *     so it closes '{{ ' with ' }}' at the cursor position, resulting in '{{  }}drop }}'
-   *   - Something similar happens if we include the `-` in the autoclosing pairs
-   *   - This is annoying!
-   *
-   * So our solution is the following:
-   * 1. We change the pairs to include the closing space (this way our cursor remains where we want it to be)
-   *    - {{| }}
-   *    - {%| %}
-   * 2. We add this OnTypeFormattingProvider that does the following "fixes":
-   *    - {{| }}   into {{ | }}
-   *    - {{ -| }} into {{- | -}}
-   *    - {%| %}   into {% | %}
-   *    - {% -| %} into {%- | -%}
-   *
-   * This lets us avoid the unnecessary close and accomplish 1, 2 and 3 :)
-   *
-   * Fallback for editor.onTypeFormatting: false is to let the user type the `-` on both sides manually
-   */
+  constructor(public documentManager: DocumentManager) {
+    this.providers = [new BracketsAutoclosingOnTypeFormattingProvider()];
+  }
+
   async onTypeFormatting(params: DocumentOnTypeFormattingParams) {
     const document = this.documentManager.get(params.textDocument.uri);
     if (!document) return null;
-    const textDocument = document.textDocument;
-    const ch = params.ch;
-    // position is position of cursor so 1 ahead of char
-    const { line, character } = params.position;
-    // This is an early return to avoid doing currentLine.at(-1);
-    if ((ch === ' ' && character <= 2) || character <= 1) return null;
-    const currentLineRange = Range.create(Position.create(line, 0), Position.create(line + 1, 0));
-    const currentLine = textDocument.getText(currentLineRange);
-    const charIdx = ch === ' ' ? character - 2 : character - 1;
-    const char = currentLine.at(charIdx);
-    switch (char) {
-      // here we fix {{| }} with {{ | }}
-      // here we fix {%| %} with {% | %}
-      case '{':
-      case '%': {
-        const chars = currentLine.slice(charIdx - 1, charIdx + 4);
-        if (chars === '{{ }}' || chars === '{% %}') {
-          return [TextEdit.insert(Position.create(line, charIdx + 1), ' ')];
-        }
-      }
-
-      // here we fix {{ -| }} to {{- | -}}
-      // here we fix {% -| }} to {%- | -%}
-      case '-': {
-        // remember 0-index means 4th char
-        if (charIdx < 3) return null;
-
-        const chars = currentLine.slice(charIdx - 3, charIdx + 4);
-        if (chars === '{{ - }}' || chars === '{% - %}') {
-          // Here we're being clever and doing the {{- -}} if the first character
-          // you type is a `-`, leaving your cursor in the middle :)
-          return [
-            // Start with
-            //   {{ - }}
-            //     ^ start replace
-            //       ^ end replace (excluded)
-            // Replace with '- ', get
-            //   {{- }}
-            TextEdit.replace(
-              Range.create(Position.create(line, charIdx - 1), Position.create(line, charIdx + 1)),
-              '- ',
-            ),
-            // Start with
-            //   {{ - }}
-            //      ^ char
-            //        ^ insertion point
-            // Insert ' ' , get
-            //   {{ - -}}
-            // Both together and you get {{- -}} with your cursor in the middle
-            TextEdit.insert(Position.create(line, charIdx + 2), '-'),
-          ];
-        }
-      }
-    }
-    return null;
+    const results = this.providers.map((provider) => provider.onTypeFormatting(document, params));
+    return results.find((result) => result !== null) ?? null;
   }
 }

--- a/packages/theme-language-server-common/src/formatting/OnTypeFormattingProvider.ts
+++ b/packages/theme-language-server-common/src/formatting/OnTypeFormattingProvider.ts
@@ -1,13 +1,20 @@
 import { DocumentOnTypeFormattingParams } from 'vscode-languageserver';
 import { DocumentManager } from '../documents';
-import { BaseOnTypeFormattingProvider } from './types';
 import { BracketsAutoclosingOnTypeFormattingProvider } from './providers/BracketsAutoclosingOnTypeFormattingProvider';
+import { HtmlElementAutoclosingOnTypeFormattingProvider } from './providers/HtmlElementAutoclosingOnTypeFormattingProvider';
+import { BaseOnTypeFormattingProvider, SetCursorPosition } from './types';
 
 export class OnTypeFormattingProvider {
   private providers: BaseOnTypeFormattingProvider[];
 
-  constructor(public documentManager: DocumentManager) {
-    this.providers = [new BracketsAutoclosingOnTypeFormattingProvider()];
+  constructor(
+    public documentManager: DocumentManager,
+    public setCursorPosition: SetCursorPosition = async () => {},
+  ) {
+    this.providers = [
+      new BracketsAutoclosingOnTypeFormattingProvider(),
+      new HtmlElementAutoclosingOnTypeFormattingProvider(setCursorPosition),
+    ];
   }
 
   async onTypeFormatting(params: DocumentOnTypeFormattingParams) {

--- a/packages/theme-language-server-common/src/formatting/providers/BracketsAutoclosingOnTypeFormattingProvider.spec.ts
+++ b/packages/theme-language-server-common/src/formatting/providers/BracketsAutoclosingOnTypeFormattingProvider.spec.ts
@@ -1,0 +1,89 @@
+import { assert, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { DocumentOnTypeFormattingParams } from 'vscode-languageserver';
+import { Position } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { DocumentManager } from '../../documents';
+import { OnTypeFormattingProvider } from '../OnTypeFormattingProvider';
+
+const options: DocumentOnTypeFormattingParams['options'] = {
+  insertSpaces: true,
+  tabSize: 2,
+};
+
+describe('Module: BracketsAutoclosingOnTypeFormattingProvider', () => {
+  let documentManager: DocumentManager;
+  let onTypeFormattingProvider: OnTypeFormattingProvider;
+
+  beforeEach(() => {
+    documentManager = new DocumentManager();
+    onTypeFormattingProvider = new OnTypeFormattingProvider(documentManager);
+  });
+
+  it('should return a TextEdit to insert a space after "{{" in "{{ }}"', async () => {
+    const params: DocumentOnTypeFormattingParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 2),
+      ch: '{',
+      options,
+    };
+
+    documentManager.open(params.textDocument.uri, '{{ }}', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await onTypeFormattingProvider.onTypeFormatting(params);
+    assert(result);
+    expect(TextDocument.applyEdits(document, result)).to.equal('{{  }}');
+  });
+
+  it('should return a TextEdit to insert a space after "{%" in "{% %}"', async () => {
+    const params: DocumentOnTypeFormattingParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 2),
+      ch: '%',
+      options,
+    };
+
+    documentManager.open(params.textDocument.uri, '{% %}', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await onTypeFormattingProvider.onTypeFormatting(params);
+    assert(result);
+    expect(TextDocument.applyEdits(document, result)).to.equal('{%  %}');
+  });
+
+  it('should return a TextEdit to replace and insert characters in "{{ - }}"', async () => {
+    const params: DocumentOnTypeFormattingParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 4),
+      ch: '-',
+      options,
+    };
+
+    documentManager.open(params.textDocument.uri, '{{ - }}', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await onTypeFormattingProvider.onTypeFormatting(params);
+    assert(result);
+    expect(TextDocument.applyEdits(document, result)).to.equal('{{-  -}}');
+  });
+
+  it('should return a TextEdit to replace and insert characters in "{% - %}"', async () => {
+    const params: DocumentOnTypeFormattingParams = {
+      textDocument: { uri: 'file:///path/to/document.liquid' },
+      position: Position.create(0, 4),
+      ch: '-',
+      options,
+    };
+
+    documentManager.open(params.textDocument.uri, '{% - %}', 1);
+    const document = documentManager.get(params.textDocument.uri)?.textDocument;
+    assert(document);
+
+    const result = await onTypeFormattingProvider.onTypeFormatting(params);
+    assert(result);
+    expect(TextDocument.applyEdits(document, result)).to.equal('{%-  -%}');
+  });
+});

--- a/packages/theme-language-server-common/src/formatting/providers/BracketsAutoclosingOnTypeFormattingProvider.ts
+++ b/packages/theme-language-server-common/src/formatting/providers/BracketsAutoclosingOnTypeFormattingProvider.ts
@@ -1,0 +1,114 @@
+import {
+  Range,
+  DocumentOnTypeFormattingParams,
+  TextEdit,
+  Position,
+} from 'vscode-languageserver-protocol';
+import { AugmentedSourceCode } from '../../documents';
+import { BaseOnTypeFormattingProvider } from '../types';
+
+export class BracketsAutoclosingOnTypeFormattingProvider implements BaseOnTypeFormattingProvider {
+  /**
+   * This very complex piece of code here exists to provide a good autoclosing UX.
+   *
+   * The story is kind of long so here goes...
+   *
+   * What we want:
+   * 1. Basic autoclosing of {{, {% with the corresponding pair (and spaces)
+   *   - user types: {{
+   *   - user sees: {{ | }} (with cursor position at |)
+   * 2. Autoclosing of {{- with -}}, {%- with -%}
+   *   - user types: {{-
+   *   - user sees: {{- | -}} (with cursor at |)
+   * 3. User adds whitespace stripping on one side of the braces of an existing tag
+   *   - user types: - at | in `{{| drop }}`
+   *   - user sees: {{- drop }}
+   *
+   * Why we can't do it with autoclosingPairs:
+   *   - VS Code's settings accepts autoclosingPairs and autocloseBefore
+   *     - autoclosingPairs is a set of pairs that should be autoclosed (e.g. ['{%', '%}'])
+   *     - autocloseBefore is a character set of 'allowed next characters' that would cause a closing pair
+   *   - If we put a space (' ') the autoclosingPairs set, then (3) from above becomes funky:
+   *     - assume autoclosingPairs = {|}, {{|}}, {{ | }}
+   *     - user types: a space at | in `{{| drop }}`
+   *     - user sees: {{   }}drop }}
+   *   - This happens because the space is an autocloseBefore character, it sees a space after the cursor
+   *     so it closes '{{ ' with ' }}' at the cursor position, resulting in '{{  }}drop }}'
+   *   - Something similar happens if we include the `-` in the autoclosing pairs
+   *   - This is annoying!
+   *
+   * So our solution is the following:
+   * 1. We change the pairs to include the closing space (this way our cursor remains where we want it to be)
+   *    - {{| }}
+   *    - {%| %}
+   * 2. We add this OnTypeFormattingProvider that does the following "fixes":
+   *    - {{| }}   into {{ | }}
+   *    - {{ -| }} into {{- | -}}
+   *    - {%| %}   into {% | %}
+   *    - {% -| %} into {%- | -%}
+   *
+   * This lets us avoid the unnecessary close and accomplish 1, 2 and 3 :)
+   *
+   * Fallback for editor.onTypeFormatting: false is to let the user type the `-` on both sides manually
+   */
+  onTypeFormatting(
+    document: AugmentedSourceCode,
+    params: DocumentOnTypeFormattingParams,
+  ): TextEdit[] | null {
+    const textDocument = document.textDocument;
+    const ch = params.ch;
+    // position is position of cursor so 1 ahead of char
+    const { line, character } = params.position;
+    // This is an early return to avoid doing currentLine.at(-1);
+    if ((ch === ' ' && character <= 2) || character <= 1) return null;
+    const currentLineRange = Range.create(Position.create(line, 0), Position.create(line + 1, 0));
+    const currentLine = textDocument.getText(currentLineRange);
+    const charIdx = ch === ' ' ? character - 2 : character - 1;
+    const char = currentLine.at(charIdx);
+    switch (char) {
+      // here we fix {{| }} with {{ | }}
+      // here we fix {%| %} with {% | %}
+      case '{':
+      case '%': {
+        const chars = currentLine.slice(charIdx - 1, charIdx + 4);
+        if (chars === '{{ }}' || chars === '{% %}') {
+          return [TextEdit.insert(Position.create(line, charIdx + 1), ' ')];
+        }
+      }
+
+      // here we fix {{ -| }} to {{- | -}}
+      // here we fix {% -| }} to {%- | -%}
+      case '-': {
+        // remember 0-index means 4th char
+        if (charIdx < 3) return null;
+
+        const chars = currentLine.slice(charIdx - 3, charIdx + 4);
+        if (chars === '{{ - }}' || chars === '{% - %}') {
+          // Here we're being clever and doing the {{- -}} if the first character
+          // you type is a `-`, leaving your cursor in the middle :)
+          return [
+            // Start with
+            //   {{ - }}
+            //     ^ start replace
+            //       ^ end replace (excluded)
+            // Replace with '- ', get
+            //   {{- }}
+            TextEdit.replace(
+              Range.create(Position.create(line, charIdx - 1), Position.create(line, charIdx + 1)),
+              '- ',
+            ),
+            // Start with
+            //   {{ - }}
+            //      ^ char
+            //        ^ insertion point
+            // Insert ' ' , get
+            //   {{ - -}}
+            // Both together and you get {{- -}} with your cursor in the middle
+            TextEdit.insert(Position.create(line, charIdx + 2), '-'),
+          ];
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/packages/theme-language-server-common/src/formatting/providers/HtmlElementAutoclosingOnTypeFormattingProvider.spec.ts
+++ b/packages/theme-language-server-common/src/formatting/providers/HtmlElementAutoclosingOnTypeFormattingProvider.spec.ts
@@ -1,0 +1,148 @@
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DocumentOnTypeFormattingParams } from 'vscode-languageserver';
+import { Position } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { DocumentManager } from '../../documents';
+import { OnTypeFormattingProvider } from '../OnTypeFormattingProvider';
+
+const options: DocumentOnTypeFormattingParams['options'] = {
+  insertSpaces: true,
+  tabSize: 2,
+};
+
+describe('Module: HtmlElementAutoclosingOnTypeFormattingProvider', () => {
+  let documentManager: DocumentManager;
+  let onTypeFormattingProvider: OnTypeFormattingProvider;
+  let setCursorPositionSpy: ReturnType<typeof vi.fn>;
+  const uri = 'file:///path/to/document.liquid';
+
+  beforeEach(() => {
+    setCursorPositionSpy = vi.fn();
+    documentManager = new DocumentManager();
+    onTypeFormattingProvider = new OnTypeFormattingProvider(documentManager, setCursorPositionSpy);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return a TextEdit to insert a closing <tag> when you type > for an unclosed tag', async () => {
+    const source = '<div id="main">';
+    documentManager.open(uri, source, 1);
+    const document = documentManager.get(uri)?.textDocument!;
+
+    const params: DocumentOnTypeFormattingParams = {
+      textDocument: { uri },
+      position: document.positionAt(source.indexOf('>') + 1),
+      ch: '>',
+      options,
+    };
+
+    assert(document);
+
+    const result = await onTypeFormattingProvider.onTypeFormatting(params);
+    assert(result);
+    expect(TextDocument.applyEdits(document, result)).to.equal('<div id="main"></div>');
+
+    vi.advanceTimersByTime(10);
+    expect(setCursorPositionSpy).toHaveBeenCalledWith(
+      document,
+      document.positionAt(source.indexOf('>') + 1),
+    );
+  });
+
+  it('should return a TextEdit to insert a closing <tag> when you type > for an unclosed tag even if the unclosed tag is higher up', async () => {
+    const CURSOR = '█';
+    // in this scenario, the cursor is after div#inner, but the unclosed tag is div#main.
+    // we still want to close it because that's probably what you want to do.
+    const source = `
+      <div id="main">
+        <img>
+        <div id="inner">█
+      </div>
+    `;
+    documentManager.open(uri, source.replace(CURSOR, ''), 1);
+    const document = documentManager.get(uri)?.textDocument!;
+
+    const indexOfCursor = source.indexOf(CURSOR);
+    const params: DocumentOnTypeFormattingParams = {
+      textDocument: { uri },
+      position: document.positionAt(indexOfCursor),
+      ch: '>',
+      options,
+    };
+
+    assert(document);
+
+    const result = await onTypeFormattingProvider.onTypeFormatting(params);
+    assert(result);
+    expect(TextDocument.applyEdits(document, result)).to.equal(`
+      <div id="main">
+        <img>
+        <div id="inner"></div>
+      </div>
+    `);
+
+    vi.advanceTimersByTime(10);
+    expect(setCursorPositionSpy).toHaveBeenCalledWith(document, document.positionAt(indexOfCursor));
+  });
+
+  it('should return a TextEdit to insert a closing <tag> when you type > for an unclosed tag even if the unclosed tag is higher up and theres a sibling closed tag', async () => {
+    const CURSOR = '█';
+    // in this scenario, the cursor is after div#inner, but the unclosed tag is div#main.
+    // we still want to close it because that's probably what you want to do.
+    const source = `
+      <div id="main">
+        <div id="inner">█
+        <div></div>
+      </div>
+    `;
+    documentManager.open(uri, source.replace(CURSOR, ''), 1);
+    const document = documentManager.get(uri)?.textDocument!;
+
+    const indexOfCursor = source.indexOf(CURSOR);
+    const params: DocumentOnTypeFormattingParams = {
+      textDocument: { uri },
+      position: document.positionAt(indexOfCursor),
+      ch: '>',
+      options,
+    };
+
+    assert(document);
+
+    const result = await onTypeFormattingProvider.onTypeFormatting(params);
+    assert(result);
+    expect(TextDocument.applyEdits(document, result)).to.equal(`
+      <div id="main">
+        <div id="inner"></div>
+        <div></div>
+      </div>
+    `);
+
+    vi.advanceTimersByTime(10);
+    expect(setCursorPositionSpy).toHaveBeenCalledWith(document, document.positionAt(indexOfCursor));
+  });
+
+  it('should not try to close the tag when pressing > inside a Liquid tag if condition (what HTML would do)', async () => {
+    const CURSOR = '█';
+    const scenarios = ['<div {% if cond >█', '<div {% if cond >█ %}>', '<div {% if cond >█ 2 %}>'];
+    for (const source of scenarios) {
+      documentManager.open(uri, source.replace(CURSOR, ''), 1);
+      const document = documentManager.get(uri)?.textDocument!;
+
+      const indexOfCursor = source.indexOf(CURSOR);
+      const params: DocumentOnTypeFormattingParams = {
+        textDocument: { uri },
+        position: document.positionAt(indexOfCursor),
+        ch: '>',
+        options,
+      };
+
+      assert(document);
+
+      const result = await onTypeFormattingProvider.onTypeFormatting(params);
+      assert(!result);
+    }
+  });
+});

--- a/packages/theme-language-server-common/src/formatting/providers/HtmlElementAutoclosingOnTypeFormattingProvider.ts
+++ b/packages/theme-language-server-common/src/formatting/providers/HtmlElementAutoclosingOnTypeFormattingProvider.ts
@@ -1,0 +1,113 @@
+import {
+  getName,
+  LiquidHTMLASTParsingError,
+  LiquidHtmlNode,
+  NodeTypes,
+  toLiquidHtmlAST,
+} from '@shopify/liquid-html-parser';
+import {
+  DocumentOnTypeFormattingParams,
+  Position,
+  Range,
+  TextEdit,
+} from 'vscode-languageserver-protocol';
+import { AugmentedSourceCode } from '../../documents';
+import { BaseOnTypeFormattingProvider } from '../types';
+import { findCurrentNode } from '../../visitor';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { SetCursorPosition } from '../types';
+
+const defer = (fn: () => void) => setTimeout(fn, 10);
+
+/**
+ * This class is responsible for closing dangling HTML elements.
+ *
+ * Say user types <script>, then we'd want `</script>` to be inserted.
+ *
+ * Thing is we want to do that only if the `</script>` isn't already present in the file.
+ * If the user goes to edit `<script>` and types `>`, we don't want to insert `</script>` again.
+ *
+ * The "trick" we use here is to only add the `</script>` part if the
+ * document.ast is an instance of LiquidHTMLASTParsingError and that the
+ * unclosed element is of the correct name.
+ *
+ * @example:
+ * ```html
+ *   <div id="main">
+ *     <div id="inner">|
+ *   </div>
+ * ```
+ * - The user just finished typing `<div id="inner">` inside the div#main.
+ * - This parses as though the div#inner is closed and div#main isn't.
+ * - That's OK.
+ * - This makes a LiquidHTMLASTParsingError with unclosed div (the div#main).
+ * - Since
+ *     - the cursor is at the end of a div, and
+ *     - the unclosed element is a div,
+ *   Then we can insert one automatically after the cursor and fix the AST.
+ *
+ * ```html
+ *  <div id="main">
+ *    <div id="inner">|</div>
+ *  </div>
+ * ```
+ */
+export class HtmlElementAutoclosingOnTypeFormattingProvider
+  implements BaseOnTypeFormattingProvider
+{
+  constructor(private setCursorPosition: SetCursorPosition) {}
+
+  onTypeFormatting(
+    document: AugmentedSourceCode,
+    params: DocumentOnTypeFormattingParams,
+  ): TextEdit[] | null {
+    const textDocument = document.textDocument;
+    const ch = params.ch;
+    // position is position of cursor so 1 ahead of char
+    const { line, character } = params.position;
+    switch (ch) {
+      // here we fix `>` with `</$unclosed>`
+      case '>': {
+        const ast = document.ast;
+        if (
+          ch === '>' &&
+          ast instanceof LiquidHTMLASTParsingError &&
+          ast.unclosed &&
+          ast.unclosed.type === NodeTypes.HtmlElement &&
+          (ast.unclosed.blockStartPosition.end === textDocument.offsetAt(params.position) ||
+            shouldClose(ast.unclosed, nodeAtCursor(textDocument, params.position)))
+        ) {
+          defer(() => this.setCursorPosition(textDocument, params.position));
+          return [TextEdit.insert(Position.create(line, character), `</${ast.unclosed.name}>`)];
+        }
+      }
+    }
+    return null;
+  }
+}
+
+function nodeAtCursor(textDocument: TextDocument, position: Position) {
+  const text = textDocument.getText(Range.create(Position.create(0, 0), position));
+  try {
+    const ast = toLiquidHtmlAST(text, {
+      allowUnclosedDocumentNode: true,
+      mode: 'tolerant',
+    });
+
+    const [node, ancestors] = findCurrentNode(ast, textDocument.offsetAt(position));
+    if (ancestors.at(-1)?.type === NodeTypes.HtmlElement) return ancestors.at(-1)!;
+    if (node.type === NodeTypes.LiquidBranch) return ancestors.at(-1)!;
+    return node;
+  } catch {
+    return null;
+  }
+}
+
+function shouldClose(unclosed: any, node: LiquidHtmlNode | null) {
+  if (node === null || !('blockStartPosition' in node)) return false;
+
+  return (
+    [NodeTypes.HtmlElement, NodeTypes.LiquidTag, NodeTypes.HtmlRawNode].includes(unclosed.type) &&
+    getName(node) === unclosed.name
+  );
+}

--- a/packages/theme-language-server-common/src/formatting/types.ts
+++ b/packages/theme-language-server-common/src/formatting/types.ts
@@ -1,0 +1,12 @@
+import { DocumentOnTypeFormattingParams, Position, TextEdit } from 'vscode-languageserver-protocol';
+import { AugmentedSourceCode } from '../documents';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+export interface BaseOnTypeFormattingProvider {
+  onTypeFormatting(
+    document: AugmentedSourceCode,
+    params: DocumentOnTypeFormattingParams,
+  ): TextEdit[] | null;
+}
+
+export type SetCursorPosition = (textDocument: TextDocument, position: Position) => Promise<void>;

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -3,6 +3,7 @@ import {
   Connection,
   FileOperationRegistrationOptions,
   InitializeResult,
+  ShowDocumentRequest,
   TextDocumentSyncKind,
 } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
@@ -66,7 +67,20 @@ export function startServer(
   const diagnosticsManager = new DiagnosticsManager(connection);
   const documentLinksProvider = new DocumentLinksProvider(documentManager);
   const codeActionsProvider = new CodeActionsProvider(documentManager, diagnosticsManager);
-  const onTypeFormattingProvider = new OnTypeFormattingProvider(documentManager);
+  const onTypeFormattingProvider = new OnTypeFormattingProvider(
+    documentManager,
+    async function setCursorPosition(textDocument, position) {
+      if (!clientCapabilities.hasShowDocumentSupport) return;
+      connection.sendRequest(ShowDocumentRequest.type, {
+        uri: textDocument.uri,
+        takeFocus: true,
+        selection: {
+          start: position,
+          end: position,
+        },
+      });
+    },
+  );
   const linkedEditingRangesProvider = new LinkedEditingRangesProvider(documentManager);
   const documentHighlightProvider = new DocumentHighlightsProvider(documentManager);
   const renameProvider = new RenameProvider(documentManager);

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -204,7 +204,7 @@ export function startServer(
         },
         documentOnTypeFormattingProvider: {
           firstTriggerCharacter: ' ',
-          moreTriggerCharacter: ['{', '%', '-'],
+          moreTriggerCharacter: ['{', '%', '-', '>'],
         },
         documentLinkProvider: {
           resolveProvider: false,

--- a/packages/theme-language-server-common/src/visitor.ts
+++ b/packages/theme-language-server-common/src/visitor.ts
@@ -93,7 +93,10 @@ export function findCurrentNode(
       current,
       ancestors.concat(current),
       (child, lineage) => {
-        if (isCovered(child, cursorPosition) && size(child) <= size(current)) {
+        if (
+          isUnclosed(child) ||
+          (isCovered(child, cursorPosition) && size(child) <= size(current))
+        ) {
           current = child;
           ancestors = lineage;
         }
@@ -110,4 +113,13 @@ function isCovered(node: LiquidHtmlNode, offset: number): boolean {
 
 function size(node: LiquidHtmlNode): number {
   return node.position.end - node.position.start;
+}
+
+function isUnclosed(node: LiquidHtmlNode): boolean {
+  if ('blockEndPosition' in node) {
+    return node.blockEndPosition?.end === -1;
+  } else if ('children' in node) {
+    return node.children!.length > 0;
+  }
+  return false;
 }

--- a/packages/vscode-extension/scripts/on-enter-actions.ts
+++ b/packages/vscode-extension/scripts/on-enter-actions.ts
@@ -1,6 +1,9 @@
 import { EnterAction, OnEnterRule } from 'vscode';
+import { voidElements } from './constants';
 
-export interface OnEnterRuleJSON extends Omit<OnEnterRule, 'action'> {
+export interface OnEnterRuleJSON extends Omit<OnEnterRule, 'action' | 'beforeText' | 'afterText'> {
+  beforeText?: string;
+  afterText?: string;
   action: EnterActionJSON;
 }
 
@@ -9,5 +12,19 @@ export interface EnterActionJSON extends Omit<EnterAction, 'indentAction'> {
 }
 
 export async function onEnterRules(): Promise<OnEnterRuleJSON[]> {
-  return [];
+  // Adapted from the Monaco Editor source code
+  // https://github.com/microsoft/monaco-editor/blob/f6dc0eb8fce67e57f6036f4769d92c1666cdf546/src/basic-languages/html/html.ts#L88
+  return [
+    {
+      beforeText: `<(?!(?:${voidElements.join('|')}))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!/)>)[^<]*$`,
+      afterText: `^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>$`,
+      action: {
+        indent: 'indentOutdent',
+      },
+    },
+    {
+      beforeText: `<(?!(?:${voidElements.join('|')}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
+      action: { indent: 'indent' },
+    },
+  ];
 }


### PR DESCRIPTION
## The feature's TL;DR:


https://github.com/user-attachments/assets/d9f5c6f3-c8de-494b-901c-5cda8d571b0b



- Type `>` to close an HTML element, get the `</$tagName>` for free.

```liquid
<!-- type this -->
<div id="main">
  <div id="inner">|
</div>

<!-- get this -->
<div id="main">
  <div id="inner">|</div>
</div>
```

- Type `enter` in the middle of a closed tag and get the correct level of indentation


https://github.com/user-attachments/assets/b1bfdffa-7118-4df2-a53d-ed367c40ccc4


### Fun exceptions we support

```liquid
{% # type %}
<div
  {% if cond > 2 %}
    note="the `>` inside the if condition doesn't trip the parser"
  {% endif %}
>|

{% # get %}
<div
  {% if cond > 2 %}
    note="the `>` inside the if condition doesn't trip the parser"
  {% endif %}
>|</div>
```

## What are you adding in this PR?

- Rearchitect `OnTypeFormattingProvider` for extensibility
- Add `unclosed` node information on LiquidHTMLASTParsingErrors
- Add HTML Element close tag auto-insertion support

### How it works

- Language Client makes [server->client `textDocument/onTypeFormatting` requests](tdotf) when the user types the `>` character
  - **If** the `document.ast` is a `LiquidHTMLASTParsingError` that says one of:
    - "Attempting to close X before Y was closed",
    - "Attempting to end parsing before Y was closed",
  - **Then** we reply with a [TextEdit](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit) that modifies the file and appends `</$tag>` at the cursor position
    - When that happens, we also use the [`window/showDocument` server->client request][wsd] to place the cursor in the right location.

- When the stars are not aligned, we do nothing.

[tdotf]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_onTypeFormatting

## What did you learn?

- [The `window/showDocument` server->client request][wsds] accepts a `selection` parameter which makes it possible to move the cursor back to after the `>` after inserting the `</$tagname>`.

[wsds]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument:~:text=a%20text%0A%09%20*%20file.%0A%09%20*/-,selection,-%3F%3A%20Range%3B
[wsd]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument

## Before you deploy

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
