### PR TITLE
Should not highlight, linked edit or rename dangling HTML tags

### DIFF
--- a/packages/theme-language-server-common/src/linkedEditingRanges/providers/HtmlTagNameLinkedRangesProvider.spec.ts
+++ b/packages/theme-language-server-common/src/linkedEditingRanges/providers/HtmlTagNameLinkedRangesProvider.spec.ts
@@ -4,92 +4,97 @@ import { DocumentManager } from '../../documents';
 import { LinkedEditingRangeParams } from 'vscode-languageserver';
 import { Position } from 'vscode-languageserver-protocol';
 import { htmlElementNameWordPattern } from '../wordPattern';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 
 describe('Module: HtmlTagNameLinkedRangesProvider', () => {
+  const uri = 'file:///path/to/document.liquid';
   let documentManager: DocumentManager;
   let provider: LinkedEditingRangesProvider;
+  let params: LinkedEditingRangeParams;
+  let document: TextDocument;
+  let source: string;
 
   beforeEach(() => {
     documentManager = new DocumentManager();
     provider = new LinkedEditingRangesProvider(documentManager);
   });
 
-  it('should return null for non-existent documents', async () => {
-    const params: LinkedEditingRangeParams = {
-      textDocument: { uri: 'file:///path/to/non-existent-document.liquid' },
-      position: Position.create(0, 0),
-    };
+  describe('When the HTML tag is closed and the cursor is inside the tag name', () => {
+    beforeEach(() => {
+      source = '<div id="main"><img><div></div></div>';
+      documentManager.open(uri, source, 1);
+      document = documentManager.get(uri)?.textDocument!;
+    });
 
-    const result = await provider.linkedEditingRanges(params);
-    expect(result).toBeNull();
+    it('should return linked editing ranges for HTML tag names', async () => {
+      params = {
+        textDocument: { uri },
+        position: document.positionAt(1), // position within the opening div#main tag name
+      };
+
+      const result = await provider.linkedEditingRanges(params);
+      assert(result);
+      assert(result.ranges[0]);
+      assert(result.ranges[1]);
+      expect(result.ranges[0]).not.to.eql(result.ranges[1]);
+
+      const startTagName = document.getText(result.ranges[0]);
+      const endTagName = document.getText(result.ranges[1]);
+
+      expect(startTagName).toBe('div');
+      expect(endTagName).toBe('div');
+      expect(result.wordPattern).toBe(htmlElementNameWordPattern);
+    });
+
+    it('should return linked editing ranges for closing HTML tag names', async () => {
+      params = {
+        textDocument: { uri },
+        position: document.positionAt(source.indexOf('</div>') + 2), // position within the closing div tag name
+      };
+
+      const result = await provider.linkedEditingRanges(params);
+      assert(result);
+      assert(result.ranges[0]);
+      assert(result.ranges[1]);
+
+      const startTagName = document.getText(result.ranges[0]);
+      const endTagName = document.getText(result.ranges[1]);
+
+      expect(startTagName).toBe('div');
+      expect(endTagName).toBe('div');
+      expect(result.wordPattern).toBe(htmlElementNameWordPattern);
+    });
   });
 
-  it('should return null for non-HTML documents', async () => {
-    const params: LinkedEditingRangeParams = {
-      textDocument: { uri: 'file:///path/to/document.liquid' },
-      position: Position.create(0, 0),
-    };
+  describe('When The HTML tag name is dangling', () => {
+    beforeEach(() => {
+      // This is acceptable Liquid. We allow folks to have an unclosed HTML
+      // element inside conditional blocks.
+      source = `
+        {% if cond %}
+          <div>
+        {% endif %}
+      `;
+      documentManager.open(uri, source, 1);
+      document = documentManager.get(uri)?.textDocument!;
+    });
 
-    documentManager.open(params.textDocument.uri, 'Sample text content', 1);
-
-    const result = await provider.linkedEditingRanges(params);
-    expect(result).toBeNull();
-  });
-
-  it('should return linked editing ranges for HTML tag names', async () => {
-    const params: LinkedEditingRangeParams = {
-      textDocument: { uri: 'file:///path/to/document.liquid' },
-      position: Position.create(0, 3), // position within the tag name
-    };
-
-    documentManager.open(params.textDocument.uri, '<div></div>', 1);
-    const document = documentManager.get(params.textDocument.uri)?.textDocument;
-    assert(document);
-
-    const result = await provider.linkedEditingRanges(params);
-    assert(result);
-    assert(result.ranges[0]);
-    assert(result.ranges[1]);
-    expect(result.ranges[0]).not.to.eql(result.ranges[1]);
-
-    const startTagName = document.getText(result.ranges[0]);
-    const endTagName = document.getText(result.ranges[1]);
-
-    expect(startTagName).toBe('div');
-    expect(endTagName).toBe('div');
-    expect(result.wordPattern).toBe(htmlElementNameWordPattern);
-  });
-
-  it('should return linked editing ranges for closing HTML tag names', async () => {
-    const params: LinkedEditingRangeParams = {
-      textDocument: { uri: 'file:///path/to/document.liquid' },
-      position: Position.create(0, 16), // position within the closing div tag name
-    };
-
-    documentManager.open(params.textDocument.uri, '<div><img><div></div></div>', 1);
-    const document = documentManager.get(params.textDocument.uri)?.textDocument;
-    assert(document);
-
-    const result = await provider.linkedEditingRanges(params);
-    assert(result);
-    assert(result.ranges[0]);
-    assert(result.ranges[1]);
-
-    const startTagName = document.getText(result.ranges[0]);
-    const endTagName = document.getText(result.ranges[1]);
-
-    expect(startTagName).toBe('div');
-    expect(endTagName).toBe('div');
-    expect(result.wordPattern).toBe(htmlElementNameWordPattern);
+    it('should not return linked editing ranges', async () => {
+      params = {
+        textDocument: { uri },
+        position: document.positionAt(source.indexOf('<div>') + 1),
+      };
+      const result = await provider.linkedEditingRanges(params);
+      expect(result).toBeNull();
+    });
   });
 
   it('should return null for positions not within HTML tag names', async () => {
-    const params: LinkedEditingRangeParams = {
-      textDocument: { uri: 'file:///path/to/document.liquid' },
+    documentManager.open(uri, '<div></div>', 1);
+    params = {
+      textDocument: { uri },
       position: Position.create(0, 0), // position outside the tag name
     };
-
-    documentManager.open(params.textDocument.uri, '<div></div>', 1);
 
     const result = await provider.linkedEditingRanges(params);
     expect(result).toBeNull();

--- a/packages/theme-language-server-common/src/utils/htmlTagNames.ts
+++ b/packages/theme-language-server-common/src/utils/htmlTagNames.ts
@@ -35,7 +35,7 @@ export function getHtmlElementNameRanges(
     htmlElementNode = node;
   }
 
-  if (!htmlElementNode) return null;
+  if (!htmlElementNode || isDanglingOpenHtmlElement(htmlElementNode)) return null;
 
   const nameNodes = htmlElementNode.name;
   const firstNode = nameNodes.at(0)!;
@@ -44,6 +44,7 @@ export function getHtmlElementNameRanges(
     textDocument.positionAt(firstNode.position.start),
     textDocument.positionAt(lastNode.position.end),
   );
+
   const endRange = Range.create(
     // </ means offset 2 characters
     textDocument.positionAt(htmlElementNode.blockEndPosition.start + 2),
@@ -51,4 +52,10 @@ export function getHtmlElementNameRanges(
   );
 
   return [startRange, endRange];
+}
+
+export function isDanglingOpenHtmlElement(node: LiquidHtmlNode) {
+  return (
+    node.type === NodeTypes.HtmlElement && node.blockEndPosition.start === node.blockEndPosition.end
+  );
 }


### PR DESCRIPTION
## What are you adding in this PR?

When doing Liquid tag completion, I noticed that linked editing of
HTML tag names was broken inside liquid branches.

```liquid
{% # this is acceptable %}
{% if cond %}
  <div>
{% endif %}

{% if cond %}
  </div>
{% endif %}
```

The code we had in place made the `<div>` highlight with `{% ` of the endif.

This PR fixes that.

## Before you deploy

We didn't release Linked Editing yet, so consider this PR part of the changeset for Linked Editing before we release it.

cc @Shopify/advanced-edits 
