### PR TITLE
Fix broken tests

### DIFF
--- a/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
+++ b/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
@@ -25,16 +25,16 @@ describe('Module: CompletionItemsAssertion', () => {
 
   it('should assert a list of completion items', async () => {
     await expect(provider).to.complete('{% rend', [
-      {
+      expect.objectContaining({
         label: 'render',
         sortText: 'render',
         documentation: {
           kind: 'markdown',
           value: '### render',
         },
-        insertTextFormat: 1,
+        insertTextFormat: 2,
         kind: 14,
-      },
+      }),
     ]);
   });
 


### PR DESCRIPTION
## What are you adding in this PR?

The [last commit](https://github.com/Shopify/theme-tools/pull/520) found a typo where `CompletionItemsAssertion` tests weren't running, but after fixing it, CI didn't warn us that the tests were broken. Patching the broken test.

CI on merge: https://github.com/Shopify/theme-tools/actions/runs/11223315187/job/31197681873

