### PR TITLE
Do not activate for non-theme-{json,liquid} files

### DIFF
--- a/.changeset/breezy-walls-bake.md
+++ b/.changeset/breezy-walls-bake.md
@@ -1,0 +1,5 @@
+---
+'theme-check-vscode': patch
+---
+
+Do not activate language server for non-theme files

--- a/packages/vscode-extension/src/browser/extension.ts
+++ b/packages/vscode-extension/src/browser/extension.ts
@@ -1,9 +1,14 @@
 /// <reference lib="webworker" />
 import { FileStat, FileTuple, path } from '@shopify/theme-check-common';
 import { commands, ExtensionContext, languages, Uri, workspace } from 'vscode';
-import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient/browser';
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  DocumentSelector,
+} from 'vscode-languageclient/browser';
 import LiquidFormatter from '../common/formatter';
 import { vscodePrettierFormat } from './formatter';
+import { documentSelectors } from '../common/constants';
 
 const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
@@ -39,16 +44,7 @@ export function deactivate() {
 async function startServer(context: ExtensionContext) {
   console.log('Starting Theme Check Language Server');
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-      { language: 'liquid' },
-      { language: 'plaintext' },
-      { language: 'html' },
-      { language: 'javascript' },
-      { language: 'css' },
-      { language: 'scss' },
-      { language: 'json' },
-      { language: 'jsonc' },
-    ],
+    documentSelector: documentSelectors as DocumentSelector,
   };
 
   client = createWorkerLanguageClient(context, clientOptions);

--- a/packages/vscode-extension/src/common/constants.ts
+++ b/packages/vscode-extension/src/common/constants.ts
@@ -1,0 +1,14 @@
+import { DocumentSelector } from 'vscode';
+
+/**
+ * The document selectors is the list of documents for which vscode needs to send requests/notifications to the language server.
+ *
+ * We specifically don't want to answer completion requests in package.json files and so on.
+ *
+ * Nor do we want to handle js,css,scss liquid files.
+ */
+export const documentSelectors: DocumentSelector = [
+  { language: 'liquid', pattern: '**/*.liquid' },
+  { language: 'json', pattern: '**/{config,locales,sections,templates}/**/*.json' },
+  { language: 'jsonc', pattern: '**/{config,locales,sections,templates}/**/*.json' },
+];

--- a/packages/vscode-extension/src/node/extension.ts
+++ b/packages/vscode-extension/src/node/extension.ts
@@ -2,11 +2,13 @@ import { FileStat, FileTuple, path as pathUtils } from '@shopify/theme-check-com
 import * as path from 'node:path';
 import { commands, ExtensionContext, languages, Uri, workspace } from 'vscode';
 import {
+  DocumentSelector,
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
   TransportKind,
 } from 'vscode-languageclient/node';
+import { documentSelectors } from '../common/constants';
 import LiquidFormatter from '../common/formatter';
 import { vscodePrettierFormat } from './formatter';
 
@@ -50,16 +52,7 @@ async function startServer(context: ExtensionContext) {
   }
 
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-      { language: 'liquid' },
-      { language: 'plaintext' },
-      { language: 'html' },
-      { language: 'javascript' },
-      { language: 'css' },
-      { language: 'scss' },
-      { language: 'json' },
-      { language: 'jsonc' },
-    ],
+    documentSelector: documentSelectors as DocumentSelector,
   };
 
   client = new LanguageClient(


### PR DESCRIPTION

## What are you adding in this PR?

I wrote this thing 3 or 4 years ago without really understanding what I was doing.

The DocumentSelector is what the client uses to tell if it should send requests/notifications to the language server for a given file.

We were sending messages for files that were not supported by us. `package.json` and so on were sent to the language server and we weren't even sure they were theme files.

Fixes #576

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
