### PR TITLE
Verify schema name translation

### DIFF
--- a/.changeset/nervous-brooms-invite.md
+++ b/.changeset/nervous-brooms-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Add translation checking to `ValidSchemaName` check

--- a/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { highlightedOffenses, runLiquidCheck } from '../../test';
+import { highlightedOffenses, runLiquidCheck, check } from '../../test';
 import { ValidSchemaName } from './index';
 
 const DEFAULT_FILE_NAME = 'sections/file.liquid';
@@ -16,10 +16,70 @@ describe('Module: ValidSchemaName', () => {
 
     const offenses = await runLiquidCheck(ValidSchemaName, sourceCode, DEFAULT_FILE_NAME);
     expect(offenses).toHaveLength(1);
-    expect(offenses[0].message).toEqual('Schema name is too long (max 25 characters)');
+    expect(offenses[0].message).toEqual(
+      "Schema name 'test-schema-name-that-is-too-long' is too long (max 25 characters)",
+    );
 
     const highlights = highlightedOffenses({ [DEFAULT_FILE_NAME]: sourceCode }, offenses);
     expect(highlights).to.have.length(1);
     expect(highlights[0]).toBe('"test-schema-name-that-is-too-long"');
+  });
+
+  it('reports no offenses with schema name translation that exists and is not over 25 chars long', async () => {
+    const offenses = await check(
+      {
+        'locales/en.default.schema.json': '{ "my_translation_key": "My translation is good."}',
+        'code.liquid': `
+          {% schema %}
+            {
+              "name": "t:my_translation_key"
+        } 
+      {% endschema %}`,
+      },
+      [ValidSchemaName],
+    );
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports an offense with schema name translation is missing', async () => {
+    const offenses = await check(
+      {
+        'locales/en.default.schema.json': '{ "another_translation_key": "Another translation"}',
+        'code.liquid': `
+          {% schema %}
+            {
+              "name": "t:my_translation_key"
+            } 
+          {% endschema %}`,
+      },
+      [ValidSchemaName],
+    );
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual(
+      "'t:my_translation_key' does not have a matching entry in 'locales/en.default.schema.json'",
+    );
+  });
+
+  it('reports an offense with schema name translation that exists and is over 25 chars long', async () => {
+    const offenses = await check(
+      {
+        'locales/en.default.schema.json':
+          '{ "my_translation_key": "My translation is tooooooooo long."}',
+        'code.liquid': `
+          {% schema %}
+            {
+              "name": "t:my_translation_key"
+            } 
+          {% endschema %}`,
+      },
+      [ValidSchemaName],
+    );
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual(
+      "Schema name 'My translation is tooooooooo long.' from 'locales/en.default.schema.json' is too long (max 25 characters)",
+    );
   });
 });

--- a/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
@@ -28,11 +28,12 @@ describe('Module: ValidSchemaName', () => {
   it('reports no offenses with schema name translation that exists and is not over 25 chars long', async () => {
     const offenses = await check(
       {
-        'locales/en.default.schema.json': '{ "my_translation_key": "My translation is good."}',
+        'locales/en.default.schema.json':
+          '{ "default": { "my_translation_key": "My translation is good."}}',
         'code.liquid': `
           {% schema %}
             {
-              "name": "t:my_translation_key"
+              "name": "t:default.my_translation_key"
         } 
       {% endschema %}`,
       },

--- a/packages/theme-check-common/src/checks/valid-schema-name/index.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-name/index.ts
@@ -1,8 +1,8 @@
-import { JSONNode, LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { LiteralNode, ValueNode } from 'json-to-ast';
+import { parseJSON } from '../../json';
 import { toJSONAST } from '../../to-source-code';
+import { JSONNode, LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { visit } from '../../visitor';
-import { LiteralNode } from 'json-to-ast';
-import { ValueNode } from 'json-to-ast';
 
 const MAX_SCHEMA_NAME_LENGTH = 25;
 const ROOT_NODE_ANCESTORS_COUNT = 1;
@@ -14,7 +14,7 @@ export const ValidSchemaName: LiquidCheckDefinition = {
     docs: {
       description: 'This check is aimed at ensuring a valid schema name.',
       recommended: true,
-      url: 'https://shopify.dev/docs/storefronts/thesadmes/tools/theme-check/checks/valid-schema-name',
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-schema-name',
     },
     type: SourceCodeType.LiquidHtml,
     severity: Severity.ERROR,
@@ -35,28 +35,53 @@ export const ValidSchemaName: LiquidCheckDefinition = {
         );
 
         const jsonSchemaAst = toJSONAST(jsonSchemaString);
-        visit<SourceCodeType.JSON, void>(jsonSchemaAst as JSONNode, {
-          Property(nameNode, ancestors) {
+
+        const promises = visit<SourceCodeType.JSON, Promise<void>>(jsonSchemaAst as JSONNode, {
+          async Property(nameNode, ancestors) {
             if (
               nameNode.key.value === 'name' &&
               ancestors.length === ROOT_NODE_ANCESTORS_COUNT &&
               isLiteralNode(nameNode.value)
             ) {
               const name = getLiteralValue(nameNode.value);
+              const startIndex = node.blockStartPosition.end + getLiteralLocStart(nameNode.value);
+              const endIndex = node.blockStartPosition.end + getLiteralLocEnd(nameNode.value);
 
-              // We will be handling the translation length in a follow up
               if (!name.startsWith('t:') && name.length > MAX_SCHEMA_NAME_LENGTH) {
-                const startIndex = node.blockStartPosition.end + getLiteralLocStart(nameNode.value);
-                const endIndex = node.blockStartPosition.end + getLiteralLocEnd(nameNode.value);
                 context.report({
-                  message: 'Schema name is too long (max 25 characters)',
+                  message: `Schema name '${name}' is too long (max 25 characters)`,
                   startIndex: startIndex,
                   endIndex: endIndex,
                 });
               }
+
+              if (name.startsWith('t:')) {
+                const defaultLocale = await context.getDefaultLocale();
+                const key = name.replace('t:', '');
+                const defaultTranslations = await context.getDefaultSchemaTranslations();
+                const translation = getTranslation(key, defaultTranslations);
+
+                if (translation === undefined) {
+                  context.report({
+                    message: `'${name}' does not have a matching entry in 'locales/${defaultLocale}.default.schema.json'`,
+                    startIndex: startIndex,
+                    endIndex: endIndex,
+                  });
+                }
+
+                if (translation !== undefined && translation.length > MAX_SCHEMA_NAME_LENGTH) {
+                  context.report({
+                    message: `Schema name '${translation}' from 'locales/${defaultLocale}.default.schema.json' is too long (max 25 characters)`,
+                    startIndex: startIndex,
+                    endIndex: endIndex,
+                  });
+                }
+              }
             }
           },
         });
+
+        await Promise.all(promises);
       },
     };
   },
@@ -79,4 +104,20 @@ function getLiteralLocStart(node: LiteralNode): number {
 
 function getLiteralLocEnd(node: LiteralNode): number {
   return node.loc?.end.offset ?? 0;
+}
+
+function getTranslation(key: string, pointer: any) {
+  for (const token of key.split('.')) {
+    if (typeof pointer !== 'object') {
+      return undefined;
+    }
+
+    if (!pointer.hasOwnProperty(token)) {
+      return undefined;
+    }
+
+    pointer = pointer[token];
+  }
+
+  return pointer; //the last pointer is the translation
 }

--- a/packages/theme-check-common/src/checks/valid-schema-name/index.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-name/index.ts
@@ -1,5 +1,5 @@
+import { deepGet } from '../../utils/file-utils';
 import { LiteralNode, ValueNode } from 'json-to-ast';
-import { parseJSON } from '../../json';
 import { toJSONAST } from '../../to-source-code';
 import { JSONNode, LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { visit } from '../../visitor';
@@ -59,7 +59,7 @@ export const ValidSchemaName: LiquidCheckDefinition = {
                 const defaultLocale = await context.getDefaultLocale();
                 const key = name.replace('t:', '');
                 const defaultTranslations = await context.getDefaultSchemaTranslations();
-                const translation = getTranslation(key, defaultTranslations);
+                const translation = deepGet(defaultTranslations, key.split('.'));
 
                 if (translation === undefined) {
                   context.report({
@@ -104,20 +104,4 @@ function getLiteralLocStart(node: LiteralNode): number {
 
 function getLiteralLocEnd(node: LiteralNode): number {
   return node.loc?.end.offset ?? 0;
-}
-
-function getTranslation(key: string, pointer: any) {
-  for (const token of key.split('.')) {
-    if (typeof pointer !== 'object') {
-      return undefined;
-    }
-
-    if (!pointer.hasOwnProperty(token)) {
-      return undefined;
-    }
-
-    pointer = pointer[token];
-  }
-
-  return pointer; //the last pointer is the translation
 }

--- a/packages/theme-check-common/src/test/MockFileSystem.ts
+++ b/packages/theme-check-common/src/test/MockFileSystem.ts
@@ -1,4 +1,5 @@
 import { AbstractFileSystem, FileStat, FileTuple, FileType } from '../AbstractFileSystem';
+import { deepGet } from '../utils/file-utils';
 import { normalize, relative } from '../path';
 import { MockTheme } from './MockTheme';
 
@@ -76,8 +77,4 @@ export class MockFileSystem implements AbstractFileSystem {
   private rootRelative(uri: string) {
     return relative(normalize(uri), this.rootUri);
   }
-}
-
-function deepGet(obj: any, path: string[]): any {
-  return path.reduce((acc, key) => acc?.[key], obj);
 }

--- a/packages/theme-check-common/src/utils/file-utils.ts
+++ b/packages/theme-check-common/src/utils/file-utils.ts
@@ -56,3 +56,7 @@ export async function hasLocalAssetSizeExceededThreshold<
 
   return fileExceedsThreshold;
 }
+
+export function deepGet(obj: any, path: string[]): any {
+  return path.reduce((acc, key) => acc?.[key], obj);
+}


### PR DESCRIPTION
## What are you adding in this PR?
Addresses https://github.com/Shopify/theme-tools/issues/557

We want to verify that the schema name's translation exists, and that its value is less than 25 characters in length. Scope-wise, as aligned with @charlespwd and @albchu, we are doing this check against the default schema translation. 
 
I approached this by doing: if the name starts with `t:`, fetching the default schema translation file and verifying its length.

Video:
https://screenshot.click/12-16-h0bx0-ol5uv.mp4

Follow up:
PR in the `shopify-dev` repo to point out the existence / usage of this check

As a future progressive enhancement, when we can have quick and easy access to all schema locales, it would be great to check all translations for their existence and length.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

Mia's note: I interpreted "changes of the configuration of a check" to include when you add new functionality to a check. LMK if that's not right and I'll remove the changeset file.

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
