### PR TITLE
Add LiquidFreeSettings Check

### DIFF
--- a/.changeset/large-geese-confess.md
+++ b/.changeset/large-geese-confess.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Add LiquidFreeSettings check

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -15,6 +15,7 @@ import { DeprecatedFilter } from './deprecated-filter';
 import { DeprecatedTag } from './deprecated-tag';
 import { ImgWidthAndHeight } from './img-width-and-height';
 import { JSONSyntaxError } from './json-syntax-error';
+import { LiquidFreeSettings } from './liquid-free-settings';
 import { LiquidHTMLSyntaxError } from './liquid-html-syntax-error';
 import { MatchingTranslations } from './matching-translations';
 import { MissingAsset } from './missing-asset';
@@ -53,6 +54,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   DeprecateLazysizes,
   ImgWidthAndHeight,
   JSONSyntaxError,
+  LiquidFreeSettings,
   LiquidHTMLSyntaxError,
   MatchingTranslations,
   MissingAsset,

--- a/packages/theme-check-common/src/checks/liquid-free-settings/index.spec.ts
+++ b/packages/theme-check-common/src/checks/liquid-free-settings/index.spec.ts
@@ -1,0 +1,157 @@
+import { expect, describe, it } from 'vitest';
+import { LiquidFreeSettings } from './index';
+import { check, MockTheme } from '../../test';
+
+describe('LiquidFreeSettings validation', () => {
+  const paths = ['sections', 'blocks'];
+  paths.forEach((path) => {
+    it(`should not report errors for valid settings without liquid logic in ${path} bucket`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test-section.liquid`]: `
+        {% schema %}
+        {
+          "name": "Section name",
+          "settings": [
+            {
+              "id": "text_value",
+              "type": "text",
+              "label": "Text Value",
+              "default": "Some text without liquid logic."
+            }
+          ]
+        }
+        {% endschema %}
+      `,
+      };
+
+      const offenses = await check(theme, [LiquidFreeSettings]);
+      expect(offenses).to.have.length(0);
+    });
+
+    it(`should not report errors for valid settings with dynamic source liquid logic in ${path} bucket`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test-section.liquid`]: `
+        {% schema %}
+        {
+          "name": "Section name",
+          "settings": [
+            {
+              "id": "text_value",
+              "type": "text",
+              "label": "Text Value",
+              "default": "Title {{ product.title }}"
+            }
+          ]
+        }
+        {% endschema %}
+      `,
+      };
+
+      const offenses = await check(theme, [LiquidFreeSettings]);
+      expect(offenses).to.have.length(0);
+    });
+
+    it(`should report an error when settings value contains Liquid logic in ${path} bucket`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test-section.liquid`]: `
+        {% schema %}
+        {
+          "name": "Section name",
+          "settings": [
+            {
+              "id": "input_with_logic",
+              "type": "text",
+              "label": "Input with Logic",
+              "default": "Hello {% if user %} User {% endif %}!"
+            }
+          ]
+        }
+        {% endschema %}
+      `,
+      };
+
+      const offenses = await check(theme, [LiquidFreeSettings]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal('Settings values cannot contain liquid logic.');
+    });
+
+    it(`should report an error with correct indices when settings value contains Liquid logic in ${path} bucket`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test-section.liquid`]: `
+        {% schema %}
+        {
+          "name": "Section name",
+          "settings": [
+            {
+              "id": "input_with_logic",
+              "type": "text",
+              "label": "Input with Logic",
+              "default": "Hello {% if user %} User {% endif %}!"
+            }
+          ]
+        }
+        {% endschema %}
+      `,
+      };
+
+      const offenses = await check(theme, [LiquidFreeSettings]);
+      expect(offenses).to.have.length(1);
+      const content = theme[`${path}/test-section.liquid`];
+      const errorContent = content.slice(offenses[0].start.index, offenses[0].end.index);
+      expect(errorContent).to.equal('"Hello {% if user %} User {% endif %}!"');
+    });
+
+    it(`should report an error when settings value contains Liquid logic in object format in ${path} bucket`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test-section.liquid`]: `
+        {% schema %}
+        {
+          "name": "test",
+          "settings": {
+            "text_block": {
+              "type": "text",
+              "id": "text_block",
+              "label": "Text Block",
+              "default": "Hello {% if user %} User {% endif %}!"
+            }
+          }
+        }
+      {% endschema %}
+      `,
+      };
+
+      const offenses = await check(theme, [LiquidFreeSettings]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal('Settings values cannot contain liquid logic.');
+    });
+
+    it(`should report errors when preset block values contain Liquid logic in ${path} bucket`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test-section.liquid`]: `
+        {% schema %}
+        {
+          "name": "Section name",
+          "presets": [
+            {
+              "name": "Default",
+              "block": [
+                {
+                  "type": "text",
+                  "settings": {
+                    "text": "Hello World!{% random liquid logic %}"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+        {% endschema %}
+      `,
+      };
+
+      const offenses = await check(theme, [LiquidFreeSettings]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal('Settings values cannot contain liquid logic.');
+    });
+  });
+});

--- a/packages/theme-check-common/src/checks/liquid-free-settings/index.spec.ts
+++ b/packages/theme-check-common/src/checks/liquid-free-settings/index.spec.ts
@@ -153,5 +153,28 @@ describe('LiquidFreeSettings validation', () => {
       expect(offenses).to.have.length(1);
       expect(offenses[0].message).to.equal('Settings values cannot contain liquid logic.');
     });
+
+    it(`should not report errors when settings value is available_if and it contains liquid logic`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test-section.liquid`]: `
+        {% schema %}
+        {
+          "name": "test",
+          "settings": {
+            "text_block": {
+              "type": "text",
+              "id": "text_block",
+              "label": "Text Block",
+              "default": "Hello World!",
+              "available_if": "{% if user %} true {% endif %}"
+            }
+          }
+        }
+      {% endschema %}
+      `,
+      };
+      const offenses = await check(theme, [LiquidFreeSettings]);
+      expect(offenses).to.have.length(0);
+    });
   });
 });

--- a/packages/theme-check-common/src/checks/liquid-free-settings/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-free-settings/index.ts
@@ -37,7 +37,13 @@ export const LiquidFreeSettings: LiquidCheckDefinition = {
           Property(schemaNode, ancestors) {
             if (isInArrayWithParentKey(ancestors, 'settings') && isLiteralNode(schemaNode.value)) {
               const { value, loc } = schemaNode.value;
-              if (typeof value === 'string' && value.includes('{%') && value.includes('%}')) {
+              const propertyValue = schemaNode.key.value;
+              if (
+                typeof value === 'string' &&
+                propertyValue !== 'available_if' &&
+                value.includes('{%') &&
+                value.includes('%}')
+              ) {
                 context.report({
                   message: 'Settings values cannot contain liquid logic.',
                   startIndex: node.blockStartPosition.end + loc!.start.offset,

--- a/packages/theme-check-common/src/checks/liquid-free-settings/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-free-settings/index.ts
@@ -36,12 +36,12 @@ export const LiquidFreeSettings: LiquidCheckDefinition = {
         visit<SourceCodeType.JSON, void>(jsonFile, {
           Property(schemaNode, ancestors) {
             if (isInArrayWithParentKey(ancestors, 'settings') && isLiteralNode(schemaNode.value)) {
-              const value = schemaNode.value.value;
+              const { value, loc } = schemaNode.value;
               if (typeof value === 'string' && value.includes('{%') && value.includes('%}')) {
                 context.report({
                   message: 'Settings values cannot contain liquid logic.',
-                  startIndex: node.blockStartPosition.end + schemaNode.value.loc!.start.offset,
-                  endIndex: node.blockStartPosition.end + schemaNode.value.loc!.end.offset,
+                  startIndex: node.blockStartPosition.end + loc!.start.offset,
+                  endIndex: node.blockStartPosition.end + loc!.end.offset,
                 });
               }
             }

--- a/packages/theme-check-common/src/checks/liquid-free-settings/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-free-settings/index.ts
@@ -1,0 +1,68 @@
+import { JSONNode, LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { toJSONAST } from '../../to-source-code';
+import { visit } from '../../visitor';
+import { LiteralNode } from 'json-to-ast';
+
+export const LiquidFreeSettings: LiquidCheckDefinition = {
+  meta: {
+    code: 'LiquidFreeSettings',
+    name: 'Check for liquid free settings values',
+    docs: {
+      description: 'Ensures settings values are liquid free.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/themes/tools/theme-check/checks/liquid-free-settings',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    return {
+      async LiquidRawTag(node) {
+        if (node.name !== 'schema' || node.body.kind !== 'json') {
+          return;
+        }
+
+        const jsonString = node.source.slice(
+          node.blockStartPosition.end,
+          node.blockEndPosition.start,
+        );
+
+        const jsonFile = toJSONAST(jsonString);
+        if (jsonFile instanceof Error) return;
+
+        visit<SourceCodeType.JSON, void>(jsonFile, {
+          Property(schemaNode, ancestors) {
+            if (isInArrayWithParentKey(ancestors, 'settings') && isLiteralNode(schemaNode.value)) {
+              const value = schemaNode.value.value;
+              if (typeof value === 'string' && value.includes('{%') && value.includes('%}')) {
+                context.report({
+                  message: 'Settings values cannot contain liquid logic.',
+                  startIndex: node.blockStartPosition.end + schemaNode.value.loc!.start.offset,
+                  endIndex: node.blockStartPosition.end + schemaNode.value.loc!.end.offset,
+                });
+              }
+            }
+          },
+        });
+      },
+    };
+  },
+};
+
+function isLiteralNode(node: JSONNode): node is LiteralNode {
+  return node.type === 'Literal';
+}
+
+function isInArrayWithParentKey(ancestors: JSONNode[], parentKey: string): boolean {
+  return ancestors.some((ancestor, index) => {
+    const parent = ancestors[index - 1];
+    return (
+      (ancestor.type === 'Array' || ancestor.type === 'Object') &&
+      parent?.type === 'Property' &&
+      parent.key?.value === parentKey
+    );
+  });
+}

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -52,6 +52,9 @@ ImgWidthAndHeight:
 JSONSyntaxError:
   enabled: true
   severity: 0
+LiquidFreeSettings:
+  enabled: true
+  severity: 1
 LiquidHTMLSyntaxError:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -33,6 +33,9 @@ ImgWidthAndHeight:
 JSONSyntaxError:
   enabled: true
   severity: 0
+LiquidFreeSettings:
+  enabled: true
+  severity: 1
 LiquidHTMLSyntaxError:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?

Resolves https://github.com/Shopify/theme-tools/issues/558

This PR introduces enhanced validation checks for `Settings`; specifically ensuring that they do not contain liquid logic in the format of `{% ... %}`.
![image](https://github.com/user-attachments/assets/3f90a33f-5cf1-40cc-b395-14ff433874e4)

## What's next? Any followup issues?

With this being a new check, we will want to update https://github.com/Shopify/shopify-dev so users can understand their errors. Developer Docs changes: https://github.com/Shopify/shopify-dev/pull/50841

## What did you learn?

When writing this check I thought of three different implementations that could have been used -- it is important to understand the balance of complexity and shipping fast. 

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
