### PR TITLE
Auto-complete metafields depending on shop data

### DIFF
--- a/.changeset/wet-trees-listen.md
+++ b/.changeset/wet-trees-listen.md
@@ -1,0 +1,42 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+---
+
+Support metafield auto-completion based on .shopify/metafields.json file
+
+- The metafield definitions can be fetched from Admin API
+- The format of the JSON needs to be the following:
+
+```
+{
+    "<definition_group>": [
+        {
+            "name": "...",
+            "namespace": "...",
+            "description": "...",
+            "type": {
+                "category": "...",
+                "name": "..."
+            },
+        },
+        ...
+    ],
+    ...
+}
+```
+
+The definition group needs to be one of the following:
+- 'article'
+- 'blog'
+- 'brand'
+- 'collection'
+- 'company'
+- 'company_location'
+- 'location'
+- 'market'
+- 'order'
+- 'page'
+- 'product'
+- 'variant'
+- 'shop'

--- a/packages/theme-check-common/src/index.ts
+++ b/packages/theme-check-common/src/index.ts
@@ -7,6 +7,7 @@ import {
   makeGetDefaultSchemaLocale,
   makeGetDefaultSchemaTranslations,
   makeGetDefaultTranslations,
+  makeGetMetafieldDefinitions,
 } from './context-utils';
 import { createDisabledChecksModule } from './disabled-checks';
 import { isIgnored } from './ignore';
@@ -74,6 +75,8 @@ export async function check(
     getDefaultTranslations: makeGetDefaultTranslations(fs, theme, rootUri),
     getDefaultSchemaLocale: makeGetDefaultSchemaLocale(fs, rootUri),
     getDefaultSchemaTranslations: makeGetDefaultSchemaTranslations(fs, theme, rootUri),
+    getMetafieldDefinitions:
+      injectedDependencies.getMetafieldDefinitions ?? makeGetMetafieldDefinitions(fs),
   };
 
   const { DisabledChecksVisitor, isDisabled } = createDisabledChecksModule();

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -268,6 +268,37 @@ type CheckLifecycleMethods<T extends SourceCodeType> = {
   onCodePathEnd(file: SourceCode<T> & { ast: AST[T] }): Promise<void>;
 };
 
+export type MetafieldCategory =
+  | 'article'
+  | 'blog'
+  | 'brand'
+  | 'collection'
+  | 'company'
+  | 'company_location'
+  | 'location'
+  | 'market'
+  | 'order'
+  | 'page'
+  | 'product'
+  | 'variant'
+  | 'shop';
+
+export type MetafieldDefinitionMap = {
+  [key in MetafieldCategory]: MetafieldDefinition[];
+};
+
+export type MetafieldDefinition = {
+  name: string;
+  namespace: string;
+  description: string;
+  type: MetafieldDefinitionType;
+};
+
+type MetafieldDefinitionType = {
+  category: string;
+  name: string;
+};
+
 export type Translations = {
   [k in string]: string | Translations;
 };
@@ -276,6 +307,7 @@ export interface Dependencies {
   fs: AbstractFileSystem;
   themeDocset?: ThemeDocset;
   jsonValidationSet?: JsonValidationSet;
+  getMetafieldDefinitions?: (rootUri: UriString) => Promise<MetafieldDefinitionMap>;
 }
 
 export type ValidateJSON<T extends SourceCodeType> = (

--- a/packages/theme-check-common/src/utils/memo.spec.ts
+++ b/packages/theme-check-common/src/utils/memo.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { memo, memoize } from './memo';
+
+describe('memo', () => {
+  const helloFn = (name: string) => `Hello ${name}!`;
+  const goodByeFn = (name: string) => `Goodbye ${name}!`;
+
+  describe('Function: memo', () => {
+    it("should memo a function's result", () => {
+      const memoedHelloFn = memo(helloFn);
+      const memoedGoodByeFn = memo(goodByeFn);
+
+      expect(memoedHelloFn('Bob')).toBe('Hello Bob!');
+      expect(memoedHelloFn('Josh')).toBe('Hello Bob!');
+      expect(memoedGoodByeFn('Alice')).toBe('Goodbye Alice!');
+      expect(memoedGoodByeFn('Emily')).toBe('Goodbye Alice!');
+    });
+
+    it("should clear the function's result from cache", () => {
+      const memoedHelloFn = memo(helloFn);
+      const memoedGoodByeFn = memo(goodByeFn);
+
+      expect(memoedHelloFn('Bob')).toBe('Hello Bob!');
+      expect(memoedGoodByeFn('Alice')).toBe('Goodbye Alice!');
+
+      memoedHelloFn.clearCache();
+
+      expect(memoedHelloFn('Josh')).toBe('Hello Josh!');
+      expect(memoedGoodByeFn('Emily')).toBe('Goodbye Alice!');
+    });
+  });
+
+  describe('Function: memoize', () => {
+    let spiedHelloFn: (name: string) => string;
+
+    beforeEach(() => {
+      spiedHelloFn = vi.fn(helloFn);
+    });
+
+    it("should memoize a function's result by key", () => {
+      const memoizedHelloFn = memoize(spiedHelloFn, (name: string) => name);
+
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+      expect(memoizedHelloFn('Josh')).toBe('Hello Josh!');
+
+      expect(spiedHelloFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should invalidate cache for a specific key', () => {
+      const memoizedHelloFn = memoize(spiedHelloFn, (name: string) => name);
+
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+
+      expect(spiedHelloFn).toHaveBeenCalledTimes(1);
+
+      memoizedHelloFn.invalidate('Bob');
+
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+
+      expect(spiedHelloFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should force a recalculation for a specific key', () => {
+      const memoizedHelloFn = memoize(spiedHelloFn, (name: string) => name);
+
+      expect(memoizedHelloFn('Bob')).toBe('Hello Bob!');
+
+      expect(spiedHelloFn).toHaveBeenCalledTimes(1);
+
+      expect(memoizedHelloFn.force('Bob')).toBe('Hello Bob!');
+      expect(spiedHelloFn).toHaveBeenCalledTimes(2);
+
+      expect(memoizedHelloFn.force('Bob')).toBe('Hello Bob!');
+      expect(spiedHelloFn).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/packages/theme-check-common/src/utils/memo.ts
+++ b/packages/theme-check-common/src/utils/memo.ts
@@ -52,7 +52,7 @@ export function memoize<AT, F extends (arg: AT) => any, RT extends ReturnType<F>
 ) {
   const cache: Record<string, RT> = {};
 
-  return (arg: AT): RT => {
+  const memoedFunction = (arg: AT): RT => {
     const key = keyFn(arg);
 
     if (!cache[key]) {
@@ -61,4 +61,16 @@ export function memoize<AT, F extends (arg: AT) => any, RT extends ReturnType<F>
 
     return cache[key];
   };
+
+  memoedFunction.force = (arg: AT): RT => {
+    memoedFunction.invalidate(arg);
+    return memoedFunction(arg);
+  };
+
+  memoedFunction.invalidate = (arg: AT): void => {
+    const key = keyFn(arg);
+    delete cache[key];
+  };
+
+  return memoedFunction;
 }

--- a/packages/theme-language-server-common/src/ClientCapabilities.ts
+++ b/packages/theme-language-server-common/src/ClientCapabilities.ts
@@ -27,6 +27,10 @@ export class ClientCapabilities {
     return !!this.capabilities?.workspace?.didChangeConfiguration?.dynamicRegistration;
   }
 
+  get hasDidChangeWatchedFilesDynamicRegistrationSupport() {
+    return !!this.capabilities?.workspace?.didChangeWatchedFiles?.dynamicRegistration;
+  }
+
   get hasShowDocumentSupport() {
     return !!this.capabilities?.window?.showDocument;
   }

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -1,4 +1,4 @@
-import { SourceCodeType, ThemeDocset } from '@shopify/theme-check-common';
+import { MetafieldDefinitionMap, SourceCodeType, ThemeDocset } from '@shopify/theme-check-common';
 import { CompletionItem, CompletionParams } from 'vscode-languageserver';
 import { TypeSystem } from '../TypeSystem';
 import { DocumentManager } from '../documents';
@@ -25,6 +25,7 @@ export interface CompletionProviderDependencies {
   getTranslationsForURI?: GetTranslationsForURI;
   getSnippetNamesForURI?: GetSnippetNamesForURI;
   getThemeSettingsSchemaForURI?: GetThemeSettingsSchemaForURI;
+  getMetafieldDefinitions: (rootUri: string) => Promise<MetafieldDefinitionMap>;
   log?: (message: string) => void;
 }
 
@@ -37,6 +38,7 @@ export class CompletionsProvider {
   constructor({
     documentManager,
     themeDocset,
+    getMetafieldDefinitions,
     getTranslationsForURI = async () => ({}),
     getSnippetNamesForURI = async () => [],
     getThemeSettingsSchemaForURI = async () => [],
@@ -45,7 +47,11 @@ export class CompletionsProvider {
     this.documentManager = documentManager;
     this.themeDocset = themeDocset;
     this.log = log;
-    const typeSystem = new TypeSystem(themeDocset, getThemeSettingsSchemaForURI);
+    const typeSystem = new TypeSystem(
+      themeDocset,
+      getThemeSettingsSchemaForURI,
+      getMetafieldDefinitions,
+    );
 
     this.providers = [
       new HtmlTagCompletionProvider(),

--- a/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.spec.ts
@@ -1,4 +1,4 @@
-import { FilterEntry, ObjectEntry } from '@shopify/theme-check-common';
+import { FilterEntry, MetafieldDefinitionMap, ObjectEntry } from '@shopify/theme-check-common';
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
@@ -93,6 +93,7 @@ describe('Module: FilterCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
@@ -3,6 +3,7 @@ import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
 import { HtmlData } from '../../docset';
 import { sortByName } from './common';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 const globalAttributeNames = [...HtmlData.globalAttributes].sort(sortByName).map((x) => x.name);
 const aTag = HtmlData.tags.find((x) => x.name === 'a')!;
@@ -20,6 +21,7 @@ describe('Module: HtmlAttributeCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeValueCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeValueCompletionProvider.spec.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: HtmlAttributeValueCompletionProvider', async () => {
   let provider: CompletionsProvider;
@@ -14,6 +15,7 @@ describe('Module: HtmlAttributeValueCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/HtmlTagCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlTagCompletionProvider.spec.ts
@@ -3,6 +3,7 @@ import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
 import { HtmlData } from '../../docset';
 import { sortByName } from './common';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 const allTagNames = [...HtmlData.tags].sort(sortByName).map((x) => x.name);
 
@@ -18,6 +19,7 @@ describe('Module: HtmlTagCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
@@ -1,7 +1,7 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
-import { TagEntry } from '@shopify/theme-check-common';
+import { MetafieldDefinitionMap, TagEntry } from '@shopify/theme-check-common';
 import { InsertTextFormat, InsertTextMode, TextEdit } from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CURSOR } from '../params';
@@ -90,6 +90,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
         tags: async () => tags,
         systemTranslations: async () => ({}),
       },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.spec.ts
@@ -2,6 +2,7 @@ import { describe, beforeEach, it, expect, vi } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
 import { SettingsSchemaJSONFile } from '../../settings';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: ObjectAttributeCompletionProvider', async () => {
   let provider: CompletionsProvider;
@@ -72,6 +73,7 @@ describe('Module: ObjectAttributeCompletionProvider', async () => {
         systemTranslations: async () => ({}),
       },
       getThemeSettingsSchemaForURI: settingsProvider,
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.spec.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: RenderSnippetCompletionProvider', async () => {
   let provider: CompletionsProvider;
@@ -16,6 +17,7 @@ describe('Module: RenderSnippetCompletionProvider', async () => {
       },
       getTranslationsForURI: async (_) => ({}),
       getSnippetNamesForURI: async (_) => ['product-card', 'image'],
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.spec.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: TranslationCompletionProvider', async () => {
   let provider: CompletionsProvider;
@@ -14,6 +15,7 @@ describe('Module: TranslationCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
       getTranslationsForURI: async (_) => ({
         general: {
           username_html: '<b>username</b>',

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -12,7 +12,11 @@ export function makeRunChecks(
     loadConfig,
     themeDocset,
     jsonValidationSet,
-  }: Pick<Dependencies, 'fs' | 'loadConfig' | 'themeDocset' | 'jsonValidationSet'>,
+    getMetafieldDefinitions,
+  }: Pick<
+    Dependencies,
+    'fs' | 'loadConfig' | 'themeDocset' | 'jsonValidationSet' | 'getMetafieldDefinitions'
+  >,
 ) {
   return async function runChecks(triggerURIs: string[]): Promise<void> {
     // This function takes an array of triggerURIs so that we can correctly
@@ -38,6 +42,7 @@ export function makeRunChecks(
         jsonValidationSet,
         themeDocset,
         fs,
+        getMetafieldDefinitions,
       });
 
       // We iterate over the theme files (as opposed to offenses) because if

--- a/packages/theme-language-server-common/src/hover/HoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/HoverProvider.ts
@@ -1,4 +1,4 @@
-import { SourceCodeType, ThemeDocset } from '@shopify/theme-check-common';
+import { MetafieldDefinitionMap, SourceCodeType, ThemeDocset } from '@shopify/theme-check-common';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import { TypeSystem } from '../TypeSystem';
 import { DocumentManager } from '../documents';
@@ -23,10 +23,15 @@ export class HoverProvider {
   constructor(
     readonly documentManager: DocumentManager,
     readonly themeDocset: ThemeDocset,
+    readonly getMetafieldDefinitions: (rootUri: string) => Promise<MetafieldDefinitionMap>,
     readonly getTranslationsForURI: GetTranslationsForURI = async () => ({}),
     readonly getSettingsSchemaForURI: GetThemeSettingsSchemaForURI = async () => [],
   ) {
-    const typeSystem = new TypeSystem(themeDocset, getSettingsSchemaForURI);
+    const typeSystem = new TypeSystem(
+      themeDocset,
+      getSettingsSchemaForURI,
+      getMetafieldDefinitions,
+    );
     this.providers = [
       new LiquidTagHoverProvider(themeDocset),
       new LiquidFilterHoverProvider(themeDocset),

--- a/packages/theme-language-server-common/src/hover/providers/HtmlAttributeHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/HtmlAttributeHoverProvider.spec.ts
@@ -1,17 +1,22 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: HtmlAttributeHoverProvider', async () => {
   let provider: HoverProvider;
 
   beforeEach(async () => {
-    provider = new HoverProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [],
-      tags: async () => [],
-      systemTranslations: async () => ({}),
-    });
+    provider = new HoverProvider(
+      new DocumentManager(),
+      {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    );
   });
 
   it('should return the hover description of the attribute', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/HtmlAttributeValueHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/HtmlAttributeValueHoverProvider.spec.ts
@@ -1,17 +1,22 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: HtmlAttributeHoverProvider', async () => {
   let provider: HoverProvider;
 
   beforeEach(async () => {
-    provider = new HoverProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [],
-      tags: async () => [],
-      systemTranslations: async () => ({}),
-    });
+    provider = new HoverProvider(
+      new DocumentManager(),
+      {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    );
   });
 
   it('should return the hover description of the attribute', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/HtmlTagHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/HtmlTagHoverProvider.spec.ts
@@ -1,17 +1,22 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: HtmlTagHoverProvider', async () => {
   let provider: HoverProvider;
 
   beforeEach(async () => {
-    provider = new HoverProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [],
-      tags: async () => [],
-      systemTranslations: async () => ({}),
-    });
+    provider = new HoverProvider(
+      new DocumentManager(),
+      {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    );
   });
 
   it('should return the hover description of the tag', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/LiquidFilterHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidFilterHoverProvider.spec.ts
@@ -1,24 +1,29 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: LiquidFilterHoverProvider', async () => {
   let provider: HoverProvider;
 
   beforeEach(async () => {
-    provider = new HoverProvider(new DocumentManager(), {
-      filters: async () => [
-        {
-          name: 'upcase',
-          syntax: 'string | upcase',
-          description: 'upcase description',
-          return_type: [{ type: 'string', name: '' }],
-        },
-      ],
-      objects: async () => [],
-      tags: async () => [],
-      systemTranslations: async () => ({}),
-    });
+    provider = new HoverProvider(
+      new DocumentManager(),
+      {
+        filters: async () => [
+          {
+            name: 'upcase',
+            syntax: 'string | upcase',
+            description: 'upcase description',
+            return_type: [{ type: 'string', name: '' }],
+          },
+        ],
+        objects: async () => [],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    );
   });
 
   it('should return the hover description of the object', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.spec.ts
@@ -1,43 +1,48 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: LiquidObjectAttributeHoverProvider', async () => {
   let provider: HoverProvider;
 
   beforeEach(async () => {
-    provider = new HoverProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [
-        {
-          name: 'product',
-          description: 'product description',
-          return_type: [],
-          properties: [
-            {
-              name: 'featured_image',
-              description: 'featured_image description',
-              return_type: [{ type: 'image', name: '' }],
-            },
-            {
-              name: 'title',
-              return_type: [{ type: 'string', name: '' }],
-            },
-          ],
-        },
-        {
-          name: 'image',
-          description: 'image description',
-          access: {
-            global: false,
-            parents: [],
-            template: [],
+    provider = new HoverProvider(
+      new DocumentManager(),
+      {
+        filters: async () => [],
+        objects: async () => [
+          {
+            name: 'product',
+            description: 'product description',
+            return_type: [],
+            properties: [
+              {
+                name: 'featured_image',
+                description: 'featured_image description',
+                return_type: [{ type: 'image', name: '' }],
+              },
+              {
+                name: 'title',
+                return_type: [{ type: 'string', name: '' }],
+              },
+            ],
           },
-        },
-      ],
-      tags: async () => [],
-      systemTranslations: async () => ({}),
-    });
+          {
+            name: 'image',
+            description: 'image description',
+            access: {
+              global: false,
+              parents: [],
+              template: [],
+            },
+          },
+        ],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    );
   });
 
   it('should return the hover description of the object property', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
@@ -1,77 +1,129 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: LiquidObjectHoverProvider', async () => {
   let provider: HoverProvider;
 
   beforeEach(async () => {
-    provider = new HoverProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [
-        {
-          name: 'product',
-          description: 'product description',
-          return_type: [],
-          properties: [
-            {
-              name: 'featured_image',
-              return_type: [{ type: 'image', name: '' }],
+    provider = new HoverProvider(
+      new DocumentManager(),
+      {
+        filters: async () => [],
+        objects: async () => [
+          {
+            name: 'product',
+            description: 'product description',
+            return_type: [],
+            properties: [
+              {
+                name: 'featured_image',
+                return_type: [{ type: 'image', name: '' }],
+              },
+              {
+                name: 'title',
+                return_type: [{ type: 'string', name: '' }],
+              },
+              { name: 'metafields' },
+            ],
+          },
+          {
+            name: 'all_products',
+            return_type: [{ type: 'array', array_value: 'product' }],
+          },
+          {
+            name: 'paginate',
+            access: { global: false, parents: [], template: [] },
+            return_type: [],
+          },
+          {
+            name: 'forloop',
+            access: { global: false, parents: [], template: [] },
+            return_type: [],
+          },
+          {
+            name: 'tablerowloop',
+            access: { global: false, parents: [], template: [] },
+            return_type: [],
+          },
+          {
+            name: 'image',
+            description: 'image description',
+            access: { global: false, parents: [], template: [] },
+          },
+          {
+            name: 'section',
+            access: { global: false, parents: [], template: [] },
+          },
+          {
+            name: 'block',
+            access: { global: false, parents: [], template: [] },
+          },
+          {
+            name: 'app',
+            access: { global: false, parents: [], template: [] },
+          },
+          {
+            name: 'predictive_search',
+            access: { global: false, parents: [], template: [] },
+          },
+          {
+            name: 'recommendations',
+            access: { global: false, parents: [], template: [] },
+          },
+          {
+            name: 'metafield',
+            access: {
+              global: false,
+              template: [],
+              parents: [],
             },
+            properties: [
+              {
+                name: 'type',
+                description: 'the type of the metafield',
+                return_type: [{ type: 'string', name: '' }],
+              },
+              {
+                name: 'value',
+                description: 'the value of the metafield',
+                return_type: [{ type: 'untyped', name: '' }],
+              },
+            ],
+          },
+        ],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      async (_uri: string) => {
+        return {
+          article: [],
+          blog: [],
+          brand: [],
+          collection: [],
+          company: [],
+          company_location: [],
+          location: [],
+          market: [],
+          order: [],
+          page: [],
+          product: [
             {
-              name: 'title',
-              return_type: [{ type: 'string', name: '' }],
+              name: 'color',
+              namespace: 'custom',
+              description: 'the color of the product',
+              type: {
+                category: 'COLOR',
+                name: 'color',
+              },
             },
           ],
-        },
-        {
-          name: 'all_products',
-          return_type: [{ type: 'array', array_value: 'product' }],
-        },
-        {
-          name: 'paginate',
-          access: { global: false, parents: [], template: [] },
-          return_type: [],
-        },
-        {
-          name: 'forloop',
-          access: { global: false, parents: [], template: [] },
-          return_type: [],
-        },
-        {
-          name: 'tablerowloop',
-          access: { global: false, parents: [], template: [] },
-          return_type: [],
-        },
-        {
-          name: 'image',
-          description: 'image description',
-          access: { global: false, parents: [], template: [] },
-        },
-        {
-          name: 'section',
-          access: { global: false, parents: [], template: [] },
-        },
-        {
-          name: 'block',
-          access: { global: false, parents: [], template: [] },
-        },
-        {
-          name: 'app',
-          access: { global: false, parents: [], template: [] },
-        },
-        {
-          name: 'predictive_search',
-          access: { global: false, parents: [], template: [] },
-        },
-        {
-          name: 'recommendations',
-          access: { global: false, parents: [], template: [] },
-        },
-      ],
-      tags: async () => [],
-      systemTranslations: async () => ({}),
-    });
+          variant: [],
+          shop: [],
+        } as MetafieldDefinitionMap;
+      },
+    );
   });
 
   it('should return the hover description of the object', async () => {
@@ -176,6 +228,17 @@ describe('Module: LiquidObjectHoverProvider', async () => {
       );
       await expect(provider).to.hover({ source, relativePath: 'file.liquid' }, null);
     }
+  });
+
+  it('should support metafields', async () => {
+    await expect(provider).to.hover(
+      '{{ product.metafields.custom█ }}',
+      '### custom: `product_metafield_custom`',
+    );
+    await expect(provider).to.hover(
+      '{{ product.metafields.custom.color█ }}',
+      '### color: `metafield_color`\nthe color of the product',
+    );
   });
 
   it('should return nothing if the thing is untyped', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.spec.ts
@@ -1,20 +1,25 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: LiquidTagHoverProvider', async () => {
   let provider: HoverProvider;
 
   beforeEach(async () => {
-    provider = new HoverProvider(new DocumentManager(), {
-      filters: async () => [],
-      objects: async () => [],
-      tags: async () => [
-        { name: 'if', description: 'if statement description' },
-        { name: 'echo', description: 'echo description' },
-      ],
-      systemTranslations: async () => ({}),
-    });
+    provider = new HoverProvider(
+      new DocumentManager(),
+      {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [
+          { name: 'if', description: 'if statement description' },
+          { name: 'echo', description: 'echo description' },
+        ],
+        systemTranslations: async () => ({}),
+      },
+      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    );
   });
 
   it('should return the hover description of the correct tag', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/TranslationHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/TranslationHoverProvider.spec.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: TranslationHoverProvider', async () => {
   let provider: HoverProvider;
@@ -14,6 +15,7 @@ describe('Module: TranslationHoverProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
+      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
       async () => ({
         general: {
           password: 'password',

--- a/packages/theme-language-server-common/src/server/Configuration.ts
+++ b/packages/theme-language-server-common/src/server/Configuration.ts
@@ -1,5 +1,10 @@
 import { memo } from '@shopify/theme-check-common';
-import { Connection, DidChangeConfigurationNotification } from 'vscode-languageserver';
+import {
+  Connection,
+  DidChangeConfigurationNotification,
+  DidChangeWatchedFilesNotification,
+  DidChangeWatchedFilesRegistrationOptions,
+} from 'vscode-languageserver';
 import { ClientCapabilities } from '../ClientCapabilities';
 
 export const CHECK_ON_OPEN = 'themeCheck.checkOnOpen' as const;
@@ -61,4 +66,11 @@ export class Configuration {
     if (!this.capabilities.hasDidChangeConfigurationDynamicRegistrationSupport) return;
     return this.connection.client.register(DidChangeConfigurationNotification.type);
   });
+
+  registerDidChangeWatchedFilesNotification = async (
+    options?: DidChangeWatchedFilesRegistrationOptions,
+  ) => {
+    if (!this.capabilities.hasDidChangeWatchedFilesDynamicRegistrationSupport) return;
+    return this.connection.client.register(DidChangeWatchedFilesNotification.type, options);
+  };
 }

--- a/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
+++ b/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it, beforeEach } from 'vitest';
 import { CompletionsProvider } from '../completions';
 import { DocumentManager } from '../documents';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 
 describe('Module: CompletionItemsAssertion', () => {
   let provider: CompletionsProvider;
@@ -16,6 +17,7 @@ describe('Module: CompletionItemsAssertion', () => {
         tags: async () => [{ name: 'render' }],
         systemTranslations: async () => ({}),
       },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
     });
   });
 

--- a/packages/theme-language-server-common/src/types.ts
+++ b/packages/theme-language-server-common/src/types.ts
@@ -7,7 +7,7 @@ import { URI } from 'vscode-languageserver';
 
 import { WithOptional } from './utils';
 
-export type Dependencies = WithOptional<RequiredDependencies, 'log'>;
+export type Dependencies = WithOptional<RequiredDependencies, 'log' | 'getMetafieldDefinitions'>;
 
 export interface RequiredDependencies {
   /**
@@ -79,4 +79,11 @@ export interface RequiredDependencies {
    * The browser accepts a custom implementation.
    */
   fs: AbstractFileSystem;
+
+  /**
+   * In local environments, the Language Server can download the metafield definitions
+   * and provide a set of memoized definitions. In other environments, we rely on dynamically
+   * fetching the set of metafield definitions every time.
+   */
+  getMetafieldDefinitions: ThemeCheckDependencies['getMetafieldDefinitions'];
 }


### PR DESCRIPTION
## What are you adding in this PR?

Part 1 for https://github.com/Shopify/theme-tools/issues/502
- Adding support for metadata autocompletion on our editors
- listens to file changes for `.shopify` folder
- This should work for VScode only


## What's next? Any followup issues?

- We need to make it work on OSE next
- We will create a CLI command to fetch the metafields.json
- We need to automatically call this CLI command in VSCode on startup

## What did you learn?

- registering for `DidChangeWatchedFilesNotification` took some time, but had to read-up on client capabilities and how to subscribe to notifications after initialization

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles

## Tophat

Run the following query and dump the contents into `.shopify/metafields.json` in the theme repository. Remove the `nodes` array, and place it directory under each group.

```
query {
	article: metafieldDefinitions(ownerType: ARTICLE, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	blog: metafieldDefinitions(ownerType: BLOG, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	brand: metafieldDefinitions(ownerType: BRAND, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	collection: metafieldDefinitions(ownerType: COLLECTION, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	company: metafieldDefinitions(ownerType: COMPANY, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	company_location: metafieldDefinitions(ownerType: COMPANY_LOCATION, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	location: metafieldDefinitions(ownerType: LOCATION, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	market: metafieldDefinitions(ownerType: MARKET, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	order: metafieldDefinitions(ownerType: ORDER, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	page: metafieldDefinitions(ownerType: PAGE, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	product: metafieldDefinitions(ownerType: PRODUCT, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	variant: metafieldDefinitions(ownerType: PRODUCTVARIANT, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
	shop: metafieldDefinitions(ownerType: SHOP, first: 250) {
		nodes {
			...MetafieldDefinitionFields
		}
	}
}

fragment MetafieldDefinitionFields on MetafieldDefinition {
	name
	namespace
	description
	type {
		category
		name
	}
}
```

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
