### PR TITLE
Ignore `git:` URI requests and notifications

### DIFF
--- a/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.spec.ts
+++ b/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.spec.ts
@@ -5,33 +5,35 @@ import { DocumentLinksProvider } from './DocumentLinksProvider';
 describe('DocumentLinksProvider', () => {
   let documentManager: DocumentManager;
   let documentLinksProvider: DocumentLinksProvider;
+  let rootUri: string;
+  let uriString: string;
 
   beforeEach(() => {
     documentManager = new DocumentManager();
-    documentLinksProvider = new DocumentLinksProvider(documentManager);
+    documentLinksProvider = new DocumentLinksProvider(documentManager, async () => rootUri);
   });
 
   it('should return an empty array for non-LiquidHtml documents', async () => {
-    const uriString = 'file:///path/to/non-liquid-html-document.txt';
-    const rootUri = 'file:///path/to/project';
+    uriString = 'file:///path/to/non-liquid-html-document.txt';
+    rootUri = 'file:///path/to/project';
 
     documentManager.open(uriString, 'Sample plain text content', 1);
 
-    const result = await documentLinksProvider.documentLinks(uriString, rootUri);
+    const result = await documentLinksProvider.documentLinks(uriString);
     expect(result).toEqual([]);
   });
 
   it('should return an empty array for non-existent documents', async () => {
-    const uriString = 'file:///path/to/non-existent-document.txt';
-    const rootUri = 'file:///path/to/project';
+    uriString = 'file:///path/to/non-existent-document.txt';
+    rootUri = 'file:///path/to/project';
 
-    const result = await documentLinksProvider.documentLinks(uriString, rootUri);
+    const result = await documentLinksProvider.documentLinks(uriString);
     expect(result).toEqual([]);
   });
 
   it('should return a list of document links with correct URLs for a LiquidHtml document', async () => {
-    const uriString = 'file:///path/to/liquid-html-document.liquid';
-    const rootUri = 'file:///path/to/project';
+    uriString = 'file:///path/to/liquid-html-document.liquid';
+    rootUri = 'file:///path/to/project';
 
     const liquidHtmlContent = `
       {% render 'snippet1' %}
@@ -44,7 +46,7 @@ describe('DocumentLinksProvider', () => {
 
     documentManager.open(uriString, liquidHtmlContent, 1);
 
-    const result = await documentLinksProvider.documentLinks(uriString, rootUri);
+    const result = await documentLinksProvider.documentLinks(uriString);
     const expectedUrls = [
       'file:///path/to/project/snippets/snippet1.liquid',
       'file:///path/to/project/snippets/snippet2.liquid',

--- a/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.ts
+++ b/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.ts
@@ -8,9 +8,12 @@ import { DocumentManager } from '../documents';
 import { visit, Visitor } from '../visitor';
 
 export class DocumentLinksProvider {
-  constructor(private documentManager: DocumentManager) {}
+  constructor(
+    private documentManager: DocumentManager,
+    private findThemeRootURI: (uri: string) => Promise<string>,
+  ) {}
 
-  async documentLinks(uriString: string, rootUri: string): Promise<DocumentLink[]> {
+  async documentLinks(uriString: string): Promise<DocumentLink[]> {
     const sourceCode = this.documentManager.get(uriString);
     if (
       !sourceCode ||
@@ -20,8 +23,8 @@ export class DocumentLinksProvider {
       return [];
     }
 
+    const rootUri = await this.findThemeRootURI(uriString);
     const visitor = documentLinksVisitor(sourceCode.textDocument, URI.parse(rootUri));
-
     return visit(sourceCode.ast, visitor);
   }
 }


### PR DESCRIPTION
The `git:` VFS used by VS Code is the one for URLs shown in git diffs. It does not implement `fs.readDirectory` and makes any kind of complex call to the language server break for that reason.

## What are you adding in this PR?

So this commit makes it so we ignore `git:` requests and notifications.


## Before you deploy

No changeset because VFS hasn't been published yet and it's a VFS "bug."
