### PR TITLE
Simplify CaptureOnContentForBlock & make it fail when nested

### DIFF
--- a/.changeset/slow-planets-nail.md
+++ b/.changeset/slow-planets-nail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fixup CaptureOnContentForBlock check

--- a/packages/theme-check-common/src/checks/capture-on-content-for-block/index.spec.ts
+++ b/packages/theme-check-common/src/checks/capture-on-content-for-block/index.spec.ts
@@ -18,6 +18,25 @@ describe('Module: ContentForHeaderModification', () => {
     expect(highlights).toEqual(['{% content_for "block", type: "text", id:"static-block-id" %}']);
   });
 
+  it('reports offense with the use of capture (nested)', async () => {
+    const sourceCode = `
+      {% capture x %}
+        <div>
+          {% if cond %}
+            {% content_for "block", type: "text", id:"static-block-id" %}
+          {% endif %}
+        </div>
+      {% endcapture %}
+    `;
+
+    const offenses = await runLiquidCheck(CaptureOnContentForBlock, sourceCode);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual('Do not capture `content_for "block"`');
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights).toEqual(['{% content_for "block", type: "text", id:"static-block-id" %}']);
+  });
+
   it('does not report an offense with normal use', async () => {
     const sourceCode = '{% content_for "block", type: "text", id:"static-block-id" %}';
 


### PR DESCRIPTION
## What are you adding in this PR?

- Simplify `CaptureOnContentForBlock` check with the ancestors array
- Make it fail for `content_for` tags that were nested inside divs and such

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
