### PR TITLE
Preload theme on boot with progress

### DIFF
--- a/.changeset/cuddly-elephants-remember.md
+++ b/.changeset/cuddly-elephants-remember.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Preload theme files on file open instead of on rename

--- a/.changeset/thirty-laws-watch.md
+++ b/.changeset/thirty-laws-watch.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-docs-updater': patch
+'@shopify/theme-check-common': patch
+---
+
+Moving internal methods around

--- a/packages/theme-check-common/src/find-root.ts
+++ b/packages/theme-check-common/src/find-root.ts
@@ -45,6 +45,9 @@ async function not(ap: Promise<boolean>) {
  *
  * So you can think of this function as the function that infers where a .theme-check.yml
  * should be.
+ *
+ * Note: that this is not the theme root. The config file might have a `root` entry in it
+ * that points to somewhere else.
  */
 export async function findRoot(curr: UriString, fileExists: FileExists): Promise<UriString> {
   const currIsRoot = await isRoot(curr, fileExists);

--- a/packages/theme-check-common/src/test/MockFileSystem.ts
+++ b/packages/theme-check-common/src/test/MockFileSystem.ts
@@ -30,7 +30,7 @@ export class MockFileSystem implements AbstractFileSystem {
         ? this.fileTree
         : deepGet(this.fileTree, relativePath.split('/'));
     if (tree === undefined) {
-      throw new Error(`Directory not found: ${uri}`);
+      throw new Error(`Directory not found: ${uri} in ${this.rootUri}`);
     }
 
     if (typeof tree === 'string') {

--- a/packages/theme-check-common/src/utils/memo.ts
+++ b/packages/theme-check-common/src/utils/memo.ts
@@ -46,10 +46,7 @@ export function memo<F extends (...args: any[]) => any>(fn: F): MemoedFunction<F
  * fastOnSubsequentCalls(thing1);
  * fastOnSubsequentCalls(thing1);
  */
-export function memoize<AT, F extends (arg: AT) => any, RT extends ReturnType<F>>(
-  fn: F,
-  keyFn: (arg: AT) => string,
-) {
+export function memoize<AT, RT>(fn: (arg: AT) => RT, keyFn: (arg: AT) => string) {
   const cache: Record<string, RT> = {};
 
   const memoedFunction = (arg: AT): RT => {

--- a/packages/theme-check-docs-updater/src/utils.ts
+++ b/packages/theme-check-docs-updater/src/utils.ts
@@ -1,6 +1,3 @@
-import { Resource, downloadResource } from './themeLiquidDocsDownloader';
-import { root } from './themeLiquidDocsDownloader';
-
 export type Logger = (message: string) => void;
 export const noop = () => {};
 
@@ -12,46 +9,4 @@ export const tap = <T>(tappingFunction: (x: T) => void) => {
   };
 };
 
-/** Returns a cached version of a function. Only caches one result. */
-export function memo<F extends (...args: any[]) => any>(
-  fn: F,
-): (...args: ArgumentTypes<F>) => ReturnType<F> {
-  let cachedValue: ReturnType<F>;
-
-  return (...args: ArgumentTypes<F>) => {
-    if (!cachedValue) {
-      cachedValue = fn(...args);
-    }
-    return cachedValue;
-  };
-}
-
-export function memoize<AT, F extends (arg: AT) => any, RT extends ReturnType<F>>(
-  fn: F,
-  keyFn: (arg: AT) => string,
-) {
-  const cache: Record<string, RT> = {};
-
-  return (arg: AT): RT => {
-    const key = keyFn(arg);
-
-    if (!cache[key]) {
-      cache[key] = fn(arg);
-    }
-
-    return cache[key];
-  };
-}
-
-/**
- * ArgumentTypes extracts the type of the arguments of a function.
- *
- * @example
- *
- * function doStuff(a: number, b: string) {
- *   // do stuff
- * }
- *
- * type DoStuffArgs = ArgumentTypes<typeof doStuff> // = [number, string].
- */
-type ArgumentTypes<F extends Function> = F extends (...args: infer T) => void ? T : never;
+export { memo, memoize } from '@shopify/theme-check-common';

--- a/packages/theme-language-server-common/src/ClientCapabilities.ts
+++ b/packages/theme-language-server-common/src/ClientCapabilities.ts
@@ -35,6 +35,10 @@ export class ClientCapabilities {
     return !!this.capabilities?.window?.showDocument;
   }
 
+  get hasProgressSupport() {
+    return !!this.capabilities?.window?.workDoneProgress;
+  }
+
   initializationOption<T>(key: string, defaultValue: T): T {
     // { 'themeCheck.checkOnSave': true }
     const direct = this.initializationOptions?.[key];

--- a/packages/theme-language-server-common/src/documents/DocumentManager.spec.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.spec.ts
@@ -1,10 +1,13 @@
 import { path } from '@shopify/theme-check-common';
 import { MockFileSystem } from '@shopify/theme-check-common/src/test';
-import { assert, beforeEach, describe, expect, it } from 'vitest';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { URI, Utils } from 'vscode-uri';
 import { DocumentManager } from './DocumentManager';
+import { mockConnection } from '../test/MockConnection';
+import { ClientCapabilities } from '../ClientCapabilities';
 
 describe('Module: DocumentManager', () => {
+  const mockRoot = 'mock-fs:';
   let documentManager: DocumentManager;
 
   beforeEach(() => {
@@ -38,6 +41,7 @@ describe('Module: DocumentManager', () => {
         'mock-fs:',
       );
       documentManager = new DocumentManager(fs);
+      vi.spyOn(fs, 'readFile');
       await documentManager.preload('mock-fs:/');
     });
 
@@ -64,17 +68,118 @@ describe('Module: DocumentManager', () => {
         const theme = documentManager.theme('mock-fs:/', true);
         expect(theme).to.have.lengthOf(2);
       });
+    });
 
-      it('is possible to remove files from the cache after preload', async () => {
+    describe('Unit: close(uri)', () => {
+      it('sets the source version to undefined (value is on disk)', () => {
+        documentManager.open('mock-fs:/snippet/foo.liquid', 'hello {% render "bar" %}', 10);
         documentManager.close('mock-fs:/snippet/foo.liquid');
-        const theme = documentManager.theme('mock-fs:/', true);
-        expect(theme).to.have.lengthOf(1);
+        const sc = documentManager.get('mock-fs:/snippet/foo.liquid');
+        assert(sc);
+        expect(sc.source).to.equal('hello {% render "bar" %}');
+        expect(sc.version).to.equal(undefined);
+      });
+    });
+
+    describe('Unit: delete(uri)', () => {
+      it('deletes the source code from the document manager', () => {
+        // as though the file no longer exists
+        documentManager.open('mock-fs:/snippet/foo.liquid', 'hello {% render "bar" %}', 10);
+        documentManager.delete('mock-fs:/snippet/foo.liquid');
+        const sc = documentManager.get('mock-fs:/snippet/foo.liquid');
+        assert(!sc);
+      });
+    });
+
+    describe('Unit: preload(rootUri)', () => {
+      it('should be memoized and only run once', async () => {
+        await documentManager.preload('mock-fs:/');
+        await documentManager.preload('mock-fs:/');
+        await documentManager.preload('mock-fs:/');
+        await documentManager.preload('mock-fs:/');
+        expect(vi.mocked(fs.readFile)).toHaveBeenCalledTimes(
+          documentManager.theme('mock-fs:/', true).length,
+        );
       });
 
-      it('is possible to remove files from the cache after preload', async () => {
-        documentManager.delete('mock-fs:/snippet/foo.liquid');
-        const theme = documentManager.theme('mock-fs:/', true);
-        expect(theme).to.have.lengthOf(1);
+      describe('When initialized with a connection & hasProgressSupport', () => {
+        let connection: ReturnType<typeof mockConnection>;
+
+        beforeEach(() => {
+          const capabilities = new ClientCapabilities();
+          capabilities.setup({
+            window: {
+              workDoneProgress: true,
+            },
+          });
+          connection = mockConnection(mockRoot);
+          connection.spies.onRequest.mockImplementationOnce(async (method) => {
+            switch (method) {
+              case 'window/workDoneProgress/create':
+                return 'ok';
+              default:
+                throw new Error(`Unexpected method: ${method}`);
+            }
+          });
+
+          fs = new MockFileSystem(
+            {
+              'snippet/1.liquid': `hello {% render 'bar' %}`,
+              'snippet/2.liquid': `hello {% render 'bar' %}`,
+              'snippet/3.liquid': `hello {% render 'bar' %}`,
+              'snippet/4.liquid': `hello {% render 'bar' %}`,
+              'snippet/5.liquid': `hello {% render 'bar' %}`,
+              'snippet/6.liquid': `hello {% render 'bar' %}`,
+              'snippet/7.liquid': `hello {% render 'bar' %}`,
+              'snippet/8.liquid': `hello {% render 'bar' %}`,
+              'snippet/9.liquid': `hello {% render 'bar' %}`,
+              'snippet/10.liquid': `hello {% render 'bar' %}`,
+            },
+            mockRoot,
+          );
+          vi.spyOn(fs, 'readFile');
+
+          documentManager = new DocumentManager(fs, connection, capabilities);
+        });
+
+        it('should report progress while preloading', async () => {
+          await documentManager.preload(mockRoot);
+          expect(connection.spies.sendProgress).toHaveBeenCalledTimes(4);
+          expect(connection.spies.sendProgress).toHaveBeenCalledWith(
+            expect.anything(),
+            'preload#mock-fs:',
+            {
+              kind: 'begin',
+              title: 'Initializing Liquid LSP',
+            },
+          );
+          expect(connection.spies.sendProgress).toHaveBeenCalledWith(
+            expect.anything(),
+            'preload#mock-fs:',
+            {
+              kind: 'report',
+              message: 'Preloading files',
+              percentage: 10,
+            },
+          );
+          expect(connection.spies.sendProgress).toHaveBeenCalledWith(
+            expect.anything(),
+            'preload#mock-fs:',
+            {
+              kind: 'report',
+              message: 'Preloading files [10/10]',
+              percentage: 100,
+            },
+          );
+          expect(connection.spies.sendProgress).toHaveBeenCalledWith(
+            expect.anything(),
+            'preload#mock-fs:',
+            {
+              kind: 'end',
+              message: 'Completed',
+            },
+          );
+        });
       });
     });
   });

--- a/packages/theme-language-server-common/src/documents/DocumentManager.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.ts
@@ -1,18 +1,22 @@
 import {
   AbstractFileSystem,
+  memoize,
   path,
   recursiveReadDirectory,
   SourceCode,
   SourceCodeType,
   Theme,
   toSourceCode,
+  UriString,
 } from '@shopify/theme-check-common';
+import { Connection } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { URI } from 'vscode-languageserver-types';
+import { ClientCapabilities } from '../ClientCapabilities';
+import { percent as percent, Progress } from '../progress';
 
 export type AugmentedSourceCode<SCT extends SourceCodeType = SourceCodeType> = SourceCode<SCT> & {
   textDocument: TextDocument;
-  uri: URI;
+  uri: UriString;
 };
 
 export type AugmentedLiquidSourceCode = AugmentedSourceCode<SourceCodeType.LiquidHtml>;
@@ -27,31 +31,48 @@ export class DocumentManager {
    * Files that are opened in the editor have a defined version, while files that
    * are preloaded have a version of `undefined`.
    */
-  private sourceCodes: Map<URI, AugmentedSourceCode>;
+  private sourceCodes: Map<UriString, AugmentedSourceCode>;
   private readonly fs: AbstractFileSystem | undefined;
+  private readonly connection: Connection | undefined;
+  private readonly clientCapabilities: ClientCapabilities | undefined;
 
-  constructor(fs?: AbstractFileSystem) {
+  constructor(
+    fs?: AbstractFileSystem,
+    connection?: Connection,
+    clientCapabilities?: ClientCapabilities,
+  ) {
     this.sourceCodes = new Map();
     this.fs = fs;
+    this.connection = connection;
+    this.clientCapabilities = clientCapabilities;
   }
 
-  public open(uri: URI, source: string, version: number | undefined) {
+  public open(uri: UriString, source: string, version: number | undefined) {
     return this.set(uri, source, version);
   }
 
-  public change(uri: URI, source: string, version: number | undefined) {
+  public change(uri: UriString, source: string, version: number | undefined) {
     return this.set(uri, source, version);
   }
 
-  public close(uri: URI) {
+  public close(uri: UriString) {
+    const sourceCode = this.sourceCodes.get(uri);
+    if (!sourceCode) return;
+    return this.set(uri, sourceCode.source, undefined);
+  }
+
+  public delete(uri: UriString) {
     return this.sourceCodes.delete(uri);
   }
 
-  public delete(uri: URI) {
-    return this.sourceCodes.delete(uri);
+  public rename(oldUri: UriString, newUri: UriString) {
+    const sourceCode = this.sourceCodes.get(oldUri);
+    if (!sourceCode) return;
+    this.sourceCodes.delete(oldUri);
+    this.set(newUri, sourceCode.source, sourceCode.version);
   }
 
-  public theme(root: URI, includeFilesFromDisk = false): AugmentedSourceCode[] {
+  public theme(root: UriString, includeFilesFromDisk = false): AugmentedSourceCode[] {
     return [...this.sourceCodes.values()]
       .filter((sourceCode) => sourceCode.uri.startsWith(root))
       .filter(
@@ -63,11 +84,15 @@ export class DocumentManager {
     return [...this.sourceCodes.values()].filter((sourceCode) => sourceCode.version !== undefined);
   }
 
-  public get(uri: URI) {
+  public get(uri: UriString) {
     return this.sourceCodes.get(path.normalize(uri));
   }
 
-  private set(uri: URI, source: string, version: number | undefined) {
+  public has(uri: UriString) {
+    return this.sourceCodes.has(path.normalize(uri));
+  }
+
+  private set(uri: UriString, source: string, version: number | undefined) {
     uri = path.normalize(uri);
     // We only support json and liquid files.
     if (!/\.(json|liquid)$/.test(uri) || /\.(s?css|js).liquid$/.test(uri)) {
@@ -93,15 +118,41 @@ export class DocumentManager {
    *
    * Files that are loaded from the AbstractFileSystem will have a version of `undefined`.
    */
-  public async preload(rootUri: URI) {
-    if (!this.fs) throw new Error('Cannot call preload without a FileSystem');
-    const missingFiles = await recursiveReadDirectory(
-      this.fs,
-      rootUri,
-      ([uri]) => /.(liquid|json)$/.test(uri) && !this.sourceCodes.has(uri),
-    );
-    await Promise.all(
-      missingFiles.map(async (file) => this.set(file, await this.fs!.readFile(file), undefined)),
-    );
-  }
+  public preload = memoize(
+    async (rootUri: UriString) => {
+      if (!this.fs) throw new Error('Cannot call preload without a FileSystem');
+      const { fs, connection, clientCapabilities } = this;
+      const progress = Progress.create(connection, clientCapabilities, `preload#${rootUri}`);
+
+      progress.start('Initializing Liquid LSP');
+
+      // We'll only load the files that aren't already in the store. No need to
+      // parse a file we already parsed.
+      const filesToLoad = await recursiveReadDirectory(
+        this.fs,
+        rootUri,
+        ([uri]) => /.(liquid|json)$/.test(uri) && !this.sourceCodes.has(uri),
+      );
+
+      progress.report(10, 'Preloading files');
+
+      let [i, n] = [0, filesToLoad.length];
+      await Promise.all(
+        filesToLoad.map(async (file) => {
+          // This is what is important, we are loading the file from the file system
+          // And setting their initial version to `undefined` to mean "on disk".
+          this.set(file, await fs.readFile(file), undefined);
+
+          // This is just doing progress reporting
+          if (++i % 10 === 0) {
+            const message = `Preloading files [${i}/${n}]`;
+            progress.report(percent(i, n, 10), message);
+          }
+        }),
+      );
+
+      progress.end('Completed');
+    },
+    (rootUri) => rootUri,
+  );
 }

--- a/packages/theme-language-server-common/src/progress.ts
+++ b/packages/theme-language-server-common/src/progress.ts
@@ -1,0 +1,83 @@
+import { Connection } from 'vscode-languageserver';
+import { WorkDoneProgress, WorkDoneProgressCreateRequest } from 'vscode-languageserver-protocol';
+import { ClientCapabilities } from './ClientCapabilities';
+
+export interface IProgress {
+  start(title: string, initialMessage?: string): Promise<void>;
+  report(percentage?: number, message?: string): Promise<void>;
+  end(message?: string): Promise<void>;
+}
+
+/**
+ * A short hand for handling progress reporting to the language client.
+ *
+ * It handles all the LSP protocol details for you.
+ *
+ * @example
+ * const progress = Progress.create(connection, capabilities, progressToken);
+ * await progress.start('Starting progress');
+ * await progress.report(50, 'Halfway there');
+ * await progress.end('Finished');
+ */
+export class Progress {
+  constructor(private connection: Connection, private progressToken: string) {}
+
+  static create(
+    connection: Connection | undefined,
+    capabilities: ClientCapabilities | undefined,
+    progressToken: string,
+  ): IProgress {
+    if (!connection || !capabilities || !capabilities.hasProgressSupport) {
+      // If you don't have a connection, we give you a mock that doesn't do anything.
+      return {
+        start: async () => {},
+        report: async () => {},
+        end: async () => {},
+      } as IProgress;
+    }
+    return new Progress(connection!, progressToken);
+  }
+
+  async start(title: string) {
+    await this.connection.sendRequest(WorkDoneProgressCreateRequest.type, {
+      token: this.progressToken,
+    });
+    await this.connection.sendProgress(WorkDoneProgress.type, this.progressToken, {
+      kind: 'begin',
+      title,
+    });
+  }
+
+  async report(percentage?: number, message?: string) {
+    await this.connection.sendProgress(WorkDoneProgress.type, this.progressToken, {
+      kind: 'report',
+      message,
+      percentage,
+    });
+  }
+
+  async end(message?: string) {
+    await this.connection.sendProgress(WorkDoneProgress.type, this.progressToken, {
+      kind: 'end',
+      message,
+    });
+  }
+}
+
+/**
+ * Given a current/total and an offset, report the percent complete
+ * @param current - number of items processed from total
+ * @param total   - total number of items
+ * @param offset  - offset % to start at
+ *
+ * @example
+ * const offset = 50 // Start at 50%
+ * const current = 0
+ * const total = 100 // files or whatever
+ * percent(0, total, offset)   // 50 %
+ * percent(50, total, offset)  // 75 %
+ * percent(100, total, offset) // 100 %
+ */
+export function percent(current: number, total: number, offset: number = 0) {
+  return Math.round(offset + (current / total) * (100 - offset));
+}

--- a/packages/theme-language-server-common/src/renamed/handlers/AssetRenameHandler.spec.ts
+++ b/packages/theme-language-server-common/src/renamed/handlers/AssetRenameHandler.spec.ts
@@ -10,13 +10,15 @@ import { MockConnection, mockConnection } from '../../test/MockConnection';
 import { RenameHandler } from '../RenameHandler';
 
 describe('Module: AssetRenameHandler', () => {
+  const mockRoot = 'mock-fs:';
+  const findThemeRootURI = async () => mockRoot;
   let capabilities: ClientCapabilities;
   let documentManager: DocumentManager;
   let handler: RenameHandler;
   let connection: MockConnection;
   let fs: MockFileSystem;
   beforeEach(() => {
-    connection = mockConnection();
+    connection = mockConnection(mockRoot);
     connection.spies.sendRequest.mockReturnValue(Promise.resolve(true));
     capabilities = new ClientCapabilities();
     fs = new MockFileSystem(
@@ -25,10 +27,10 @@ describe('Module: AssetRenameHandler', () => {
         'sections/section.liquid': `<script src="{{ 'oldName.js' | asset_url }}" defer></script>`,
         'blocks/block.liquid': `{{ 'oldName.js' | asset_url | script_tag }} oldName.js`,
       },
-      'mock-fs:',
+      mockRoot,
     );
     documentManager = new DocumentManager(fs);
-    handler = new RenameHandler(connection, capabilities, documentManager, makeFileExists(fs));
+    handler = new RenameHandler(connection, capabilities, documentManager, findThemeRootURI);
   });
 
   describe('when the client does not support workspace/applyEdit', () => {
@@ -183,7 +185,7 @@ describe('Module: AssetRenameHandler', () => {
         'mock-fs:',
       );
       documentManager = new DocumentManager(fs);
-      handler = new RenameHandler(connection, capabilities, documentManager, makeFileExists(fs));
+      handler = new RenameHandler(connection, capabilities, documentManager, findThemeRootURI);
 
       await handler.onDidRenameFiles({
         files: [

--- a/packages/theme-language-server-common/src/renamed/handlers/SnippetRenameHandler.spec.ts
+++ b/packages/theme-language-server-common/src/renamed/handlers/SnippetRenameHandler.spec.ts
@@ -10,13 +10,15 @@ import { RenameHandler } from '../RenameHandler';
 import { ClientCapabilities } from '../../ClientCapabilities';
 
 describe('Module: SnippetRenameHandler', () => {
+  const mockRoot = 'mock-fs:';
+  const findThemeRootURI = async () => mockRoot;
   let capabilities: ClientCapabilities;
   let documentManager: DocumentManager;
   let handler: RenameHandler;
   let connection: MockConnection;
   let fs: MockFileSystem;
   beforeEach(() => {
-    connection = mockConnection();
+    connection = mockConnection(mockRoot);
     connection.spies.sendRequest.mockReturnValue(Promise.resolve(true));
     capabilities = new ClientCapabilities();
     fs = new MockFileSystem(
@@ -26,10 +28,10 @@ describe('Module: SnippetRenameHandler', () => {
         'snippets/oldName.liquid': `<div>oldName{%</div>`,
         'snippets/other.liquid': `<div>{% render 'oldName' %}{% render 'other' %}</div>`,
       },
-      'mock-fs:',
+      mockRoot,
     );
     documentManager = new DocumentManager(fs);
-    handler = new RenameHandler(connection, capabilities, documentManager, makeFileExists(fs));
+    handler = new RenameHandler(connection, capabilities, documentManager, findThemeRootURI);
   });
 
   describe('when the client does not support workspace/applyEdit', () => {

--- a/packages/theme-language-server-common/src/test/MockConnection.ts
+++ b/packages/theme-language-server-common/src/test/MockConnection.ts
@@ -14,6 +14,7 @@ import {
   ProtocolConnection,
   WatchDog,
 } from 'vscode-languageserver';
+import { path } from '@shopify/theme-check-common';
 
 type MockConnectionMethods = {
   /** Trigger all appropriate onNotification handlers on the connection */
@@ -70,7 +71,7 @@ function protocolConnection(requests: EventEmitter, notifications: EventEmitter)
   } satisfies ProtocolConnection;
 }
 
-export function mockConnection(): MockConnection {
+export function mockConnection(rootUri: string): MockConnection {
   const watchDog: WatchDog = {
     exit: vi.fn(),
     initialize: vi.fn(),
@@ -115,7 +116,7 @@ export function mockConnection(): MockConnection {
       triggerNotification(DidOpenTextDocumentNotification.type, {
         textDocument: {
           languageId: 'liquid',
-          uri: `browser:/${relativePath}`,
+          uri: path.join(rootUri, relativePath),
           version: 0,
           text,
         },
@@ -125,7 +126,7 @@ export function mockConnection(): MockConnection {
     changeDocument(relativePath, text, version) {
       triggerNotification(DidChangeTextDocumentNotification.type, {
         textDocument: {
-          uri: `browser:/${relativePath}`,
+          uri: path.join(rootUri, relativePath),
           version,
         },
         contentChanges: [
@@ -139,7 +140,7 @@ export function mockConnection(): MockConnection {
     closeDocument(relativePath) {
       triggerNotification(DidCloseTextDocumentNotification.type, {
         textDocument: {
-          uri: `browser:/${relativePath}`,
+          uri: path.join(rootUri, relativePath),
         },
       });
     },
@@ -147,7 +148,7 @@ export function mockConnection(): MockConnection {
     saveDocument(relativePath) {
       triggerNotification(DidSaveTextDocumentNotification.type, {
         textDocument: {
-          uri: `browser:/${relativePath}`,
+          uri: path.join(rootUri, relativePath),
         },
       });
     },


### PR DESCRIPTION
## What are you adding in this PR?

We'll do more stuff like the `{Snippet,Asset}RenameHandler`. We don't want those operations to feel slow the first time it runs.

So as soon as we open a text document in a theme, we'll preload all the files in it.

- Added new helpers in DocumentManager to handle create, delete, rename correctly and prevent requiring preload invalidation.

- Added a `Progress` class to help with progress bars. The LSP stuff feels very heavy and that class makes it a bit cuter/less disruptive in the code. Still gotta do percent calculations (which sucks), but with a couple of comments it ain't so bad.

- Running theme check _after_ the rename handler completes so that we no longer have a race condition that makes it so the file appears to not be there when it is.

Performance wise:
- We'll cache the preload. A theme is only preloaded once per theme root URI.

I'm making this a patch because it's a minor perf improvement and not necessarily something folks should care about externally.

https://github.com/user-attachments/assets/c0a875f7-d98e-4409-9a9d-4c47a5b6d07b




## What did you learn?

- Unit tests in startServer are freaking annoying to write. So much setup. `flushAsync` concerns. Yuk.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
