### PR TITLE
Add missing lang-jsonc test files

### DIFF
--- a/packages/lang-jsonc/package.json
+++ b/packages/lang-jsonc/package.json
@@ -32,9 +32,9 @@
     "@lezer/lr": "^1.3.7"
   },
   "scripts": {
-    "build": "yarn build:esm && yarn build:umd",
+    "build": "yarn build:ts",
     "build:ci": "yarn build",
-    "build:ts": "true",
+    "build:ts": "yarn build:esm && yarn build:umd",
     "build:esm": "tsc -b tsconfig.json",
     "build:umd": "tsc -b tsconfig.umd.json",
     "prebuild:esm": "yarn generate",

--- a/packages/lang-jsonc/src/test/arrays.txt
+++ b/packages/lang-jsonc/src/test/arrays.txt
@@ -1,0 +1,34 @@
+# Empty Array
+
+[ ]
+
+==>
+
+JsoncText(Array)
+
+# Array With One Value
+
+["One is the loneliest number"]
+
+==>
+
+JsoncText(Array(String))
+
+# Array With Multiple Values
+
+[
+  "The more the merrier",
+  1e5,
+  true,
+  { },
+  ["I'm", "nested"]
+]
+
+==>
+
+JsoncText(Array(
+  String,
+  Number,
+  True,
+  Object,
+  Array(String,String)))

--- a/packages/lang-jsonc/src/test/comments.txt
+++ b/packages/lang-jsonc/src/test/comments.txt
@@ -1,0 +1,33 @@
+# Line Comment
+
+{
+    // FIXME
+}
+
+==>
+
+JsoncText(Object("{",LineComment,"}"))
+
+# Block Comment
+
+{
+    /* I am a big old
+
+
+    "comment
+    */
+}
+
+==>
+
+JsoncText(Object("{",BlockComment,"}"))
+
+# Line comment as "string"
+
+{
+    // This is a "comment"
+}
+
+==>
+
+JsoncText(Object("{",LineComment,"}"))

--- a/packages/lang-jsonc/src/test/literals.txt
+++ b/packages/lang-jsonc/src/test/literals.txt
@@ -1,0 +1,23 @@
+# True
+
+true
+
+==>
+
+JsoncText(True)
+
+# False
+
+false
+
+==>
+
+JsoncText(False)
+
+# Null
+
+null
+
+==>
+
+JsoncText(Null)

--- a/packages/lang-jsonc/src/test/numbers.txt
+++ b/packages/lang-jsonc/src/test/numbers.txt
@@ -1,0 +1,87 @@
+# Simple Integer
+
+42
+
+==>
+
+JsoncText(Number)
+
+# Zero By Itself Is Ok
+
+0
+
+==>
+
+JsoncText(Number)
+
+# Leading Zeros Aren't Ok
+
+[0123]
+
+==>
+
+JsoncText(Array(Number, ⚠(Number)))
+
+# Optional Minus Sign
+
+-53
+
+==>
+
+JsoncText(Number)
+
+# Decimal Digits
+
+123.4
+
+==>
+
+JsoncText(Number)
+
+# Must Have Digits After Decimal
+
+123.
+
+==>
+
+JsoncText(Number, ⚠)
+
+# Exponent: Lowercase e
+
+1e5
+
+==>
+
+JsoncText(Number)
+
+# Exponent: Uppercase E
+
+1E5
+
+==>
+
+JsoncText(Number)
+
+# Exponent: Optional Plus Sign
+
+1e+5
+
+==>
+
+JsoncText(Number)
+
+# Exponent: Optional Minus Sign
+
+1E-5
+
+==>
+
+JsoncText(Number)
+
+# Exponent Without Digit Is Not Ok
+
+42e
+
+==>
+
+JsoncText(Number, ⚠)

--- a/packages/lang-jsonc/src/test/objects.txt
+++ b/packages/lang-jsonc/src/test/objects.txt
@@ -1,0 +1,49 @@
+# Empty Object
+
+{ }
+
+==>
+
+JsoncText(Object)
+
+# One Property
+
+{
+  "foo": 123
+}
+
+==>
+
+JsoncText(Object(Property(PropertyName,Number)))
+
+# Multiple Properties
+
+{
+  "foo": 123,
+  "bar": "I'm a bar!",
+  "obj": {},
+  "arr": [1, 2, 3]
+}
+
+==>
+
+JsoncText(Object(
+  Property(PropertyName,Number),
+  Property(PropertyName,String),
+  Property(PropertyName,Object),
+  Property(PropertyName,Array(Number,Number,Number))))
+
+# Trailing Commas
+
+{
+  "obj": {"key": 1,},
+  "arr": [1, 2, 3,],
+}
+
+==>
+
+JsoncText(Object(
+  Property(PropertyName,Object(
+    Property(PropertyName, Number)
+  )),
+  Property(PropertyName,Array(Number,Number,Number))))

--- a/packages/lang-jsonc/src/test/strings.txt
+++ b/packages/lang-jsonc/src/test/strings.txt
@@ -1,0 +1,31 @@
+# Empty String
+
+""
+
+==>
+
+JsoncText(String)
+
+# Non-empty String
+
+"This is a boring old string"
+
+==>
+
+JsoncText(String)
+
+# All The Valid One-Character Escapes
+
+"\"\\\/\b\f\n\rt\t"
+
+==>
+
+JsoncText(String)
+
+# Unicode Escape
+
+"\u005C"
+
+==>
+
+JsoncText(String)

--- a/packages/lang-jsonc/src/test/test-jsonc.spec.js
+++ b/packages/lang-jsonc/src/test/test-jsonc.spec.js
@@ -1,0 +1,18 @@
+import { describe, it } from 'vitest';
+import { parser } from '../parser';
+import { fileTests } from '@lezer/generator/dist/test';
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+let caseDir = path.dirname(fileURLToPath(import.meta.url));
+
+for (let file of fs.readdirSync(caseDir)) {
+  if (!/\.txt$/.test(file)) continue;
+
+  let name = /^[^\.]*/.exec(file)[0];
+  describe(name, () => {
+    for (let { name, run } of fileTests(fs.readFileSync(path.join(caseDir, file), 'utf8'), file))
+      it(name, () => run(parser));
+  });
+}


### PR DESCRIPTION

## What are you adding in this PR?

Turns out that the test files for lang-jsonc were excluded by a `.git/exclude/info` entry of mine. I must have put that there during the burst.

Anyway, the tests all pass and they are now here :D oops!
