### PR TITLE
Add `content_for` tag parser support + `ValidContentForArguments` check

### DIFF
--- a/.changeset/purple-pears-report.md
+++ b/.changeset/purple-pears-report.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-check-browser': minor
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Add the `ValidContentForArguments` check

--- a/.changeset/tasty-mugs-behave.md
+++ b/.changeset/tasty-mugs-behave.md
@@ -1,0 +1,7 @@
+---
+'@shopify/liquid-html-parser': minor
+'@shopify/prettier-plugin-liquid': minor
+'@shopify/theme-language-server-common': minor
+---
+
+Add support for the `content_for` Liquid tag

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -50,6 +50,7 @@ Liquid <: Helpers {
     | liquidTagBreak
     | liquidTagContinue
     | liquidTagCycle
+    | liquidTagContentFor
     | liquidTagDecrement
     | liquidTagEcho
     | liquidTagElse
@@ -124,6 +125,11 @@ Liquid <: Helpers {
   // redefines liquidTagOpenRule, liquidTagRule, and space.
   liquidTagLiquid = liquidTagRule<"liquid", liquidTagLiquidMarkup>
   liquidTagLiquidMarkup = tagMarkup
+
+  liquidTagContentFor = liquidTagRule<"content_for", liquidTagContentForMarkup>
+  liquidTagContentForMarkup =
+    contentForType (argumentSeparatorOptionalComma tagArguments) (space* ",")? space*
+  contentForType = liquidString<delimTag>
 
   liquidTagInclude = liquidTagRule<"include", liquidTagRenderMarkup>
   liquidTagRender = liquidTagRule<"render", liquidTagRenderMarkup>

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -586,6 +586,45 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.markup.expression.lookups').to.eql([]);
         }
       });
+
+      it('should parse content_for "blocks"', () => {
+        for (const { toCST, expectPath } of testCases) {
+          cst = toCST(`{% content_for "blocks" -%}`);
+          expectPath(cst, '0.type').to.equal('LiquidTag');
+          expectPath(cst, '0.name').to.equal('content_for');
+          expectPath(cst, '0.markup.type').to.equal('ContentForMarkup');
+          expectPath(cst, '0.markup.contentForType.type').to.equal('String');
+          expectPath(cst, '0.markup.contentForType.value').to.equal('blocks');
+          expectPath(cst, '0.markup.contentForType.single').to.equal(false);
+          expectPath(cst, '0.markup.args').to.have.lengthOf(0);
+          expectPath(cst, '0.whitespaceStart').to.equal(null);
+          expectPath(cst, '0.whitespaceEnd').to.equal('-');
+        }
+      });
+
+      it('should parse content_for "block", id: "my-id", type: "my-block"', () => {
+        for (const { toCST, expectPath } of testCases) {
+          cst = toCST(`{% content_for "block", id: "block-id", type: "block-type" -%}`);
+          expectPath(cst, '0.type').to.equal('LiquidTag');
+          expectPath(cst, '0.name').to.equal('content_for');
+          expectPath(cst, '0.markup.type').to.equal('ContentForMarkup');
+          expectPath(cst, '0.markup.contentForType.type').to.equal('String');
+          expectPath(cst, '0.markup.contentForType.value').to.equal('block');
+          expectPath(cst, '0.markup.contentForType.single').to.equal(false);
+          expectPath(cst, '0.markup.args').to.have.lengthOf(2);
+          const namedArguments = [
+            { name: 'id', valueType: 'String' },
+            { name: 'type', valueType: 'String' },
+          ];
+          namedArguments.forEach(({ name, valueType }, i) => {
+            expectPath(cst, `0.markup.args.${i}.type`).to.equal('NamedArgument');
+            expectPath(cst, `0.markup.args.${i}.name`).to.equal(name);
+            expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(valueType);
+          });
+          expectPath(cst, '0.whitespaceStart').to.equal(null);
+          expectPath(cst, '0.whitespaceEnd').to.equal('-');
+        }
+      });
     });
 
     describe('Case: LiquidTagOpen', () => {

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -75,6 +75,7 @@ export enum ConcreteNodeTypes {
   Condition = 'Condition',
 
   AssignMarkup = 'AssignMarkup',
+  ContentForMarkup = 'ContentForMarkup',
   CycleMarkup = 'CycleMarkup',
   ForMarkup = 'ForMarkup',
   RenderMarkup = 'RenderMarkup',
@@ -265,6 +266,7 @@ export type ConcreteLiquidTag = ConcreteLiquidTagNamed | ConcreteLiquidTagBaseCa
 export type ConcreteLiquidTagNamed =
   | ConcreteLiquidTagAssign
   | ConcreteLiquidTagCycle
+  | ConcreteLiquidTagContentFor
   | ConcreteLiquidTagEcho
   | ConcreteLiquidTagIncrement
   | ConcreteLiquidTagDecrement
@@ -321,10 +323,19 @@ export interface ConcreteLiquidTagCycleMarkup
   args: ConcreteLiquidExpression[];
 }
 
+export interface ConcreteLiquidTagContentFor
+  extends ConcreteLiquidTagNode<NamedTags.content_for, ConcreteLiquidTagContentForMarkup> {}
+
 export interface ConcreteLiquidTagRender
   extends ConcreteLiquidTagNode<NamedTags.render, ConcreteLiquidTagRenderMarkup> {}
 export interface ConcreteLiquidTagInclude
   extends ConcreteLiquidTagNode<NamedTags.include, ConcreteLiquidTagRenderMarkup> {}
+
+export interface ConcreteLiquidTagContentForMarkup
+  extends ConcreteBasicNode<ConcreteNodeTypes.ContentForMarkup> {
+  contentForType: ConcreteStringLiteral;
+  args: ConcreteLiquidNamedArgument[];
+}
 
 export interface ConcreteLiquidTagRenderMarkup
   extends ConcreteBasicNode<ConcreteNodeTypes.RenderMarkup> {
@@ -715,6 +726,7 @@ function toCST<T>(
     liquidTagBaseCase: 0,
     liquidTagAssign: 0,
     liquidTagEcho: 0,
+    liquidTagContentFor: 0,
     liquidTagCycle: 0,
     liquidTagIncrement: 0,
     liquidTagDecrement: 0,
@@ -774,6 +786,16 @@ function toCST<T>(
       locEnd,
       source,
     },
+
+    liquidTagContentForMarkup: {
+      type: ConcreteNodeTypes.ContentForMarkup,
+      contentForType: 0,
+      args: 2,
+      locStart,
+      locEnd,
+      source,
+    },
+    contentForType: 0,
 
     liquidTagRenderMarkup: {
       type: ConcreteNodeTypes.RenderMarkup,

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -579,6 +579,47 @@ describe('Unit: Stage 2 (AST)', () => {
           });
         });
       });
+
+      describe('Case: content_for', () => {
+        it('should parse content_for tags with no arguments', () => {
+          for (const { toAST, expectPath, expectPosition } of testCases) {
+            ast = toAST(`{% content_for "blocks" %}`);
+            expectPath(ast, 'children.0.type').to.equal('LiquidTag');
+            expectPath(ast, 'children.0.name').to.equal('content_for');
+            expectPath(ast, 'children.0.markup.type').to.equal('ContentForMarkup');
+            expectPath(ast, 'children.0.markup.contentForType.type').to.equal('String');
+            expectPath(ast, 'children.0.markup.contentForType.value').to.equal('blocks');
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+          }
+        });
+
+        it('should parse content_for named expression arguments', () => {
+          for (const { toAST, expectPath, expectPosition } of testCases) {
+            ast = toAST(`{% content_for "snippet", s: 'string', n: 10, r: (1..2), v: variable %}`);
+            expectPath(ast, 'children.0.type').to.equal('LiquidTag');
+            expectPath(ast, 'children.0.name').to.equal('content_for');
+            expectPath(ast, 'children.0.markup.type').to.equal('ContentForMarkup');
+            expectPath(ast, 'children.0.markup.contentForType.type').to.equal('String');
+            expectPath(ast, 'children.0.markup.contentForType.value').to.equal('snippet');
+            expectPath(ast, 'children.0.markup.args').to.have.lengthOf(4);
+            expectPath(ast, 'children.0.markup.args.0.type').to.equal('NamedArgument');
+            expectPath(ast, 'children.0.markup.args.0.name').to.equal('s');
+            expectPath(ast, 'children.0.markup.args.0.value.type').to.equal('String');
+            expectPath(ast, 'children.0.markup.args.1.type').to.equal('NamedArgument');
+            expectPath(ast, 'children.0.markup.args.1.name').to.equal('n');
+            expectPath(ast, 'children.0.markup.args.1.value.type').to.equal('Number');
+            expectPath(ast, 'children.0.markup.args.2.type').to.equal('NamedArgument');
+            expectPath(ast, 'children.0.markup.args.2.name').to.equal('r');
+            expectPath(ast, 'children.0.markup.args.2.value.type').to.equal('Range');
+            expectPath(ast, 'children.0.markup.args.3.type').to.equal('NamedArgument');
+            expectPath(ast, 'children.0.markup.args.3.name').to.equal('v');
+            expectPath(ast, 'children.0.markup.args.3.value.type').to.equal('VariableLookup');
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+          }
+        });
+      });
     });
 
     it(`should parse liquid inline comments`, () => {

--- a/packages/liquid-html-parser/src/types.ts
+++ b/packages/liquid-html-parser/src/types.ts
@@ -37,6 +37,7 @@ export enum NodeTypes {
   LogicalExpression = 'LogicalExpression',
 
   AssignMarkup = 'AssignMarkup',
+  ContentForMarkup = 'ContentForMarkup',
   CycleMarkup = 'CycleMarkup',
   ForMarkup = 'ForMarkup',
   PaginateMarkup = 'PaginateMarkup',
@@ -50,6 +51,7 @@ export enum NamedTags {
   assign = 'assign',
   capture = 'capture',
   case = 'case',
+  content_for = 'content_for',
   cycle = 'cycle',
   decrement = 'decrement',
   echo = 'echo',

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -121,6 +121,7 @@ function getCssDisplay(node: AugmentedNode<WithSiblings>, options: LiquidParserO
     case NodeTypes.VariableLookup:
     case NodeTypes.AssignMarkup:
     case NodeTypes.CycleMarkup:
+    case NodeTypes.ContentForMarkup:
     case NodeTypes.ForMarkup:
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
@@ -225,6 +226,7 @@ function getNodeCssStyleWhiteSpace(
     case NodeTypes.VariableLookup:
     case NodeTypes.AssignMarkup:
     case NodeTypes.CycleMarkup:
+    case NodeTypes.ContentForMarkup:
     case NodeTypes.ForMarkup:
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -165,6 +165,12 @@ function printNamedLiquidBlockStart(
       ]);
     }
 
+    case NamedTags.content_for: {
+      const markup = node.markup;
+      const trailingWhitespace = markup.args.length > 0 ? line : ' ';
+      return tag(trailingWhitespace);
+    }
+
     case NamedTags.include:
     case NamedTags.render: {
       const markup = node.markup;

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -378,6 +378,23 @@ function printNode(
       return doc;
     }
 
+    case NodeTypes.ContentForMarkup: {
+      const contentForType = path.call((p: any) => print(p), 'contentForType');
+      const doc: Doc = [contentForType];
+      if (node.args.length > 0) {
+        doc.push(
+          ',',
+          line,
+          join(
+            [',', line],
+            path.map((p) => print(p), 'args'),
+          ),
+        );
+      }
+
+      return doc;
+    }
+
     case NodeTypes.RenderMarkup: {
       const snippet = path.call((p: any) => print(p), 'snippet');
       const doc: Doc = [snippet];

--- a/packages/prettier-plugin-liquid/src/test/liquid-tag-content-for/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-tag-content-for/fixed.liquid
@@ -1,0 +1,21 @@
+It should never break a name
+printWidth: 1
+{% content_for 'block' %}
+{%- content_for 'blocks' -%}
+
+It should break on named args
+printWidth: 1
+{% content_for 'block',
+  key1: val1,
+  key2: (0..1)
+%}
+
+It should not require commas (as per syntax) but add them when pretty printed
+{% content_for 'block', key1: val1, key2: (0..1) %}
+
+It should not require spaces (as per syntax) but add them when pretty printed
+{% content_for 'block', key1: val1, key2: (0..1) %}
+
+It should strip trailing commas by default
+{% content_for 'foo' %}
+{% content_for 'foo', product: product %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-tag-content-for/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-tag-content-for/index.liquid
@@ -1,0 +1,18 @@
+It should never break a name
+printWidth: 1
+{% content_for "block" %}
+{%- content_for "blocks" -%}
+
+It should break on named args
+printWidth: 1
+{% content_for "block", key1: val1, key2: (0..1) %}
+
+It should not require commas (as per syntax) but add them when pretty printed
+{% content_for "block" key1: val1 key2: (0..1) %}
+
+It should not require spaces (as per syntax) but add them when pretty printed
+{%content_for "block",key1:val1,key2:(0..1)%}
+
+It should strip trailing commas by default
+{% content_for "foo", %}
+{% content_for "foo",product:product, %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-tag-content-for/index.spec.ts
+++ b/packages/prettier-plugin-liquid/src/test/liquid-tag-content-for/index.spec.ts
@@ -1,0 +1,6 @@
+import { test } from 'vitest';
+import { assertFormattedEqualsFixed } from '../test-helpers';
+
+test('Unit: liquid-tag-content-for', async () => {
+  await assertFormattedEqualsFixed(__dirname);
+});

--- a/packages/theme-check-common/src/checks/capture-on-content-for-block/index.ts
+++ b/packages/theme-check-common/src/checks/capture-on-content-for-block/index.ts
@@ -1,4 +1,10 @@
-import { LiquidTag, LiquidTagCapture, NodeTypes, Position } from '@shopify/liquid-html-parser';
+import {
+  LiquidTag,
+  LiquidTagCapture,
+  NamedTags,
+  NodeTypes,
+  Position,
+} from '@shopify/liquid-html-parser';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { isContentForBlock } from '../../utils/markup';
 import { isNodeOfType } from '../utils';
@@ -27,7 +33,7 @@ export const CaptureOnContentForBlock: LiquidCheckDefinition = {
     function checkContentForBlock(node: any, position: Position) {
       if (
         isNodeOfType(NodeTypes.LiquidTag, node) &&
-        node.name === 'content_for' &&
+        node.name === NamedTags.content_for &&
         isContentForBlock(node.markup)
       ) {
         context.report({
@@ -42,7 +48,7 @@ export const CaptureOnContentForBlock: LiquidCheckDefinition = {
       async LiquidTag(node) {
         if (isLiquidTagCapture(node) && node.children) {
           for (const child of node.children) {
-            if (child.type === NodeTypes.LiquidTag && typeof child.markup == 'string') {
+            if (child.type === NodeTypes.LiquidTag) {
               checkContentForBlock(child, child.position);
             }
           }

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -6,8 +6,8 @@ import { AssetSizeAppBlockCSS } from './asset-size-app-block-css';
 import { AssetSizeAppBlockJavaScript } from './asset-size-app-block-javascript';
 import { AssetSizeCSS } from './asset-size-css';
 import { AssetSizeJavaScript } from './asset-size-javascript';
-import { CdnPreconnect } from './cdn-preconnect';
 import { CaptureOnContentForBlock } from './capture-on-content-for-block';
+import { CdnPreconnect } from './cdn-preconnect';
 import { ContentForHeaderModification } from './content-for-header-modification';
 import { DeprecateBgsizes } from './deprecate-bgsizes';
 import { DeprecateLazysizes } from './deprecate-lazysizes';
@@ -26,14 +26,15 @@ import { RequiredLayoutThemeObject } from './required-layout-theme-object';
 import { TranslationKeyExists } from './translation-key-exists';
 import { UnclosedHTMLElement } from './unclosed-html-element';
 import { UndefinedObject } from './undefined-object';
+import { UniqueStaticBlockId } from './unique-static-block-id';
 import { UnknownFilter } from './unknown-filter';
 import { UnusedAssign } from './unused-assign';
+import { ValidContentForArguments } from './valid-content-for-arguments';
 import { ValidHTMLTranslation } from './valid-html-translation';
-import { ValidSchema } from './valid-schema';
 import { ValidJSON } from './valid-json';
-import { VariableName } from './variable-name';
+import { ValidSchema } from './valid-schema';
 import { ValidStaticBlockType } from './valid-static-block-type';
-import { UniqueStaticBlockId } from './unique-static-block-id';
+import { VariableName } from './variable-name';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
@@ -66,6 +67,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   UnknownFilter,
   UnusedAssign,
   ValidHTMLTranslation,
+  ValidContentForArguments,
   ValidJSON,
   ValidSchema,
   ValidStaticBlockType,

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.spec.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.spec.ts
@@ -86,7 +86,7 @@ describe('Module: LiquidHTMLSyntaxError', () => {
     const offenses = await runLiquidCheck(LiquidHTMLSyntaxError, sourceCode);
     expect(offenses).to.have.length(1);
     expect(offenses[0].message).to.equal(
-      `SyntaxError: expected "#", a letter, "when", "sections", "section", "render", "liquid", "layout", "increment", "include", "elsif", "else", "echo", "decrement", "cycle", "continue", "break", "assign", "tablerow", "unless", "if", "ifchanged", "for", "case", "capture", "paginate", "form", "end", "style", "stylesheet", "schema", "javascript", "raw", or "comment"`,
+      `SyntaxError: expected "#", a letter, "when", "sections", "section", "render", "liquid", "layout", "increment", "include", "elsif", "else", "echo", "decrement", "content_for", "cycle", "continue", "break", "assign", "tablerow", "unless", "if", "ifchanged", "for", "case", "capture", "paginate", "form", "end", "style", "stylesheet", "schema", "javascript", "raw", or "comment"`,
     );
   });
 

--- a/packages/theme-check-common/src/checks/valid-content-for-arguments/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-content-for-arguments/index.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { ValidContentForArguments } from '.';
+import { runLiquidCheck } from '../../test';
+
+describe('Module: ValidContentForArguments', () => {
+  describe('{% content_for "unknown" %}', () => {
+    it('should not report offenses for strategies we do not know or support yet', async () => {
+      const offenses = await runLiquidCheck(
+        ValidContentForArguments,
+        '{% content_for "snippet", context.product: product %}',
+      );
+      expect(offenses).toHaveLength(0);
+    });
+  });
+
+  describe('{% content_for "blocks" %}', () => {
+    it('should accept `context.*` kwargs', async () => {
+      const offenses = await runLiquidCheck(
+        ValidContentForArguments,
+        '{% content_for "blocks", context.product: product %}',
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('should report offenses for non-`context.*` kwargs', async () => {
+      const offenses = await runLiquidCheck(
+        ValidContentForArguments,
+        '{% content_for "blocks", product: product %}',
+      );
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0]!.message).to.equal(
+        `{% content_for "blocks" %} only accepts 'context.*' arguments`,
+      );
+    });
+  });
+
+  describe('{% content_for "block", type: "", id: "" %}', () => {
+    it('should accept valid arguments', async () => {
+      const offenses = await runLiquidCheck(
+        ValidContentForArguments,
+        '{% content_for "block", type: "text", id: "static-block" %}',
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it(`should report an offense if 'type' is not a string`, async () => {
+      const offenses = await runLiquidCheck(
+        ValidContentForArguments,
+        '{% content_for "block", type: 10, id: "static-block" %}',
+      );
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).to.equal(`The 'type' argument should be a string`);
+    });
+
+    it(`should report an offense if 'id' is not a string`, async () => {
+      const offenses = await runLiquidCheck(
+        ValidContentForArguments,
+        '{% content_for "block", type: "foo", id: (0..10) %}',
+      );
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).to.equal(`The 'id' argument should be a string`);
+    });
+
+    it(`should report an offense if other kwargs are passed that are not named 'context.*'`, async () => {
+      const offenses = await runLiquidCheck(
+        ValidContentForArguments,
+        '{% content_for "block", type: "foo", id: "id", product: product %}',
+      );
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).to.equal(
+        `{% content_for "block" %} only accepts 'id', 'type' and 'context.*' arguments`,
+      );
+    });
+  });
+});

--- a/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
+++ b/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
@@ -1,0 +1,95 @@
+import { ContentForMarkup, NodeTypes } from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+
+// content_for "block" and content_for "blocks" only allow `context.*` kwargs.
+const isContextArgument = (argName: string) => argName.startsWith('context.');
+
+export const ValidContentForArguments: LiquidCheckDefinition = {
+  meta: {
+    code: 'ValidContentForArguments',
+    name: 'Prevent the use of invalid arguments to the content_for tag',
+    docs: {
+      description:
+        'This check is aimed at preventing the use of invalid arguments for the content_for tag.',
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-content-for-arguments',
+      recommended: true,
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    const validationStrategies = {
+      blocks: (node: ContentForMarkup) => {
+        const problematicArguments = node.args.filter((arg) => !isContextArgument(arg.name));
+        for (const arg of problematicArguments) {
+          context.report({
+            message: `{% content_for "blocks" %} only accepts 'context.*' arguments`,
+            startIndex: arg.position.start,
+            endIndex: arg.position.end,
+          });
+        }
+      },
+
+      block: (node: ContentForMarkup) => {
+        const requiredArguments = ['id', 'type'];
+
+        // Make sure the id and string arguments are present and are strings
+        for (const requiredArgumentName of requiredArguments) {
+          const arg = node.args.find((arg) => arg.name === requiredArgumentName);
+
+          if (!arg) {
+            context.report({
+              message: `{% content_for "block" %} requires a '${requiredArgumentName}' argument`,
+              startIndex: node.position.start,
+              endIndex: node.position.end,
+              suggest: [],
+            });
+            continue;
+          }
+
+          const argValueNode = arg.value;
+          if (argValueNode.type !== NodeTypes.String) {
+            context.report({
+              message: `The '${requiredArgumentName}' argument should be a string`,
+              startIndex: argValueNode.position.start,
+              endIndex: argValueNode.position.end,
+              suggest: [],
+            });
+          }
+        }
+
+        const problematicArguments = node.args.filter(
+          (arg) => !(requiredArguments.includes(arg.name) || isContextArgument(arg.name)),
+        );
+
+        for (const arg of problematicArguments) {
+          context.report({
+            message: `{% content_for "block" %} only accepts 'id', 'type' and 'context.*' arguments`,
+            startIndex: arg.position.start,
+            endIndex: arg.position.end,
+          });
+        }
+      },
+    };
+
+    return {
+      async LiquidTag(node) {
+        if (node.name !== 'content_for' || typeof node.markup === 'string') {
+          return;
+        }
+
+        /** "block", "blocks", etc. */
+        const contentForType = node.markup.contentForType.value;
+        const validate = validationStrategies[contentForType as keyof typeof validationStrategies];
+        if (!validate) {
+          return;
+        }
+
+        validate(node.markup);
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/valid-static-block-type/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-static-block-type/index.spec.ts
@@ -1,6 +1,6 @@
-import { expect, describe, it } from 'vitest';
-import { check, MockTheme, runLiquidCheck } from '../../test';
-import { SchemaProp } from '../../types';
+import { describe, expect, it } from 'vitest';
+import { check, MockTheme } from '../../test';
+import { ValidStaticBlockType } from '.';
 
 describe('Module: ValidStaticBlockType', () => {
   const genericThemeBlock = {
@@ -30,11 +30,9 @@ describe('Module: ValidStaticBlockType', () => {
     expect(offenses).toHaveLength(0);
   });
 
-  it('should report a offense if type is invalid', async () => {
+  it('should report an offense if type is invalid', async () => {
     const offenses = await check(invalidExtensionFiles);
     expect(offenses).toHaveLength(1);
-    expect(offenses[0].message).to.equal(
-      "The type 'invalid' is not valid, use a type that exists in the blocks directory",
-    );
+    expect(offenses[0].message).to.equal("'blocks/invalid.liquid' does not exist");
   });
 });

--- a/packages/theme-check-common/src/test/MockFileSystem.ts
+++ b/packages/theme-check-common/src/test/MockFileSystem.ts
@@ -30,7 +30,7 @@ export class MockFileSystem implements AbstractFileSystem {
         ? this.fileTree
         : deepGet(this.fileTree, relativePath.split('/'));
     if (tree === undefined) {
-      throw new Error('Directory not found');
+      throw new Error(`Directory not found: ${uri}`);
     }
 
     if (typeof tree === 'string') {

--- a/packages/theme-check-common/src/utils/markup.ts
+++ b/packages/theme-check-common/src/utils/markup.ts
@@ -1,7 +1,10 @@
-export function isContentForBlock(nodeMarkup: string) {
-  const [blockType] = nodeMarkup.split(',');
-  if (blockType.replace(/["']/g, '') !== 'block') {
+import { ContentForMarkup } from '@shopify/liquid-html-parser';
+
+export function isContentForBlock(
+  nodeMarkup: string | ContentForMarkup,
+): nodeMarkup is ContentForMarkup {
+  if (typeof nodeMarkup === 'string') {
     return false;
   }
-  return true;
+  return nodeMarkup.contentForType.value === 'block';
 }

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -97,6 +97,9 @@ UnknownFilter:
 UnusedAssign:
   enabled: true
   severity: 1
+ValidContentForArguments:
+  enabled: true
+  severity: 0
 ValidHTMLTranslation:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -78,6 +78,9 @@ UnknownFilter:
 UnusedAssign:
   enabled: true
   severity: 1
+ValidContentForArguments:
+  enabled: true
+  severity: 0
 ValidHTMLTranslation:
   enabled: true
   severity: 1

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
@@ -128,6 +128,20 @@ describe('Module: LiquidCompletionParams', async () => {
         }
       });
 
+      it(`returns a String node when you're in the middle of it`, async () => {
+        const contexts = [
+          `{% render '█' %}`,
+          `{% render 'snip', var: '█' %}`,
+          `{% content_for '█' %}`,
+          `{% content_for 'block', id: '█' %}`,
+        ];
+        for (const context of contexts) {
+          const { completionContext } = createLiquidParamsFromContext(context);
+          const { node } = completionContext!;
+          expectPath(node, 'type', context).to.eql('String');
+        }
+      });
+
       it('returns a tag', async () => {
         const contexts = [
           `{% t█ %}`,
@@ -172,6 +186,7 @@ describe('Module: LiquidCompletionParams', async () => {
           `{% cycle a█ %}`,
           `{% cycle 'foo', a█ %}`,
           `{% cycle 'foo': a█ %}`,
+          `{% content_for 'foo', v: █ %}`,
           `{% render 'snip', var: a█ %}`,
           `{% render 'snip' for col█ as item %}`,
           `{% render 'snip' with object█ as name %}`,
@@ -224,6 +239,7 @@ describe('Module: LiquidCompletionParams', async () => {
           `{% cycle █ %}`,
           `{% cycle 'foo', █ %}`,
           `{% cycle 'foo': █ %}`,
+          `{% content_for 'snip', var: █ %}`,
           `{% render 'snip', var: █ %}`,
           `{% render 'snip' for █ as item %}`,
           `{% render 'snip' with █ as name %}`,

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -363,11 +363,23 @@ function findCurrentNode(
         break;
       }
 
+      case NodeTypes.ContentForMarkup: {
+        if (isNotEmpty(current.args)) {
+          finder.current = last(current.args);
+        } else if (isCovered(cursor, current.contentForType.position)) {
+          finder.current = current.contentForType;
+        }
+
+        break;
+      }
+
       case NodeTypes.RenderMarkup: {
         if (isNotEmpty(current.args)) {
           finder.current = last(current.args);
         } else if (current.variable && isCovered(cursor, current.variable.position)) {
           finder.current = current.variable;
+        } else if (current.snippet && isCovered(cursor, current.snippet.position)) {
+          finder.current = current.snippet;
         }
 
         break;

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.ts
@@ -11,14 +11,20 @@ export class RenderSnippetCompletionProvider implements Provider {
   async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
     if (!params.completionContext) return [];
 
-    const { node } = params.completionContext;
+    const { node, ancestors } = params.completionContext;
+    const parentNode = ancestors.at(-1);
 
-    if (!node || node.type !== NodeTypes.RenderMarkup || node.snippet.type !== NodeTypes.String) {
+    if (
+      !node ||
+      !parentNode ||
+      node.type !== NodeTypes.String ||
+      parentNode.type !== NodeTypes.RenderMarkup
+    ) {
       return [];
     }
 
     const options = await this.getSnippetNamesForURI(params.textDocument.uri);
-    const partial = node.snippet.value;
+    const partial = node.value;
 
     return options
       .filter((option) => option.startsWith(partial))


### PR DESCRIPTION
Fixes #466

## What are you adding in this PR?

- Add parser support for the `content_for` tag
- Updated the old `content_for` checks to use the AST rather than regexes to perform their work
- Add prettier plugin support for the `content_for` tag
- Add the `ValidContentForArguments` check
  - For `{% content_for "blocks" %}`
    - Only `context.*` arguments are accepted
  - For `{% content_for "block" %}`
    - `type` and `id` are required
    - `type` and `id` must be strings
    - `context.*` arguments are optional
    - nothing else is accepted

## What's next? Any followup issues?

- [ ] Document `ValidContentForArguments` on shopify.dev
- [x] #569 
- [x] #570
- [x] #571 

## What did you learn?

There were more things I needed to change than I remembered. TypeScript helps a ton here because it complains any time you add a new node type.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
