### PR TITLE
Fix `loadConfig` for remote files

### DIFF
--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -32,7 +32,7 @@ export function makeRunChecks(
     return;
 
     async function runChecksForRoot(configFileRootUri: string) {
-      const config = await loadConfig(configFileRootUri, fileExists);
+      const config = await loadConfig(configFileRootUri, fs);
       const theme = documentManager.theme(config.rootUri);
       const offenses = await check(theme, config, {
         jsonValidationSet,

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -88,7 +88,7 @@ export function startServer(
 
   const findThemeRootURI = async (uri: string) => {
     const rootUri = await findRoot(uri, fileExists);
-    const config = await loadConfig(rootUri, fileExists);
+    const config = await loadConfig(rootUri, fs);
     return config.rootUri;
   };
 
@@ -153,7 +153,7 @@ export function startServer(
 
   const getModeForURI = async (uri: string) => {
     const rootUri = await findRoot(uri, fileExists);
-    const config = await loadConfig(rootUri, fileExists);
+    const config = await loadConfig(rootUri, fs);
     return config.context;
   };
 

--- a/packages/theme-language-server-common/src/types.ts
+++ b/packages/theme-language-server-common/src/types.ts
@@ -51,7 +51,7 @@ export interface RequiredDependencies {
    * @param uri - a file path
    * @returns {Promise<Config>}
    */
-  loadConfig(uri: URI, fileExists: (uri: string) => Promise<boolean>): Promise<Config>;
+  loadConfig(uri: URI, fs: AbstractFileSystem): Promise<Config>;
 
   /**
    * In local environments, the Language Server can download the latest versions

--- a/packages/vscode-extension/src/browser/server.ts
+++ b/packages/vscode-extension/src/browser/server.ts
@@ -1,4 +1,4 @@
-import { findRoot } from '@shopify/theme-check-common';
+import { findRoot, makeFileExists } from '@shopify/theme-check-common';
 import {
   Dependencies,
   getConnection,
@@ -31,7 +31,8 @@ const fileSystem = new VsCodeFileSystem(connection, {});
 const dependencies: Dependencies = {
   fs: fileSystem,
   log: console.info.bind(console),
-  loadConfig: async (uri, fileExists) => {
+  loadConfig: async (uri, fs) => {
+    const fileExists = makeFileExists(fs);
     const rootUri = await findRoot(uri, fileExists);
     return {
       context: 'theme',


### PR DESCRIPTION
## What are you adding in this PR?

We'll steal a page from the [prettier playbook](https://prettier.io/docs/en/browser#:~:text=Run%20Prettier%20in%20the%20browser%20using%20its%20standalone%20version.%20This%20version%20doesn%E2%80%99t%20depend%20on%20Node.js.%20It%20only%20formats%20the%20code%20and%20has%20no%20support%20for%20config%20files%2C%20ignore%20files%2C%20CLI%20usage%2C%20or%20automatic%20loading%20of%20plugins.) and simply won't load configs in remote settings.

The problem with remote plugins and settings is that we simply can't run arbitraty node code in browser or from a `github:` VFS.

We'll offer the recommended checks for remote files. Just like prettier.

Fixes #532

## Before you deploy

No changeset because that's a bug from VFS and VFS hasn't been released yet.
