### PR TITLE
Add "block" or "blocks" completion for the `content_for` Liquid tag

### DIFF
--- a/.changeset/quick-jobs-clean.md
+++ b/.changeset/quick-jobs-clean.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Add "block" or "blocks" completion for the `content_for` Liquid tag

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -6,6 +6,7 @@ import { GetThemeSettingsSchemaForURI } from '../settings';
 import { GetTranslationsForURI } from '../translations';
 import { createLiquidCompletionParams } from './params';
 import {
+  ContentForBlockCompletionProvider,
   FilterCompletionProvider,
   HtmlAttributeCompletionProvider,
   HtmlAttributeValueCompletionProvider,
@@ -54,6 +55,7 @@ export class CompletionsProvider {
     );
 
     this.providers = [
+      new ContentForBlockCompletionProvider(),
       new HtmlTagCompletionProvider(),
       new HtmlAttributeCompletionProvider(documentManager),
       new HtmlAttributeValueCompletionProvider(),

--- a/packages/theme-language-server-common/src/completions/providers/ContentForBlockCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForBlockCompletionProvider.spec.ts
@@ -1,0 +1,26 @@
+import { describe, beforeEach, it, expect } from "vitest";
+import { CompletionsProvider } from "../CompletionsProvider";
+import { DocumentManager } from "../../documents";
+import { MetafieldDefinitionMap } from "@shopify/theme-check-common";
+
+describe('Module: ContentForBlockCompletionProvider', async () => {
+  let provider: CompletionsProvider;
+
+  beforeEach(async () => {
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    });
+  });
+
+  it('should complete content_for block keywords correctly', async () => {
+    const expected = ['block', 'blocks'].sort();
+    await expect(provider).to.complete('{% content_for "█" %}', expected);
+  });
+});

--- a/packages/theme-language-server-common/src/completions/providers/ContentForBlockCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForBlockCompletionProvider.ts
@@ -1,0 +1,39 @@
+import { NodeTypes } from '@shopify/liquid-html-parser';
+import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
+import { LiquidCompletionParams } from '../params';
+import { Provider } from './common';
+
+export class ContentForBlockCompletionProvider implements Provider {
+  constructor() {}
+
+  async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
+    if (!params.completionContext) return [];
+
+    const { node, ancestors } = params.completionContext;
+    const parentNode = ancestors.at(-1);
+
+    if (
+      !node ||
+      !parentNode ||
+      node.type !== NodeTypes.String ||
+      parentNode.type !== NodeTypes.ContentForMarkup) {
+      return [];
+    }
+
+    const options = ['block', 'blocks'];
+    const partial = node.value;
+
+    return options
+      .filter((keyword) => keyword.startsWith(partial))
+      .map(
+        (keyword: string): CompletionItem => ({
+          label: keyword,
+          kind: CompletionItemKind.Keyword,
+          documentation: {
+            kind: 'markdown',
+            value: `content_for ${keyword}`,
+          },
+        }),
+      );
+  }
+}

--- a/packages/theme-language-server-common/src/completions/providers/index.ts
+++ b/packages/theme-language-server-common/src/completions/providers/index.ts
@@ -1,3 +1,4 @@
+export { ContentForBlockCompletionProvider } from './ContentForBlockCompletionProvider';
 export { HtmlTagCompletionProvider } from './HtmlTagCompletionProvider';
 export { HtmlAttributeCompletionProvider } from './HtmlAttributeCompletionProvider';
 export { HtmlAttributeValueCompletionProvider } from './HtmlAttributeValueCompletionProvider';


### PR DESCRIPTION
## What are you adding in this PR?
- [x] #569

Added `ContentForBlockCompletionProvider` and `ContentForBlockCompletionProvider.spec.ts` to support `content_for` "block" or "blocks" completion.

## What did you learn?
Learnt some bit about completion.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible