### PR TITLE
Fetch metafield definitions on start-up

### DIFF
--- a/.changeset/plenty-flowers-eat.md
+++ b/.changeset/plenty-flowers-eat.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-language-server-node': minor
+---
+
+Fetch metafield definitions on start-up using CLI

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -18,6 +18,7 @@ import {
   InitializeResult,
   ShowDocumentRequest,
   TextDocumentSyncKind,
+  WorkspaceFolder,
 } from 'vscode-languageserver';
 import { ClientCapabilities } from '../ClientCapabilities';
 import { CodeActionKinds, CodeActionsProvider } from '../codeActions';
@@ -79,6 +80,7 @@ export function startServer(
     log = defaultLogger,
     jsonValidationSet,
     themeDocset: remoteThemeDocset,
+    fetchMetafieldDefinitionsForURI,
   }: Dependencies,
 ) {
   const fs = new CachedFileSystem(injectedFs);
@@ -241,6 +243,18 @@ export function startServer(
     connection,
   );
 
+  const fetchMetafieldDefinitionsForWorkspaceFolders = async (folders: WorkspaceFolder[]) => {
+    if (!fetchMetafieldDefinitionsForURI) return;
+
+    for (let folder of folders) {
+      const mode = await getModeForURI(folder.uri);
+
+      if (mode === 'theme') {
+        fetchMetafieldDefinitionsForURI(folder.uri);
+      }
+    }
+  };
+
   connection.onInitialize((params) => {
     clientCapabilities.setup(params.capabilities, params.initializationOptions);
     jsonLanguageService.setup(params.capabilities);
@@ -294,6 +308,10 @@ export function startServer(
           workDoneProgress: false,
         },
         workspace: {
+          workspaceFolders: {
+            supported: true,
+            changeNotifications: true,
+          },
           fileOperations: {
             didRename: fileOperationRegistrationOptions,
             didCreate: fileOperationRegistrationOptions,
@@ -320,6 +338,16 @@ export function startServer(
           globPattern: '**/.shopify/*',
         },
       ],
+    });
+
+    connection.workspace.getWorkspaceFolders().then(async (folders) => {
+      if (!folders) return;
+
+      fetchMetafieldDefinitionsForWorkspaceFolders(folders);
+    });
+
+    connection.workspace.onDidChangeWorkspaceFolders(async (params) => {
+      fetchMetafieldDefinitionsForWorkspaceFolders(params.added);
     });
   });
 

--- a/packages/theme-language-server-common/src/types.ts
+++ b/packages/theme-language-server-common/src/types.ts
@@ -7,7 +7,10 @@ import { URI } from 'vscode-languageserver';
 
 import { WithOptional } from './utils';
 
-export type Dependencies = WithOptional<RequiredDependencies, 'log' | 'getMetafieldDefinitions'>;
+export type Dependencies = WithOptional<
+  RequiredDependencies,
+  'log' | 'getMetafieldDefinitions' | 'fetchMetafieldDefinitionsForURI'
+>;
 
 export interface RequiredDependencies {
   /**
@@ -86,4 +89,10 @@ export interface RequiredDependencies {
    * fetching the set of metafield definitions every time.
    */
   getMetafieldDefinitions: ThemeCheckDependencies['getMetafieldDefinitions'];
+
+  /**
+   * Fetch Metafield definitions using the CLI provided the URI of the project root.
+   * This should only be used in node environments; not on the browser.
+   */
+  fetchMetafieldDefinitionsForURI: (uri: URI) => Promise<void>;
 }

--- a/packages/theme-language-server-node/src/index.ts
+++ b/packages/theme-language-server-node/src/index.ts
@@ -4,6 +4,7 @@ import { startServer as startCoreServer } from '@shopify/theme-language-server-c
 import { stdin, stdout } from 'node:process';
 import { createConnection } from 'vscode-languageserver/node';
 import { loadConfig } from './dependencies';
+import { fetchMetafieldDefinitionsForURI } from './metafieldDefinitions';
 
 export { NodeFileSystem } from '@shopify/theme-check-node';
 export * from '@shopify/theme-language-server-common';
@@ -21,5 +22,6 @@ export function startServer(connection = getConnection(), fs: AbstractFileSystem
     loadConfig,
     themeDocset: themeLiquidDocsManager,
     jsonValidationSet: themeLiquidDocsManager,
+    fetchMetafieldDefinitionsForURI,
   });
 }

--- a/packages/theme-language-server-node/src/metafieldDefinitions.ts
+++ b/packages/theme-language-server-node/src/metafieldDefinitions.ts
@@ -1,0 +1,41 @@
+import * as child_process from 'child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(child_process.exec);
+
+const isWin = process.platform === 'win32';
+
+const shopifyCliPathPromise = getShopifyCliPath();
+
+export async function fetchMetafieldDefinitionsForURI(uri: string) {
+  const path = await shopifyCliPathPromise;
+
+  if (!path) {
+    return;
+  }
+
+  try {
+    await exec(`${path} theme metafields pull`, {
+      cwd: new URL(uri),
+      timeout: 10_000,
+    });
+  } catch (_) {
+    // CLI command can break because of incorrect version or not being logged in
+    // If this fails, the user must fetch their own metafield definitions
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+async function getShopifyCliPath() {
+  if (isWin) {
+    const { stdout } = await exec(`where.exe shopify`);
+    const executables = stdout
+      .replace(/\r/g, '')
+      .split('\n')
+      .filter((exe) => exe.endsWith('bat'));
+    return executables.length > 0 ? executables[0] : '';
+  } else {
+    const { stdout } = await exec(`which shopify`);
+    return stdout.split('\n')[0].replace('\r', '');
+  }
+}


### PR DESCRIPTION
## What are you adding in this PR?

Part of https://github.com/Shopify/theme-tools/issues/502
- Adding the ability to fetch metafield definitions on VSCode startup
- Does not check the version of the CLI
- Timeouts if the CLI does not complete the action

## Tophat

Unfortunately, the CLI does not contain the metafield definitions pull command yet. To tophat the change override the `path` variable to use a locally built version of CLI of the main branch.

E.g.

```
const  path = '<path-to-cli-repo>/packages/cli/bin/dev.js';
```

UPDATE: CLI version 3.73 has `shopify theme metafields pull` command so you can just update your CLI and it should work if you're logged in.

## What's next? Any followup issues?

- Should we be adding `.shopify/metafields.json` as part of gitignore for themes?

## Before you deploy

- [x] I included a minor bump `changeset`
