### PR TITLE
Fix theme-check-common wiki link

### DIFF
--- a/packages/theme-check-common/README.md
+++ b/packages/theme-check-common/README.md
@@ -9,7 +9,7 @@
 
 Theme Check helps you follow best practices by analyzing the files inside your Shopify theme.
 
-Theme Check is available [to code editors that support the Language Server Protocol](https://github.com/Shopify/theme-check/wiki).
+Theme Check is available [to code editors that support the Language Server Protocol](https://github.com/Shopify/theme-tools/wiki).
 
 You may be interested by the sibling modules:
 


### PR DESCRIPTION
I updated the incorrect wiki link within the README.md of the theme-check-common package.

Not filling out all of the template of the pull request as it is such a minor change. Thanks guys.
