### PR TITLE
Add an entry's syntax declaration to hover info

### DIFF
--- a/.changeset/sweet-balloons-brake.md
+++ b/.changeset/sweet-balloons-brake.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Add syntax to hover definitions
+
+Now when hovering over a liquid tag or filter we'll show syntax information if
+we have it available.

--- a/packages/theme-language-server-common/src/docset/MarkdownRenderer.spec.ts
+++ b/packages/theme-language-server-common/src/docset/MarkdownRenderer.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+
+import { render, renderHtmlEntry, type HtmlEntry } from './MarkdownRenderer';
+import type { DocsetEntry } from '@shopify/theme-check-common';
+
+const DOC_ENTRY: DocsetEntry = {
+  name: 'entry',
+  summary: 'summary',
+  description: 'description',
+  deprecated: false,
+};
+
+const HTML_ENTRY: HtmlEntry = {
+  name: 'entry',
+  description: 'description',
+};
+
+describe('MarkdownRenderer', () => {
+  describe('render()', () => {
+    it('converts a docset entry to markdown', async () => {
+      expect(render(DOC_ENTRY)).toEqual(`### entry\nsummary\n\n---\n\ndescription`);
+    });
+
+    describe('when the entry has syntax', () => {
+      it('includes the syntax in the markdown', async () => {
+        expect(render({ ...DOC_ENTRY, syntax: 'string | image_tag' })).toEqual(
+          `### entry\n\`\`\`liquid\n{{ string | image_tag }}\n\`\`\`\n\n---\n\nsummary\n\n---\n\ndescription`,
+        );
+      });
+
+      describe('and the syntax already includes liquid tags', () => {
+        it('does not wrap the syntax in curly braces', async () => {
+          expect(render({ ...DOC_ENTRY, syntax: '{% form %}' })).toEqual(
+            `### entry\n\`\`\`liquid\n{% form %}\n\`\`\`\n\n---\n\nsummary\n\n---\n\ndescription`,
+          );
+        });
+      });
+    });
+  });
+
+  describe('renderHtmlEntry()', () => {
+    it('converts a docset entry to markdown', async () => {
+      expect(renderHtmlEntry(HTML_ENTRY)).toEqual(`### entry\ndescription`);
+    });
+  });
+});

--- a/packages/theme-language-server-common/src/docset/MarkdownRenderer.ts
+++ b/packages/theme-language-server-common/src/docset/MarkdownRenderer.ts
@@ -1,14 +1,14 @@
-import { DocsetEntry, FilterEntry, ObjectEntry } from '@shopify/theme-check-common';
+import { DocsetEntry, FilterEntry, ObjectEntry, TagEntry } from '@shopify/theme-check-common';
 import { ArrayType, PseudoType, docsetEntryReturnType, isArrayType } from '../TypeSystem';
 import { Attribute, Tag, Value } from './HtmlDocset';
 
 const HORIZONTAL_SEPARATOR = '\n\n---\n\n';
 
-type HtmlEntry = Tag | Attribute | Value;
+export type HtmlEntry = Tag | Attribute | Value;
 export type DocsetEntryType = 'filter' | 'tag' | 'object';
 
 export function render(
-  entry: DocsetEntry,
+  entry: DocsetEntry | FilterEntry | TagEntry,
   returnType?: PseudoType | ArrayType,
   docsetEntryType?: DocsetEntryType,
 ) {
@@ -51,6 +51,7 @@ function docsetEntryBody(
   docsetEntryType?: DocsetEntryType,
 ) {
   return [
+    syntax(entry),
     entry.deprecation_reason,
     entry.summary,
     entry.description,
@@ -65,6 +66,22 @@ function htmlEntryBody(entry: HtmlEntry, parentEntry?: HtmlEntry) {
   return [description(entry), references(entry), references(parentEntry)]
     .filter(Boolean)
     .join(HORIZONTAL_SEPARATOR);
+}
+
+function syntax(entry: DocsetEntry | FilterEntry | TagEntry) {
+  if (!('syntax' in entry) || !entry.syntax) {
+    return undefined;
+  }
+
+  // TagEntry entries already have liquid tags as a part of the syntax
+  // explanation so we can return them directly.
+  if (entry.syntax.startsWith('{%')) {
+    return `\`\`\`liquid\n${entry.syntax}\n\`\`\``;
+  }
+
+  // Wrap the syntax in liquid tags to ensure we get proper syntax highlighting
+  // if it's available.
+  return `\`\`\`liquid\n{{ ${entry.syntax} }}\n\`\`\``;
 }
 
 function description(entry: HtmlEntry) {


### PR DESCRIPTION
## What are you adding in this PR?

- Closes https://github.com/Shopify/theme-tools/issues/165

We currently have this information but aren't displaying it in any way. If available, this commit adds the syntax under the name of the tag/filter when hovering so that developers can more easily see how it can be used.

I've attached some screenshots showing the before/after (ignore the slight differences in styling as I'm taking the `before` from Online Store's code editor and the `after` from my local VSCode):

#### Tags

| Before | After |
|--------|--------|
| <img width="517" alt="image" src="https://github.com/user-attachments/assets/a803a8e9-d746-4acb-8fbc-3da4625d438c"> | <img width="757" alt="image" src="https://github.com/user-attachments/assets/c18ef5e0-5e2f-4b47-a41f-670f1b8c34c0"> | 

#### Filters

| Before | After |
|--------|--------|
| <img width="593" alt="image" src="https://github.com/user-attachments/assets/bbdca5ad-17db-415c-99ca-898085b2af92"> | <img width="748" alt="image" src="https://github.com/user-attachments/assets/47ce0174-b0f1-4265-bcc4-ca97053fe354"> | 

## Before you deploy

- [x] My feature is backward compatible
- [x] I included a patch bump `changeset`
