### PR TITLE
Fix hardcoded `file:` scheme in resolveConfig

### DIFF
--- a/.changeset/modern-squids-wait.md
+++ b/.changeset/modern-squids-wait.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': patch
+'@shopify/theme-check-node': patch
+---
+
+Fix weird root URI loading bug

--- a/packages/theme-check-common/src/path.ts
+++ b/packages/theme-check-common/src/path.ts
@@ -1,36 +1,40 @@
 import { RelativePath, UriString } from './types';
 import { URI, Utils } from 'vscode-uri';
 
-export function relative(uri: UriString, rootUri: UriString): RelativePath {
-  return uri
+export { URI, Utils };
+
+export function relative(uri: UriString | URI, rootUri: UriString): RelativePath {
+  return normalize(uri)
     .replace(rootUri, '')
     .replace(/\\\\/g, '/') // We expect forward slash paths (windows path get normalized)
     .replace(/^\/+/, '');
 }
 
-export function join(rootUri: UriString, ...paths: string[]): string {
-  const root = URI.parse(rootUri);
-  return normalize(Utils.joinPath(root, ...paths));
+export function join(rootUri: UriString | URI, ...paths: string[]): string {
+  return normalize(Utils.joinPath(asUri(rootUri), ...paths));
+}
+
+export function resolve(uri: UriString | URI, path: string): string {
+  return normalize(Utils.resolvePath(asUri(uri), path));
 }
 
 export function normalize(uri: UriString | URI): UriString {
-  if (!URI.isUri(uri)) {
-    uri = URI.parse(uri);
-  }
-  return uri.toString(true);
+  return asUri(uri).toString(true);
 }
 
-export function dirname(uri: UriString): UriString {
-  return normalize(Utils.dirname(URI.parse(uri)));
+export function dirname(uri: UriString | URI): UriString {
+  return normalize(Utils.dirname(asUri(uri)));
 }
 
-export function basename(uri: UriString, ext?: string): string {
-  return URI.parse(uri)
-    .path.split(/(\\|\/)/g)
-    .pop()!
-    .replace(ext ? new RegExp(`${ext}$`) : '', '');
+export function basename(uri: UriString | URI, ext?: string): string {
+  const base = Utils.basename(asUri(uri));
+  return ext ? base.replace(new RegExp(`${ext}$`), '') : base;
 }
 
-export function fsPath(uri: UriString): string {
-  return URI.parse(uri).fsPath;
+export function fsPath(uri: UriString | URI): string {
+  return asUri(uri).fsPath;
+}
+
+function asUri(uri: UriString | URI): URI {
+  return URI.isUri(uri) ? uri : URI.parse(uri);
 }


### PR DESCRIPTION
I think it should have been `'file://' + absolutePath` and is probably the cause of #586.

See the comments in 586 for some details of the investigation.

Can't confirm this fixes it because I couldn't figure out a way to reproduce the issue reported. But given that I know it should have been `file://`, let's see if that fixes it.

might solve #586 ?

## What did you learn?

- I only have a handwavy understanding of how URIs for files work
- I learned a bit of things by [reading the URI spec](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1):
    - A URI has 4 allowed syntaxes (rewritten in ohm syntax)
    
```ohmjs
Uri {
  Uri = scheme ":" hierPart ("?" query)? ("#" fragment)?
  scheme = letter (letter | digit | "-" | "+" | ".")*
  hierPart = 
    | "//" authority pathAbEmpty -- differentRule
    | pathAbsolute 
    | pathRootless
    | pathEmpty
    
  pathAbEmpty = ("/" pathSegment)*
  pathAbsolute = ("/" pathSegment)+
  pathRootless = pathSegment pathAbEmpty
  pathEmpty = "/"
  pathSegment = anyExceptStar<"/">
  authority = userInfo? host port? 
  userInfo = "..." "@"
  port = ":" digit+
  
  // host can be empty!
  host = (alnum | ".")*
 
  query = any* 
  fragment = any*
  
  anyExceptStar<lit> = (~ lit any)*
}
```

Key thing to realize is that you can only start with _one_ or _three_ slashes after the scheme. If you only have 2, then we have a problem.

The `authority` can be the empty string. Which is why `file:///` works.




    
![image](https://github.com/user-attachments/assets/f92f18de-5c78-4df9-b2f5-f4f054be30a4)

          

## Before you deploy

- [x] I included a patch bump `changeset`
