### PR TITLE
Add Liquid tag snippet completion

### DIFF
--- a/.changeset/clean-pandas-talk.md
+++ b/.changeset/clean-pandas-talk.md
@@ -1,0 +1,15 @@
+---
+'@shopify/theme-language-server-common': minor
+'theme-check-vscode': minor
+---
+
+Add Liquid tag snippet completion
+
+- Accept the completion item for `if` and get `{% if ${1:condition} %}\n  $0\n{% endif %}` with tabulated placeholders
+  - `${1:condition}` is the first placeholder, press tab to reach the next one
+  - `$0` is the last one
+- This kind of completion works for every Liquid tag and is powered by the syntax snippets on https://shopify.dev
+- The snippets are smart depending on context:
+    - Will infer whitespace stripping characters based on context
+    - Will not snippet complete `{%` and `%}` if inside a `{% liquid %}` tag
+    - Will not snippet complete if markup is already present in the tag definition

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { LiquidHtmlNode } from '@shopify/theme-check-common';
+import { LiquidHtmlNode, SourceCodeType } from '@shopify/theme-check-common';
 import { CompletionParams, Position } from 'vscode-languageserver';
 import { createLiquidCompletionParams } from './LiquidCompletionParams';
-import { DocumentManager } from '../../documents';
+import { AugmentedSourceCode, DocumentManager } from '../../documents';
 
 describe('Module: LiquidCompletionParams', async () => {
   describe('createLiquidCompletionParams', async () => {
@@ -266,7 +266,10 @@ function createLiquidParamsFromContext(
   const uri = 'file:///path/to/file.liquid';
   documentManager.open(uri, context.replace(regex, ''), 1);
   const params = mockCompletionParams({ position: cursorPosition });
-  return createLiquidCompletionParams(documentManager.get(uri)!, params);
+  return createLiquidCompletionParams(
+    documentManager.get(uri)! as AugmentedSourceCode<SourceCodeType.LiquidHtml>,
+    params,
+  );
 }
 
 function calculatePosition(context: string): Position {

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -5,6 +5,7 @@ import {
   Position,
   toLiquidHtmlAST,
 } from '@shopify/liquid-html-parser';
+import { SourceCodeType } from '@shopify/theme-check-common';
 import { CompletionParams } from 'vscode-languageserver';
 import { AugmentedSourceCode } from '../../documents';
 import { fix } from './fix';
@@ -28,10 +29,13 @@ export interface LiquidCompletionParams extends CompletionParams {
    * If undefined, then the file is unparseable.
    */
   readonly completionContext: CompletionContext | undefined;
+
+  /** The document from the document manager */
+  readonly document: AugmentedSourceCode<SourceCodeType.LiquidHtml>;
 }
 
 export function createLiquidCompletionParams(
-  sourceCode: AugmentedSourceCode,
+  sourceCode: AugmentedSourceCode<SourceCodeType.LiquidHtml>,
   params: CompletionParams,
 ): LiquidCompletionParams {
   const { textDocument } = sourceCode;
@@ -41,6 +45,7 @@ export function createLiquidCompletionParams(
   return {
     ...params,
     completionContext,
+    document: sourceCode,
   };
 }
 

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
@@ -1,12 +1,80 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
+import { TagEntry } from '@shopify/theme-check-common';
+import { InsertTextFormat, InsertTextMode, TextEdit } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { CURSOR } from '../params';
 
-export const tags = [
-  { name: 'render' },
-  { name: 'for' },
-  { name: 'comment' },
-  { name: 'if' },
+const caseSyntax = `{% case variable %}
+  {% when first_value %}
+    first_expression
+  {% else %}
+    second_expression
+{% endcase %}`;
+const caseSnippetWithInsideStripping = `case \${1:variable} -%}
+  {%- when \${2:first_value} -%}
+    \$3
+  {%- else -%}
+    \$4
+{%- endcase %}`;
+const caseSnippetWithOutsideStripping = `case \${1:variable} %}
+  {% when \${2:first_value} %}
+    \$3
+  {% else %}
+    \$4
+{% endcase -%}`;
+const caseSnippetWithAllTheStripping = `case \${1:variable} -%}
+  {%- when \${2:first_value} -%}
+    \$3
+  {%- else -%}
+    \$4
+{%- endcase -%}`;
+const caseSnippetInsideLiquidTag = `case \${1:variable}
+  when \${2:first_value}
+    \$3
+  else
+    \$4
+endcase`;
+
+export const tags: TagEntry[] = [
+  {
+    name: 'render',
+    syntax: "{% render 'snippet' %}",
+    syntax_keywords: [{ keyword: 'snippet', description: '...' }],
+  },
+  {
+    name: 'for',
+    syntax: '{% for item in array) %}body{% endfor %}',
+    syntax_keywords: [
+      { keyword: 'item', description: '...' },
+      { keyword: 'array', description: '...' },
+      { keyword: 'body', description: '...' },
+    ],
+  },
+  {
+    name: 'case',
+    syntax: caseSyntax,
+    syntax_keywords: [
+      { keyword: 'variable', description: '...' },
+      { keyword: 'first_value', description: '...' },
+      { keyword: 'first_expression', description: '...' },
+      { keyword: 'second_expression', description: '...' },
+    ],
+  },
+  {
+    name: 'comment',
+    syntax: '{% comment %}comment_body{% endcomment %}',
+    syntax_keywords: [{ keyword: 'comment_body', description: '...' }],
+  },
+  {
+    name: 'if',
+    syntax: '{% if condition %}\n  expression\n{% endif %}',
+    syntax_keywords: [
+      { keyword: 'condition', description: '...' },
+      { keyword: 'expression', description: '...' },
+    ],
+  },
   { name: 'echo' },
 ];
 
@@ -102,6 +170,200 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
       '{% form "cart", cart %} ... {% ',
       allTags.concat('endform'),
     );
+  });
+
+  describe('Snippet completion', () => {
+    it('should not snippet complete when the tag being completed already has markup in it', async () => {
+      const scenarios = [
+        '{% if█ a > b %}',
+        '{% if█ a > b -%}',
+        `{% liquid
+           if█ a > b
+         %}`,
+      ];
+      for (const source of scenarios) {
+        await expect(provider).to.complete(source, [
+          expect.objectContaining({
+            label: 'if',
+            insertTextFormat: InsertTextFormat.PlainText,
+          }),
+        ]);
+      }
+    });
+
+    it('should snippet complete when the tag being completed doesnt have existing markup in it', async () => {
+      const scenarios = [
+        '{% if█ %}',
+        '{% if█ -%}...{% if cond %}{% endif %}',
+        '{% if cond %}{% if█ -%}...{% endif %}',
+      ];
+      for (const scenario of scenarios) {
+        await expect(provider).to.complete(scenario, [
+          expect.objectContaining({
+            label: 'if',
+            insertTextFormat: InsertTextFormat.Snippet,
+          }),
+        ]);
+      }
+    });
+
+    it('should offer text edits that apply correctly', async () => {
+      const source = '...\n{% if█ %}\n...';
+      const textEdit: TextEdit = {
+        newText: 'if ${1:condition} %}\n  $2\n{% endif %}',
+        range: {
+          start: { line: 1, character: 3 },
+          end: { line: 1, character: 8 },
+        },
+      };
+      await expect(provider).to.complete(source, [
+        expect.objectContaining({
+          label: 'if',
+          insertTextFormat: InsertTextFormat.Snippet,
+          insertTextMode: InsertTextMode.adjustIndentation,
+          textEdit,
+        }),
+      ]);
+      const textDocument = TextDocument.create('', 'liquid', 0, source.replace(CURSOR, ''));
+      expect(TextDocument.applyEdits(textDocument, [textEdit])).toBe(
+        '...\n{% if ${1:condition} %}\n  $2\n{% endif %}\n...',
+      );
+    });
+
+    it('should inline the snippet if the tag is inline with more content', async () => {
+      await expect(provider).to.complete('<div {% if█ %}>', [
+        expect.objectContaining({
+          label: 'if',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: {
+            range: expect.any(Object),
+            newText: 'if ${1:condition} %}$2{% endif %}',
+          },
+        }),
+      ]);
+    });
+
+    it('should maintain inside stripping whitespace if present', async () => {
+      await expect(provider).to.complete('{% if█ -%}', [
+        expect.objectContaining({
+          label: 'if',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: {
+            range: expect.any(Object),
+            newText: 'if ${1:condition} -%}\n  $2\n{%- endif %}',
+          },
+        }),
+      ]);
+      await expect(provider).to.complete('{% case█ -%}...', [
+        expect.objectContaining({
+          label: 'case',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: {
+            range: expect.any(Object),
+            newText: caseSnippetWithInsideStripping,
+          },
+        }),
+      ]);
+    });
+
+    it('should mirror outsite stripping whitespace if present', async () => {
+      await expect(provider).to.complete('{%- if█ %}', [
+        expect.objectContaining({
+          label: 'if',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: {
+            range: expect.any(Object),
+            newText: 'if ${1:condition} %}\n  $2\n{% endif -%}',
+          },
+        }),
+      ]);
+      await expect(provider).to.complete('{%- case█ %}...', [
+        expect.objectContaining({
+          label: 'case',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: {
+            range: expect.any(Object),
+            newText: caseSnippetWithOutsideStripping,
+          },
+        }),
+      ]);
+    });
+
+    it('should default to the whitespace stripping of the outer bracket', async () => {
+      await expect(provider).to.complete('{%- if█', [
+        expect.objectContaining({
+          label: 'if',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: {
+            range: expect.any(Object),
+            newText: 'if ${1:condition} -%}\n  $2\n{%- endif -%}',
+          },
+        }),
+      ]);
+    });
+
+    it('should strip whitespace everywhere if we can infer that', async () => {
+      await expect(provider).to.complete('{%- case█ -%}', [
+        expect.objectContaining({
+          label: 'case',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: {
+            range: expect.any(Object),
+            newText: caseSnippetWithAllTheStripping,
+          },
+        }),
+      ]);
+    });
+
+    it('should snippet complete non-block tags correctly', async () => {
+      await expect(provider).to.complete('{% re█ -%}', [
+        expect.objectContaining({
+          label: 'render',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: {
+            range: expect.any(Object),
+            newText: "render '$1'$2 -%}",
+          },
+        }),
+      ]);
+    });
+
+    describe('inside {% liquid %} tags', () => {
+      it('should remove the `{%` and `%}` from the snippet', async () => {
+        const source = `
+          {% liquid
+            if a > b
+              █
+            endif
+          %}`;
+        await expect(provider).to.complete(
+          source,
+          expect.arrayContaining([
+            expect.objectContaining({
+              label: 'if',
+              textEdit: {
+                range: expect.any(Object),
+                newText: 'if ${1:condition}\n  $2\nendif',
+              },
+            }),
+            expect.objectContaining({
+              label: 'render',
+              textEdit: {
+                range: expect.any(Object),
+                newText: "render '$1'$2",
+              },
+            }),
+            expect.objectContaining({
+              label: 'case',
+              textEdit: {
+                range: expect.any(Object),
+                newText: caseSnippetInsideLiquidTag,
+              },
+            }),
+          ]),
+        );
+      });
+    });
   });
 
   it('should not complete when the cursor position is not on the name', async () => {

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
@@ -2,12 +2,22 @@ import {
   BLOCKS,
   LiquidHtmlNode,
   LiquidTag,
+  LiquidTagLiquid,
   NamedTags,
   NodeTypes,
   RAW_TAGS,
 } from '@shopify/liquid-html-parser';
-import { ThemeDocset } from '@shopify/theme-check-common';
-import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
+import { TagEntry, ThemeDocset } from '@shopify/theme-check-common';
+import {
+  CompletionItem,
+  CompletionItemKind,
+  InsertTextFormat,
+  InsertTextMode,
+  Position,
+  Range,
+  TextEdit,
+} from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { findLast } from '../../utils';
 import { CURSOR, LiquidCompletionParams } from '../params';
 import { Provider, createCompletionItem, sortByName } from './common';
@@ -33,7 +43,7 @@ export class LiquidTagsCompletionProvider implements Provider {
     return tags
       .filter(({ name }) => name.startsWith(partial))
       .sort(sortByName)
-      .map((tag) => createCompletionItem(tag, { kind: CompletionItemKind.Keyword }, 'tag'))
+      .map(toCompletionItem(params, node, ancestors, partial))
       .concat(
         blockParent && `end${blockParent.name}`.startsWith(partial)
           ? {
@@ -149,4 +159,299 @@ function findParentNode(partial: string, ancestors: LiquidHtmlNode[]): LiquidTag
   ) {
     return previousNode as LiquidTag;
   }
+}
+
+function toCompletionItem(
+  params: LiquidCompletionParams,
+  node: LiquidTag,
+  ancestors: LiquidHtmlNode[],
+  partial: string,
+): (value: TagEntry) => CompletionItem {
+  const { textDocument, source } = params.document;
+  /** Are we in a {% liquid %} context? Where new lines imply new tags? */
+  const isInLiquidLiquidTag = ancestors.some(isLiquidLiquidTag);
+  /** 0-indexed offset of cursor position */
+  const cursorOffset = textDocument.offsetAt(params.position);
+  /** Position of where the start of the word being completed is */
+  const startOfPartial = textDocument.positionAt(cursorOffset - partial.length);
+  /** Position of the rightmost position in the doc... in {% partial %} it would be after '%}' */
+  const endOfBlockStart = findEndOfBlockStart(params, node, isInLiquidLiquidTag);
+  /** whitespaceStart is '-' or '' depending on if it strips whitespace to the left of the tag */
+  const whitespaceStart = node.whitespaceStart;
+  /** whitespaceEnd is '-' or '' depending on if it strips whitespace to the right of the tag */
+  const whitespaceEnd = inferWhitespaceEnd(
+    textDocument,
+    endOfBlockStart,
+    params,
+    whitespaceStart,
+    source,
+    isInLiquidLiquidTag,
+  );
+
+  return (tag) => {
+    const extraProperties: Partial<CompletionItem> = {
+      kind: CompletionItemKind.Keyword,
+      insertTextFormat: InsertTextFormat.PlainText,
+    };
+
+    if (shouldSnippetComplete(params, endOfBlockStart)) {
+      extraProperties.insertTextFormat = InsertTextFormat.Snippet;
+      extraProperties.insertTextMode = InsertTextMode.adjustIndentation;
+      extraProperties.textEdit = TextEdit.replace(
+        Range.create(startOfPartial, endOfBlockStart),
+        toSnippetCompleteText(
+          tag,
+          node,
+          params,
+          whitespaceStart,
+          whitespaceEnd,
+          textDocument,
+          isInLiquidLiquidTag,
+        ),
+      );
+    }
+
+    return createCompletionItem(tag, extraProperties, 'tag');
+  };
+}
+
+/**
+ * Turns out it's hard to tell if something needs an `end$tag` or not.
+ *
+ * The safest way to guess that something shouldn't be completed is to check whether markup already exists.
+ *
+ * Probably shouldn't snippet complete:
+ * {% if| cond %}{% endif %}
+ * {% render| 'product' %}
+ *
+ * Probably should snippet complete:
+ * {% if| %}
+ * {% render| %}
+ *
+ * It's not perfect, but it covers swapping if for unless and so on.
+ */
+function shouldSnippetComplete(params: LiquidCompletionParams, endOfBlockStart: Position) {
+  const { completionContext } = params;
+  const { node, ancestors } = completionContext ?? {};
+  if (!node || !ancestors || node.type !== NodeTypes.LiquidTag) return false;
+  /**
+   * If the tag has non-empty markup, we can assume that the name is being
+   * edited. So adding the close tag would be very weird.
+   *
+   * User replaces `if` with `unless`.
+   *
+   * Input
+   *   {% if some_cond %}
+   *   {% endif %}
+   *
+   * ❌ Stuff we DON'T want:
+   *   {% unless some_cond %}
+   *     expression
+   *   {% endunless %}
+   *   {% endif %}
+   *
+   * ✅ Stuff we DO want:
+   *   {% unless some_cond %}
+   *   {% endif %}
+   *
+   * We'll solve the negate condition differently.
+   */
+  const markup = existingMarkup(params, endOfBlockStart);
+  return markup.trim() === '';
+}
+
+function toSnippetCompleteText(
+  tag: TagEntry,
+  node: LiquidTag,
+  params: LiquidCompletionParams,
+  whitespaceStart: string,
+  whitespaceEnd: string,
+  textDocument: TextDocument,
+  isInLiquidLiquidTag: boolean,
+) {
+  let snippet = toSnippet(tag);
+  if (shouldInline(textDocument, params, node, isInLiquidLiquidTag)) {
+    // Then we need to remove the newlines from the snippet
+    snippet = snippet.replace(/\n\s*/g, '');
+  }
+
+  if (isInLiquidLiquidTag) {
+    // then we need to get rid of all the {% and %} from the snippet
+    snippet = snippet.replace(/\{%-?[ \t]*/g, '').replace(/[ \t]*-?%\}/g, '');
+  }
+
+  if (tag.syntax_keywords) {
+    // Then we need to replace the keywords from the snippet with ${n:keyword}
+    let i = 1;
+    for (const { keyword } of tag.syntax_keywords) {
+      if (
+        keyword.includes('expression') ||
+        keyword.includes('code') ||
+        keyword.includes('content')
+      ) {
+        // first_expression, second_expression, javascript_code,
+        // forloop_content... we don't want those. Just the cursor position.
+        snippet = snippet.replace(keyword, `\$${i}`);
+      } else {
+        snippet = snippet.replace(keyword, `\${${i}:${keyword}}`);
+      }
+      i++;
+    }
+  }
+
+  // We need to add the whitespace stripping characters to the snippet if there are any to add
+  snippet = withCorrectWhitespaceStrippingCharacters(snippet, whitespaceStart, whitespaceEnd);
+
+  if (isInLiquidLiquidTag) {
+    return snippet.trimStart();
+  } else {
+    // VS Code doesn't like it when the snippet starts before the word
+    // being completed. So the completion item we offer starts off after
+    // the {%-?\s part.
+    return snippet.slice(2 + whitespaceStart.length + 1);
+  }
+}
+
+function toSnippet(tag: TagEntry) {
+  // Some of those are exceptional and we don't really want to use the same syntax used on shopify.dev
+  switch (tag.name) {
+    case 'echo':
+      return '{% echo $1 %}';
+    case 'cycle':
+      return "{% cycle '$1', '$2'$3 %}";
+    case 'content_for':
+      return "{% content_for '$1'$2 %}";
+    case 'render':
+      return "{% render '$1'$2 %}";
+    case 'elsif':
+      return '{% elsif ${1:condition} %}';
+    case 'else':
+      return '{% else %}';
+  }
+
+  if (tag.syntax) {
+    return tag.syntax;
+  } else if (isBlockTag(tag.name)) {
+    return `{% ${tag.name}$1 %}\n  $2\n{% end${tag.name} %}`;
+  } else {
+    return `{% ${tag.name}$1 %}`;
+  }
+}
+
+/**
+ * If the tag is on a new line, then we can use the snippet with newline.
+ * If there's more content on that line, then we inline the snippet in one line.
+ */
+function shouldInline(
+  textDocument: TextDocument,
+  params: LiquidCompletionParams,
+  node: LiquidTag,
+  isInLiquidLiquidTag: boolean,
+) {
+  if (isInLiquidLiquidTag) return false;
+  const endPosition = textDocument.positionAt(node.blockStartPosition.start);
+  const startPosition = Position.create(endPosition.line, 0);
+  const textBeforeTag = textDocument.getText(Range.create(startPosition, endPosition));
+  return textBeforeTag.trim() !== '';
+}
+
+/**
+ * We mirror the whitespace stripping of the start tag.
+ * {% if -%} => {% if -%}{%- endif %}
+ */
+function withCorrectWhitespaceStrippingCharacters(
+  snippet: string,
+  whitespaceStart: string,
+  whitespaceEnd: string,
+) {
+  let starti = 0;
+  let endi = 0;
+  let countOfEndTags = snippet.match(/%\}/g)?.length ?? 0;
+  snippet = snippet
+    .replace(/\{%/g, () => {
+      if (starti++ === 0) {
+        // mirror outside stripping
+        return '{%' + whitespaceStart;
+      } else {
+        // mirror inside stripping
+        return '{%' + whitespaceEnd;
+      }
+    })
+    .replace(/%\}/g, () => {
+      if (countOfEndTags > 1 && endi++ === countOfEndTags - 1) {
+        // mirror outside stripping
+        return whitespaceStart + '%}';
+      } else {
+        // mirror inside stripping
+        return whitespaceEnd + '%}';
+      }
+    });
+  return snippet;
+}
+
+function findEndOfBlockStart(
+  context: LiquidCompletionParams,
+  node: LiquidTag,
+  isInLiquidLiquidTag: boolean,
+): Position {
+  const doc = context.document.textDocument;
+  const source = context.document.source;
+  const start = node.position.start;
+  if (isInLiquidLiquidTag) {
+    return doc.positionAt(source.indexOf('\n', start));
+  }
+  const end = source.indexOf('%}', start);
+  const endOpen = source.indexOf('{%', start + 2);
+  const isThere = end !== -1 && (endOpen === -1 || end < endOpen);
+  if (isThere) {
+    // %} => + 2
+    return doc.positionAt(end + 2);
+  } else {
+    // return cursor position.
+    return context.position;
+  }
+}
+
+function existingMarkup(params: LiquidCompletionParams, endOfBlockStart: Position): string {
+  const { document } = params;
+  const { source, textDocument } = document;
+  return source
+    .slice(textDocument.offsetAt(params.position), textDocument.offsetAt(endOfBlockStart))
+    .replace(/-?%\}/, '');
+}
+
+// We're trying to infer if we should trim the whitespace to the right given what the user has already written
+// {%  if|        => ''
+// {%- if|        => '-'
+// {%- if|  %}    => ''
+// {%- if| -%}    => '-'
+// {%  if| -%}    => '-'
+// {% liquid
+//       if|      => ''
+// %}
+function inferWhitespaceEnd(
+  textDocument: TextDocument,
+  endOfBlockStart: Position,
+  params: LiquidCompletionParams,
+  whitespaceStart: string,
+  source: string,
+  isInLiquidLiquidTag: boolean,
+) {
+  if (isInLiquidLiquidTag) {
+    return '';
+  } else if (textDocument.offsetAt(endOfBlockStart) === textDocument.offsetAt(params.position)) {
+    return whitespaceStart; // if the %} wasn't auto inserted, copy whatever was there on the other side
+  } else if (source.charAt(textDocument.offsetAt(endOfBlockStart) - 3) === '-') {
+    return '-';
+  } else {
+    return '';
+  }
+}
+
+function isLiquidLiquidTag(parent: LiquidHtmlNode): parent is LiquidTagLiquid {
+  return parent.type === NodeTypes.LiquidTag && parent.name === NamedTags.liquid;
+}
+
+function isBlockTag(name: string) {
+  return BLOCKS.includes(name);
 }

--- a/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
+++ b/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
@@ -32,6 +32,7 @@ describe('Module: CompletionItemsAssertion', () => {
           kind: 'markdown',
           value: '### render',
         },
+        insertTextFormat: 1,
         kind: 14,
       },
     ]);

--- a/packages/vscode-extension/scripts/constants.ts
+++ b/packages/vscode-extension/scripts/constants.ts
@@ -1,3 +1,5 @@
+import { BLOCKS } from "@shopify/liquid-html-parser";
+
 // These HTML elements do not require to be closed (either via </tag> or <tag />)
 export const voidElements = [
   'area',
@@ -18,4 +20,9 @@ export const voidElements = [
   'wbr',
 ];
 
-export const openingLiquidTags = ['if', 'form', 'comment', 'case', 'when', 'for', 'unless'];
+const BRANCH_TAGS = ['else', 'elsif', 'when'];
+
+export const blockStartTags = BLOCKS;
+export const blockEndTags = BLOCKS.map((name) => `end${name}`);
+export const increaseIndentTags = BLOCKS.concat(BRANCH_TAGS);
+export const decreaseIndentTags = blockEndTags.concat(BRANCH_TAGS);

--- a/packages/vscode-extension/scripts/indentation-rules.spec.ts
+++ b/packages/vscode-extension/scripts/indentation-rules.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { voidElements, openingLiquidTags } from './constants';
+import { voidElements, blockStartTags } from './constants';
 import { increaseIndentPattern, decreaseIndentPattern } from './indentation-rules';
 
 describe('Module: indentationRules', () => {
@@ -32,7 +32,7 @@ describe('Module: indentationRules', () => {
   });
 
   it('should match opening liquid tags', () => {
-    openingLiquidTags.forEach((tag: any) => {
+    blockStartTags.forEach((tag: any) => {
       expect(`{% ${tag} %}`).to.match(increase);
       expect(`{% end${tag} %}`).to.match(decrease);
       expect(`{% ${tag} in collection %}`).to.match(increase);

--- a/packages/vscode-extension/scripts/indentation-rules.ts
+++ b/packages/vscode-extension/scripts/indentation-rules.ts
@@ -1,6 +1,5 @@
-import { voidElements, openingLiquidTags } from './constants';
-
-const closingLiquidTags = openingLiquidTags.map((name) => `end${name}`);
+import { BLOCKS } from '@shopify/liquid-html-parser';
+import { decreaseIndentTags, increaseIndentTags, voidElements } from './constants';
 
 export interface IndentationRulesJSON {
   increaseIndentPattern: string;
@@ -16,7 +15,7 @@ export function increaseIndentPattern() {
     String.raw`<(?!\/|${voidElements.join('|')}|!--)[^>\n]+>`,
 
     // Opening liquid tags that have a corresponding end$name tag.
-    String.raw`{%-?\s+(?:${openingLiquidTags.join('|')})[^}%]*?-?%}`, // opening liquid tags
+    String.raw`{%-?\s+(?:${increaseIndentTags.join('|')})[^}%]*?-?%}`, // opening liquid tags
 
     // Multiline HTML comment open
     String.raw`<!--[^>\n]*`,
@@ -50,7 +49,7 @@ export function decreaseIndentPattern() {
     String.raw`<\/[^>]+>`,
 
     // Closing liquid tags
-    String.raw`{%-?\s+(?:${closingLiquidTags.join('|')}).*?-?%}`, // opening liquid tags
+    String.raw`{%-?\s+(?:${decreaseIndentTags.join('|')}).*?-?%}`, // opening liquid tags
 
     // Multiline tag closed
     String.raw`%}`,

--- a/packages/vscode-extension/scripts/on-enter-actions.ts
+++ b/packages/vscode-extension/scripts/on-enter-actions.ts
@@ -1,5 +1,5 @@
 import { EnterAction, OnEnterRule } from 'vscode';
-import { voidElements } from './constants';
+import { voidElements, increaseIndentTags, blockEndTags } from './constants';
 
 export interface OnEnterRuleJSON extends Omit<OnEnterRule, 'action' | 'beforeText' | 'afterText'> {
   beforeText?: string;
@@ -11,20 +11,41 @@ export interface EnterActionJSON extends Omit<EnterAction, 'indentAction'> {
   indent: 'indent' | 'indentOutdent' | 'outdent' | 'none';
 }
 
+const OPEN_TAG = '\\{%';
+const CLOSE_TAG = '%\\}';
+
 export async function onEnterRules(): Promise<OnEnterRuleJSON[]> {
   // Adapted from the Monaco Editor source code
   // https://github.com/microsoft/monaco-editor/blob/f6dc0eb8fce67e57f6036f4769d92c1666cdf546/src/basic-languages/html/html.ts#L88
   return [
     {
+      // Matches an opening tag that is not a void element, capturing the tag name and attributes
       beforeText: `<(?!(?:${voidElements.join('|')}))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!/)>)[^<]*$`,
+      // Matches a closing tag that corresponds to the previously captured opening tag
       afterText: `^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>$`,
       action: {
         indent: 'indentOutdent',
       },
     },
     {
+      // Matches an opening tag that is not a void element, capturing the tag name and attributes
       beforeText: `<(?!(?:${voidElements.join('|')}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
       action: { indent: 'indent' },
+    },
+    {
+      // prettier-ignore
+      beforeText: `${OPEN_TAG}-?\\s*(?!end)(?:${increaseIndentTags.join('|')})((?!${CLOSE_TAG}).)*${CLOSE_TAG}\\s*$`,
+      afterText: `^${OPEN_TAG}-?\\s*(?:${blockEndTags.join('|')})((?!${CLOSE_TAG}).)*${CLOSE_TAG}`,
+      action: {
+        indent: 'indentOutdent',
+      },
+    },
+    {
+      // prettier-ignore
+      beforeText: `${OPEN_TAG}-?\\s*(?!end)(?:${increaseIndentTags.join('|')})((?!${CLOSE_TAG}).)*${CLOSE_TAG}\\s*$`,
+      action: {
+        indent: 'indent',
+      },
     },
   ];
 }


### PR DESCRIPTION
## What are you adding in this PR?

- This PR adds snippet completion for Liquid tags. 
    - Accept the completion item for `if` and get `{% if condition %}\n  \n{% endif %}` with tabulated placeholders
    - Accept the completion item for `render` and get `{% render 'snippet' %}`
    - The snippets are smart depending on context:
       - Will infer whitespace stripping characters based on context
       - Will not snippet complete `{%` and `%}` if inside a `{% liquid %}` tag
       - Will not snippet complete if markup is already present in the tag definition

https://github.com/user-attachments/assets/70d6903b-5e9f-4a53-856d-bd1c806b56af

- I have verified that this works well in CodeMirror without changes :) 


https://github.com/user-attachments/assets/f1f9f14a-00af-4497-a5da-a616304b3f24



Fixes #500

## What did you learn?

Shit is hard. Lots of edge cases to cover. 

## Before you deploy
- [x] I have added a minor changeset