### PR TITLE
[Bug] Fix metafield definition to use `key`

### DIFF
--- a/.changeset/strange-jars-end.md
+++ b/.changeset/strange-jars-end.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+[Bug fix] Metafield definitions should use `namespace.key` for auto-completion

--- a/packages/theme-check-common/src/context-utils.spec.ts
+++ b/packages/theme-check-common/src/context-utils.spec.ts
@@ -20,6 +20,7 @@ describe('Unit: getDefaultLocale', () => {
         '.shopify/metafields.json': JSON.stringify({
           product: [
             {
+              key: 'color',
               name: 'color',
               namespace: 'custom',
               description: 'the color of the product',
@@ -51,6 +52,7 @@ describe('Unit: getDefaultLocale', () => {
 
       expect(definitions.product).toHaveLength(1);
       expect(definitions.product[0]).deep.equals({
+        key: 'color',
         name: 'color',
         namespace: 'custom',
         description: 'the color of the product',

--- a/packages/theme-check-common/src/context-utils.ts
+++ b/packages/theme-check-common/src/context-utils.ts
@@ -192,6 +192,7 @@ export const makeGetMetafieldDefinitions = (fs: AbstractFileSystem) =>
       return FETCHED_METAFIELD_CATEGORIES.reduce((definitions, group) => {
         try {
           definitions[group] = json[group].map((definition: any) => ({
+            key: definition.key,
             name: definition.name,
             namespace: definition.namespace,
             description: definition.description,

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -288,6 +288,7 @@ export type MetafieldDefinitionMap = {
 };
 
 export type MetafieldDefinition = {
+  key: string;
   name: string;
   namespace: string;
   description: string;

--- a/packages/theme-language-server-common/src/TypeSystem.spec.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.spec.ts
@@ -141,6 +141,7 @@ describe('Module: TypeSystem', () => {
           market: [],
           order: [
             {
+              key: 'prods',
               name: 'products',
               namespace: 'related',
               description: 'related products',
@@ -153,6 +154,7 @@ describe('Module: TypeSystem', () => {
           page: [],
           product: [
             {
+              key: 'code',
               name: 'code',
               namespace: 'manufacturer',
               description: 'the code provided by the manufacturer',
@@ -162,6 +164,7 @@ describe('Module: TypeSystem', () => {
               },
             },
             {
+              key: 'id',
               name: 'id',
               namespace: 'manufacturer',
               description: 'the id provided by the manufacturer',
@@ -171,6 +174,7 @@ describe('Module: TypeSystem', () => {
               },
             },
             {
+              key: 'is_rare',
               name: 'is_rare',
               namespace: 'custom',
               description: 'is this product rare?',
@@ -491,7 +495,7 @@ describe('Module: TypeSystem', () => {
 
       expect(relatedProperties).toContainEqual(
         expect.objectContaining({
-          name: 'products',
+          name: 'prods',
           return_type: [{ type: 'metafield_product_array', name: '' }],
         }),
       );

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -202,7 +202,7 @@ export class TypeSystem {
         }
 
         metafieldNamespaces.get(definition.namespace)!.push({
-          name: definition.name,
+          name: definition.key,
           description: definition.description,
           return_type: metafieldReturnType(definition.type.name),
         });

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
@@ -92,6 +92,7 @@ describe('Module: ObjectCompletionProvider', async () => {
           page: [],
           product: [
             {
+              key: 'color',
               name: 'color',
               namespace: 'custom',
               description: 'the color of the product',

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
@@ -110,6 +110,7 @@ describe('Module: LiquidObjectHoverProvider', async () => {
           page: [],
           product: [
             {
+              key: 'color',
               name: 'color',
               namespace: 'custom',
               description: 'the color of the product',


### PR DESCRIPTION
## What are you adding in this PR?

Bug fix: We currently use metafield definition name for auto-completion but should be using `namespace.key`

## Before you deploy

- [x] I included a patch bump `changeset`
