### PR TITLE
Support HTML attribute auto-completion

### DIFF
--- a/.changeset/quiet-rice-brake.md
+++ b/.changeset/quiet-rice-brake.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Support HTML attribute auto-completion
+
+- Add `=""` to attributes that have values
+- Override whole attribute even if cursor is in the middle of it

--- a/.changeset/quiet-rice-brake.md
+++ b/.changeset/quiet-rice-brake.md
@@ -2,7 +2,7 @@
 '@shopify/theme-language-server-common': minor
 ---
 
-Support HTML attribute auto-completion
+Improve HTML attribute auto-completion
 
-- Add `=""` to attributes that have values
-- Override whole attribute even if cursor is in the middle of it
+- Add `=""` to attributes that should have a value when relevant
+- Override entire attribute even if the cursor was in the middle of it

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -49,7 +49,7 @@ export class CompletionsProvider {
 
     this.providers = [
       new HtmlTagCompletionProvider(),
-      new HtmlAttributeCompletionProvider(),
+      new HtmlAttributeCompletionProvider(documentManager),
       new HtmlAttributeValueCompletionProvider(),
       new LiquidTagsCompletionProvider(themeDocset),
       new ObjectCompletionProvider(typeSystem),

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
@@ -38,14 +38,21 @@ describe('Module: HtmlAttributeCompletionProvider', async () => {
   });
 
   it('should replace the existing attribute partial with the full attribute tag', async () => {
-    await expect(provider).to.complete('<text titl█', [
+    const attributePartial = 'titl';
+    const source = `<text ${attributePartial}█>`;
+    const sourceWithoutCursor = source.replace('█', '');
+
+    await expect(provider).to.complete(source, [
       expect.objectContaining({
         label: 'title',
         textEdit: {
           newText: 'title="$1"$0',
           range: {
-            start: { line: 0, character: 6 },
-            end: { line: 0, character: 10 },
+            start: { line: 0, character: sourceWithoutCursor.indexOf(attributePartial) },
+            end: {
+              line: 0,
+              character: sourceWithoutCursor.indexOf(attributePartial) + attributePartial.length,
+            },
           },
         },
       }),
@@ -53,14 +60,21 @@ describe('Module: HtmlAttributeCompletionProvider', async () => {
   });
 
   it('should replace the existing attribute partial with the full attribute tag when cursor is in the middle of attribute partial', async () => {
-    await expect(provider).to.complete('<text ti█tl', [
+    const attributePartial = 'titl';
+    const source = '<text ti█tl>';
+    const sourceWithoutCursor = source.replace('█', '');
+
+    await expect(provider).to.complete(source, [
       expect.objectContaining({
         label: 'title',
         textEdit: {
           newText: 'title="$1"$0',
           range: {
-            start: { line: 0, character: 6 },
-            end: { line: 0, character: 10 },
+            start: { line: 0, character: sourceWithoutCursor.indexOf(attributePartial) },
+            end: {
+              line: 0,
+              character: sourceWithoutCursor.indexOf(attributePartial) + attributePartial.length,
+            },
           },
         },
       }),
@@ -68,23 +82,30 @@ describe('Module: HtmlAttributeCompletionProvider', async () => {
   });
 
   it('should replace the existing attribute partial with the full attribute tag without value', async () => {
-    await expect(provider).to.complete('<button disab█', [
+    const attributePartial = 'disab';
+    const source = `<button ${attributePartial}█>`;
+    const sourceWithoutCursor = source.replace('█', '');
+
+    await expect(provider).to.complete(source, [
       expect.objectContaining({
         label: 'disabled',
         textEdit: {
           newText: 'disabled',
           range: {
-            start: { line: 0, character: 8 },
-            end: { line: 0, character: 13 },
+            start: { line: 0, character: sourceWithoutCursor.indexOf(attributePartial) },
+            end: {
+              line: 0,
+              character: sourceWithoutCursor.indexOf(attributePartial) + attributePartial.length,
+            },
           },
         },
       }),
     ]);
   });
 
-  it('should not replace any character if autocomplate is triggered with no attribute partial', async () => {
+  it('should not replace any character if auto-complete is triggered with no attribute partial', async () => {
     await expect(provider).to.complete(
-      '<a █',
+      '<a █>',
       [...aTagAttributeNames, ...globalAttributeNames].sort().map((attr) => {
         return expect.objectContaining({
           textEdit: {
@@ -100,15 +121,22 @@ describe('Module: HtmlAttributeCompletionProvider', async () => {
   });
 
   it('should not replace attribute tags containing liquid code', async () => {
+    const attributePartial = 'data--';
+    const source = '<a d█ata--{{ echo "coolstuff" }}>';
+    const sourceWithoutCursor = source.replace('█', '');
+
     await expect(provider).to.complete(
-      '<a d█ata--{{ echo "coolstuff" }}',
+      source,
       ['dir', 'download', 'draggable', 'dropzone'].map((attr) => {
         return expect.objectContaining({
           textEdit: {
             newText: expect.stringContaining(attr),
             range: {
-              start: { line: 0, character: 3 },
-              end: { line: 0, character: 9 },
+              start: { line: 0, character: sourceWithoutCursor.indexOf(attributePartial) },
+              end: {
+                line: 0,
+                character: sourceWithoutCursor.indexOf(attributePartial) + attributePartial.length,
+              },
             },
           },
         });

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
@@ -36,4 +36,83 @@ describe('Module: HtmlAttributeCompletionProvider', async () => {
     const expected = [...aTagAttributeNames, ...globalAttributeNames].sort();
     await expect(provider).to.complete('<a {% if cond %}█', expected);
   });
+
+  it('should replace the existing attribute partial with the full attribute tag', async () => {
+    await expect(provider).to.complete('<text titl█', [
+      expect.objectContaining({
+        label: 'title',
+        textEdit: {
+          newText: 'title="$1"$0',
+          range: {
+            start: { line: 0, character: 6 },
+            end: { line: 0, character: 10 },
+          },
+        },
+      }),
+    ]);
+  });
+
+  it('should replace the existing attribute partial with the full attribute tag when cursor is in the middle of attribute partial', async () => {
+    await expect(provider).to.complete('<text ti█tl', [
+      expect.objectContaining({
+        label: 'title',
+        textEdit: {
+          newText: 'title="$1"$0',
+          range: {
+            start: { line: 0, character: 6 },
+            end: { line: 0, character: 10 },
+          },
+        },
+      }),
+    ]);
+  });
+
+  it('should replace the existing attribute partial with the full attribute tag without value', async () => {
+    await expect(provider).to.complete('<button disab█', [
+      expect.objectContaining({
+        label: 'disabled',
+        textEdit: {
+          newText: 'disabled',
+          range: {
+            start: { line: 0, character: 8 },
+            end: { line: 0, character: 13 },
+          },
+        },
+      }),
+    ]);
+  });
+
+  it('should not replace any character if autocomplate is triggered with no attribute partial', async () => {
+    await expect(provider).to.complete(
+      '<a █',
+      [...aTagAttributeNames, ...globalAttributeNames].sort().map((attr) => {
+        return expect.objectContaining({
+          textEdit: {
+            newText: expect.stringContaining(attr),
+            range: {
+              start: { line: 0, character: 3 },
+              end: { line: 0, character: 3 },
+            },
+          },
+        });
+      }),
+    );
+  });
+
+  it('should not replace attribute tags containing liquid code', async () => {
+    await expect(provider).to.complete(
+      '<a d█ata--{{ echo "coolstuff" }}',
+      ['dir', 'download', 'draggable', 'dropzone'].map((attr) => {
+        return expect.objectContaining({
+          textEdit: {
+            newText: expect.stringContaining(attr),
+            range: {
+              start: { line: 0, character: 3 },
+              end: { line: 0, character: 9 },
+            },
+          },
+        });
+      }),
+    );
+  });
 });

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.ts
@@ -76,9 +76,9 @@ export class HtmlAttributeCompletionProvider implements Provider {
       };
     }
 
-    let attributeEndOffset =
-      document.source.slice(node.position.end).match(/[\s=]|{%|{{|>/)?.index ??
-      document.source.length;
+    const sourcePartialPastCursor = document.source.slice(node.position.end);
+    const attributeEndOffset =
+      sourcePartialPastCursor.match(/[\s=]|\{%|\{\{|>/)?.index ?? sourcePartialPastCursor.length;
 
     return {
       start: document.textDocument.positionAt(node.position.start),

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.ts
@@ -1,5 +1,12 @@
-import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
+import {
+  CompletionItem,
+  CompletionItemKind,
+  InsertTextFormat,
+  Range,
+  TextEdit,
+} from 'vscode-languageserver';
 import { Attribute, HtmlData, renderHtmlEntry } from '../../docset';
+import { AugmentedSourceCode, DocumentManager } from '../../documents';
 import {
   findLast,
   getCompoundName,
@@ -9,9 +16,10 @@ import {
 } from '../../utils';
 import { CURSOR, LiquidCompletionParams } from '../params';
 import { Provider, sortByName } from './common';
+import { LiquidHtmlNode } from '@shopify/liquid-html-parser';
 
 export class HtmlAttributeCompletionProvider implements Provider {
-  constructor() {}
+  constructor(private readonly documentManager: DocumentManager) {}
 
   async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
     if (!params.completionContext) return [];
@@ -19,8 +27,9 @@ export class HtmlAttributeCompletionProvider implements Provider {
     const { node, ancestors } = params.completionContext;
     const parentNode = findLast(ancestors, isAttrEmpty);
     const grandParentNode = findLast(ancestors, isNamedHtmlElementNode);
+    const document = this.documentManager.get(params.textDocument.uri);
 
-    if (!node || !parentNode || !grandParentNode) {
+    if (!node || !parentNode || !grandParentNode || !document) {
       return [];
     }
 
@@ -32,7 +41,49 @@ export class HtmlAttributeCompletionProvider implements Provider {
     const name = node.value;
     const partial = name.replace(CURSOR, '');
     const options = getOptions(partial, grandParentNodeName);
-    return options.sort(sortByName).map(toCompletionItem);
+
+    const attributeTagRange = this.attributeTagRange(node, document);
+    const hasExistingAttributeValue = this.hasExistingAttributeValue(attributeTagRange, document);
+    const hasLiquidTag = this.hasLiquidTag(attributeTagRange, document);
+
+    return options.sort(sortByName).map((tag) => {
+      return toCompletionItem(tag, attributeTagRange, hasExistingAttributeValue, hasLiquidTag);
+    });
+  }
+
+  hasExistingAttributeValue(attributeTagRange: Range, document: AugmentedSourceCode): boolean {
+    return /^\s*=/.test(
+      document.source.slice(document.textDocument.offsetAt(attributeTagRange.end)),
+    );
+  }
+
+  hasLiquidTag(attributeTagRange: Range, document: AugmentedSourceCode): boolean {
+    return /^(?:\{%|\{\{)/.test(
+      document.source.slice(document.textDocument.offsetAt(attributeTagRange.end)),
+    );
+  }
+
+  // Find the range of the attribute partial. If the attribute contains any liquid code, the range
+  // will end before the first character of the liquid block.
+  attributeTagRange(node: LiquidHtmlNode, document: AugmentedSourceCode): Range {
+    if (node.type === 'TextNode' && node.value === CURSOR) {
+      // If you try to auto-complete with no provided attribute tag,
+      // we will not try to override the subsequent character.
+      // E.g. <a href="" █>
+      return {
+        start: document.textDocument.positionAt(node.position.start),
+        end: document.textDocument.positionAt(node.position.start),
+      };
+    }
+
+    let attributeEndOffset =
+      document.source.slice(node.position.end).match(/[\s=]|{%|{{|>/)?.index ??
+      document.source.length;
+
+    return {
+      start: document.textDocument.positionAt(node.position.start),
+      end: document.textDocument.positionAt(node.position.end + attributeEndOffset),
+    };
   }
 }
 
@@ -44,10 +95,20 @@ function getOptions(partial: string, parentNodeName: string): Attribute[] {
   );
 }
 
-function toCompletionItem(tag: Attribute): CompletionItem {
+function toCompletionItem(
+  tag: Attribute,
+  attributeTagRange: Range,
+  hasExistingAttributeValue: boolean,
+  hasLiquidTag: boolean,
+): CompletionItem {
+  const attributeWithValue = !tag.valueSet || tag.valueSet !== 'v';
+  const insertSnippet = attributeWithValue && !hasExistingAttributeValue && !hasLiquidTag;
+
   return {
     label: tag.name,
     kind: CompletionItemKind.Value,
+    insertTextFormat: insertSnippet ? InsertTextFormat.Snippet : InsertTextFormat.PlainText,
+    textEdit: TextEdit.replace(attributeTagRange, insertSnippet ? `${tag.name}="$1"$0` : tag.name),
     documentation: {
       kind: 'markdown',
       value: renderHtmlEntry(tag),

--- a/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
+++ b/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
@@ -19,12 +19,12 @@ describe('Module: CompletionItemsAssertion', () => {
     });
   });
 
-  it('should assert a list of labels', () => {
-    expect(provider).to.complete('{% rend', ['render']);
+  it('should assert a list of labels', async () => {
+    await expect(provider).to.complete('{% rend', ['render']);
   });
 
-  it('should assert a list of completion items', () => {
-    expect(provider).to.complete('{% rend', [
+  it('should assert a list of completion items', async () => {
+    await expect(provider).to.complete('{% rend', [
       {
         label: 'render',
         sortText: 'render',
@@ -37,7 +37,7 @@ describe('Module: CompletionItemsAssertion', () => {
     ]);
   });
 
-  it('should assert an empty list', () => {
-    expect(provider).to.complete('{% something', []);
+  it('should assert an empty list', async () => {
+    await expect(provider).to.complete('{% something', []);
   });
 });


### PR DESCRIPTION
## What are you adding in this PR?

- Support HTML attribute auto-completion
- Override entire attribute even if the cursor is  in the middle of the attribute
- Add `=""` at the end of an attribute with a value
- Allow attribute completion when cursor is not on any character
- NOTE: Does NOT replace Liquid Code when auto-completing HTML attribute
  - Why? This seems like one of those trade-offs where we _could_ try to parse the string and assume the whole attribute (including any liquid code) is part of the tag, but we'd be overriding code which i assume isn't what the developer wants. If they really wish to remove the liquid code, they must do so manually.


### What we support

| before code completion| after code completion (once you select it from dropdown) |
| - | - |
| `<a hr█` |  `<a href=""` |
| `<button disab█` |  `<button disabled` |
| `<a █` |  `<a href=""` |
| `<button s█tyle=""` |  `<button spellcheck=""` |
| `<button d█ata--{{ echo "demo" }}=""` |  `<button dir{{ echo "demo" }}=""` |


## What did you learn?

- Edges and tradeoffs on what to support and what to ignore 🤕

## Before you deploy

- [x] I included a minor bump `changeset`
