### PR TITLE
Add script example for snippet usage

### DIFF
--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -79,7 +79,7 @@ export async function themeCheckRun(
   };
 }
 
-async function getThemeAndConfig(
+export async function getThemeAndConfig(
   root: string,
   configPath?: string,
 ): Promise<{ theme: Theme; config: Config }> {

--- a/packages/theme-language-server-common/src/index.ts
+++ b/packages/theme-language-server-common/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from '@shopify/theme-check-common';
 
 export * from './types';
+export { visit } from './visitor';
 export { debounce, memo, parseJSON, ArgumentTypes } from './utils';
 export { startServer } from './server';
 export {

--- a/scripts/snippets-usage.ts
+++ b/scripts/snippets-usage.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env ts-node
+import { LiquidTag, NodeTypes } from '@shopify/liquid-html-parser';
+import { getThemeAndConfig, path, SourceCode, SourceCodeType } from '@shopify/theme-check-node';
+import { visit } from '@shopify/theme-language-server-common';
+import { URI } from 'vscode-uri';
+
+type UsedBy = Record<string, number>;
+type Stats = Record<string, UsedBy>;
+
+async function main() {
+  const args = process.argv.slice(2);
+  const themePath = args[0];
+  if (!args[0]) {
+    console.error('Usage: scripts/snippets-usage <theme-root-path>');
+    console.error();
+    console.error('This script will output a list of snippets and the files that use them.');
+    process.exit(0);
+  }
+
+  const { theme } = await getThemeAndConfig(themePath);
+  const stats: Stats = {};
+  const root = URI.file(themePath).toString();
+  const liquidFiles = theme.filter(
+    (f): f is SourceCode<SourceCodeType.LiquidHtml> => f.type === SourceCodeType.LiquidHtml,
+  );
+  for (const file of liquidFiles) {
+    if (file.ast instanceof Error) continue;
+
+    const relative = path.relative(file.uri, root);
+
+    visit(file.ast, {
+      LiquidTag(node: LiquidTag) {
+        if (node.name !== 'include' && node.name !== 'render') return;
+        if (typeof node.markup === 'string') return;
+        const snippet = node.markup.snippet;
+        if (snippet.type !== NodeTypes.String) return;
+        const snippetPath = `snippets/${snippet.value}.liquid`;
+        stats[snippetPath] ??= {};
+        stats[snippetPath][relative] ??= 0;
+        stats[snippetPath][relative]++;
+      },
+    });
+  }
+
+  for (const [snippet, usedBy] of Object.entries(stats)) {
+    console.log(snippet);
+    for (const [file, count] of Object.entries(usedBy)) {
+      console.log(`  ${count.toString().padEnd(2)} ${file}`);
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
## What are you adding in this PR?

- Add a script in the `scripts` folder to compile snippet usage

Usage:
```
scripts/snippet-usage.ts <path-to-theme>
```

Example output:
```
snippets/banner.liquid
  1  sections/before-after.liquid
  2  sections/contact.liquid
  2  sections/footer.liquid
  2  sections/main-article.liquid
  1  sections/main-customers-activate-account.liquid
  3  sections/main-customers-login.liquid
  2  sections/main-customers-order.liquid
  1  sections/main-customers-register.liquid
  1  sections/main-customers-reset-password.liquid
  2  sections/main-gift-card.liquid
  3  sections/main-password.liquid
  2  sections/newsletter-popup.liquid
  2  sections/newsletter.liquid
```
