### PR TITLE
Better building blocks for dealing with `{% schema %}` content

### DIFF
--- a/.changeset/calm-pandas-rest.md
+++ b/.changeset/calm-pandas-rest.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+[Internal] Add better building blocks for dealing with `{% schema %}` content

--- a/packages/theme-check-common/src/JSONValidator.ts
+++ b/packages/theme-check-common/src/JSONValidator.ts
@@ -1,10 +1,18 @@
 import { LanguageService, TextDocument, getLanguageService } from 'vscode-json-languageservice';
-import { SchemaDefinition, SourceCodeType, ValidateJSON } from './types';
+import { Config, Dependencies, IsValidSchema, SchemaDefinition, ValidateJSON } from './types';
 import { indexBy } from './utils';
 
 export class JSONValidator {
   private service: LanguageService;
   private schemas: Record<string, SchemaDefinition>;
+
+  static async create(
+    jsonValidationSet: Dependencies['jsonValidationSet'],
+    config: Config,
+  ): Promise<JSONValidator | undefined> {
+    if (!jsonValidationSet) return;
+    return new JSONValidator(await jsonValidationSet.schemas(config.context));
+  }
 
   constructor(schemas: SchemaDefinition[]) {
     this.schemas = indexBy((x) => x.uri, schemas);
@@ -31,14 +39,9 @@ export class JSONValidator {
    * It's up to the caller to determine where in the file those should be.
    * (presumably by doing some offset logic)
    */
-  public validate: ValidateJSON<SourceCodeType> = async (sourceCode, jsonString) => {
-    const jsonTextDocument = TextDocument.create('file:' + sourceCode.uri, 'json', 0, jsonString);
-    const jsonDocument = this.service.parseJSONDocument(jsonTextDocument);
-    const diagnostics = await this.service.doValidation(jsonTextDocument, jsonDocument, {
-      schemaValidation: 'error',
-      trailingCommas: 'ignore',
-      comments: 'ignore',
-    });
+  public validate: ValidateJSON = async (uri: string, jsonString: string) => {
+    const jsonTextDocument = TextDocument.create(uri, 'json', 0, jsonString);
+    const diagnostics = await this.getOffsetDiagnostics(jsonTextDocument);
     return diagnostics.map((diagnostic) => ({
       message: diagnostic.message,
       startIndex: jsonTextDocument.offsetAt(diagnostic.range.start),
@@ -46,9 +49,34 @@ export class JSONValidator {
     }));
   };
 
+  public isValid: IsValidSchema = async (uri: string, jsonString: string) => {
+    return isValid(this.service, uri, jsonString);
+  };
+
+  private async getOffsetDiagnostics(jsonTextDocument: TextDocument) {
+    const jsonDocument = this.service.parseJSONDocument(jsonTextDocument);
+    return this.service.doValidation(jsonTextDocument, jsonDocument, {
+      schemaValidation: 'error',
+      trailingCommas: 'ignore',
+      comments: 'ignore',
+    });
+  }
+
   private async getSchemaForURI(uri: string): Promise<string> {
     const schema = this.schemas[uri]?.schema;
     if (!schema) return `No schema for '${uri}' found`;
     return schema;
   }
+}
+
+/** We'll reuse this in the language server */
+export async function isValid(service: LanguageService, uri: string, jsonString: string) {
+  const jsonTextDocument = TextDocument.create(uri, 'json', 0, jsonString);
+  const jsonDocument = service.parseJSONDocument(jsonTextDocument);
+  const diagnostics = await service.doValidation(jsonTextDocument, jsonDocument, {
+    schemaValidation: 'error',
+    trailingCommas: 'ignore',
+    comments: 'ignore',
+  });
+  return diagnostics.every((diagnostic) => diagnostic.severity !== 1);
 }

--- a/packages/theme-check-common/src/checks/valid-json/index.ts
+++ b/packages/theme-check-common/src/checks/valid-json/index.ts
@@ -29,7 +29,7 @@ export const ValidJSON: JSONCheckDefinition = {
 
     return {
       async onCodePathStart(file) {
-        const problems = await validateJSON(file, file.source);
+        const problems = await validateJSON(file.uri, file.source);
         if (!problems) return;
         for (const problem of problems) {
           context.report(problem);

--- a/packages/theme-check-common/src/checks/valid-schema/index.ts
+++ b/packages/theme-check-common/src/checks/valid-schema/index.ts
@@ -25,7 +25,7 @@ export const ValidSchema: LiquidCheckDefinition = {
           node.blockStartPosition.end,
           node.blockEndPosition.start,
         );
-        const problems = await context.validateJSON(context.file, jsonString);
+        const problems = await context.validateJSON(context.file.uri, jsonString);
         if (!problems) return;
 
         for (const problem of problems) {

--- a/packages/theme-check-common/src/index.ts
+++ b/packages/theme-check-common/src/index.ts
@@ -48,6 +48,7 @@ export * from './ignore';
 export * from './json';
 export * as path from './path';
 export * from './to-source-code';
+export * from './to-schema';
 export * from './types';
 export * from './utils/error';
 export * from './utils/indexBy';

--- a/packages/theme-check-common/src/json.ts
+++ b/packages/theme-check-common/src/json.ts
@@ -1,5 +1,6 @@
-import { asError } from './utils';
 import { parse, ParseError } from 'jsonc-parser';
+import { JSONNode } from './types';
+import { asError } from './utils';
 
 const PARSE_OPTS = {
   disallowComments: false,
@@ -28,4 +29,31 @@ export function parseJSON(source: string, defaultValue?: any): any | Error {
     if (defaultValue !== undefined) return defaultValue;
     return asError(error);
   }
+}
+
+/**
+ * Given a known path to a property and an ast, returns the AST node at that path.
+ *
+ * @example
+ * const nameNode = nodeAtPath(ast, ['name'])! as LiteralNode;
+ * const blocksNode = nodeAtPath(ast, ['blocks'])! as ArrayNode;
+ * const someDeepNode = nodeAtPath(ast, ['blocks', 0, 'settings', 'someDeepKey'])! as LiteralNode;
+ */
+export function nodeAtPath(node: JSONNode, path: string[]): JSONNode | undefined {
+  return path.reduce<JSONNode | undefined>((acc, key) => {
+    if (!acc || acc.type !== 'Object') return;
+    const property = acc.children.find((child) => child.key.value === key);
+    if (!property) return;
+    return property.value;
+  }, node);
+}
+
+/** Given a JSONNode, returns the start offset of the node in the source string. */
+export function getLocStart(node: JSONNode): number {
+  return node.loc?.start.offset ?? 0;
+}
+
+/** Given a JSONNode, returns the end offset of the node in the source string. */
+export function getLocEnd(node: JSONNode): number {
+  return node.loc?.end.offset ?? 0;
 }

--- a/packages/theme-check-common/src/test/MockFileSystem.ts
+++ b/packages/theme-check-common/src/test/MockFileSystem.ts
@@ -1,5 +1,5 @@
 import { AbstractFileSystem, FileStat, FileTuple, FileType } from '../AbstractFileSystem';
-import { deepGet } from '../utils/file-utils';
+import { deepGet } from '../utils';
 import { normalize, relative } from '../path';
 import { MockTheme } from './MockTheme';
 

--- a/packages/theme-check-common/src/to-schema.ts
+++ b/packages/theme-check-common/src/to-schema.ts
@@ -1,0 +1,98 @@
+import { LiquidRawTag } from '@shopify/liquid-html-parser';
+import { parseJSON } from './json';
+import * as path from './path';
+import { toJSONAST } from './to-source-code';
+import {
+  BlockSchema,
+  LiquidHtmlNode,
+  SectionSchema,
+  SourceCode,
+  SourceCodeType,
+  ThemeSchema,
+  ThemeSchemaType,
+  UriString,
+} from './types';
+import { visit } from './visitor';
+
+export function toSchema(
+  uri: UriString,
+  sourceCode: SourceCode,
+): SectionSchema | BlockSchema | undefined {
+  if (sourceCode.type !== SourceCodeType.LiquidHtml) return undefined;
+  switch (true) {
+    case isBlock(uri):
+      return toBlockSchema(uri, sourceCode.ast);
+    case isSection(uri):
+      return toSectionSchema(uri, sourceCode.ast);
+    default:
+      return undefined;
+  }
+}
+
+export function isBlock(uri: UriString) {
+  return path.dirname(uri).endsWith('blocks');
+}
+
+export function isSection(uri: UriString) {
+  return path.dirname(uri).endsWith('sections');
+}
+
+export function isBlockSchema(
+  schema: SectionSchema | BlockSchema | undefined,
+): schema is BlockSchema {
+  return schema?.type === ThemeSchemaType.Block;
+}
+
+export function isSectionSchema(
+  schema: SectionSchema | BlockSchema | undefined,
+): schema is SectionSchema {
+  return schema?.type === ThemeSchemaType.Section;
+}
+
+export function toBlockSchema(uri: UriString, liquidAst: LiquidHtmlNode | Error): BlockSchema {
+  const name = path.basename(uri, '.liquid');
+  const schemaNode = toSchemaNode(liquidAst);
+  return {
+    type: ThemeSchemaType.Block,
+    name,
+    parsed: toParsed(schemaNode),
+    ast: toAst(schemaNode),
+  };
+}
+
+// Coincidentally very similar right now... but could be different in the future
+// given there might be a plan to support folders in the blocks folder.
+// e.g. if we start having a stricter "parsed" object / ways to get settings.
+export function toSectionSchema(uri: UriString, liquidAst: LiquidHtmlNode | Error): SectionSchema {
+  const name = path.basename(uri, '.liquid');
+  const schemaNode = toSchemaNode(liquidAst);
+  return {
+    type: ThemeSchemaType.Section,
+    name,
+    parsed: toParsed(schemaNode),
+    ast: toAst(schemaNode),
+  };
+}
+
+function toSchemaNode(ast: LiquidHtmlNode | Error): LiquidRawTag | Error {
+  if (ast instanceof Error) return ast;
+  return (
+    visit<SourceCodeType.LiquidHtml, LiquidRawTag>(ast, {
+      LiquidRawTag(node) {
+        if (node.name === 'schema') {
+          return node;
+        }
+      },
+    })[0] ?? new Error('No schema tag found')
+  );
+}
+
+function toParsed(schemaNode: LiquidRawTag | Error): any | Error {
+  if (schemaNode instanceof Error) return schemaNode;
+  return parseJSON(schemaNode.body.value);
+}
+
+function toAst(schemaNode: LiquidRawTag | Error): SourceCode<SourceCodeType.JSON>['ast'] | Error {
+  if (schemaNode instanceof Error) return schemaNode;
+  return toJSONAST(schemaNode.body.value);
+}

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -14,9 +14,11 @@ import { StringCorrector, JSONCorrector } from './fixes';
 import { AbstractFileSystem, UriString } from './AbstractFileSystem';
 
 import { ThemeDocset, JsonValidationSet } from './types/theme-liquid-docs';
+import { BlockSchema, SectionSchema } from './types/theme-schemas';
 
 export * from './types/theme-liquid-docs';
 export * from './types/schema-prop-factory';
+export * from './types/theme-schemas';
 
 export const isObjectNode = (node?: ASTNode): node is ObjectNode => node?.type === 'Object';
 export const isArrayNode = (node?: ASTNode): node is ArrayNode => node?.type === 'Array';
@@ -305,10 +307,31 @@ export type Translations = {
 };
 
 export interface Dependencies {
+  /** The file system abstraction used to read files. */
   fs: AbstractFileSystem;
+
+  /** The typing information */
   themeDocset?: ThemeDocset;
+
+  /** The blocks/sections JSON schemas */
   jsonValidationSet?: JsonValidationSet;
+
+  /** Returns the typing information for the theme's metafields */
   getMetafieldDefinitions?: (rootUri: UriString) => Promise<MetafieldDefinitionMap>;
+
+  /**
+   * Asynchronously get the block schema for 'blocks/${name}.liquid'
+   * May return undefined when the theme isn't preloaded.
+   * See {@link BlockSchema} for more information
+   */
+  getBlockSchema?: (name: string) => Promise<BlockSchema | undefined>;
+
+  /**
+   * Asynchronously get the section schema for 'section/${name}.liquid'
+   * May return undefined when the theme isn't preloaded or if there are none.
+   * See {@link SectionSchema} for more information
+   */
+  getSectionSchema?: (name: string) => Promise<SectionSchema | undefined>;
 }
 
 export type ValidateJSON<T extends SourceCodeType> = (

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -14,7 +14,7 @@ import { StringCorrector, JSONCorrector } from './fixes';
 import { AbstractFileSystem, UriString } from './AbstractFileSystem';
 
 import { ThemeDocset, JsonValidationSet } from './types/theme-liquid-docs';
-import { BlockSchema, SectionSchema } from './types/theme-schemas';
+import { AppBlockSchema, ThemeBlockSchema, SectionSchema } from './types/theme-schemas';
 
 export * from './types/theme-liquid-docs';
 export * from './types/schema-prop-factory';
@@ -322,9 +322,9 @@ export interface Dependencies {
   /**
    * Asynchronously get the block schema for 'blocks/${name}.liquid'
    * May return undefined when the theme isn't preloaded.
-   * See {@link BlockSchema} for more information
+   * See {@link ThemeBlockSchema} for more information
    */
-  getBlockSchema?: (name: string) => Promise<BlockSchema | undefined>;
+  getBlockSchema?: (name: string) => Promise<ThemeBlockSchema | undefined>;
 
   /**
    * Asynchronously get the section schema for 'section/${name}.liquid'
@@ -332,12 +332,22 @@ export interface Dependencies {
    * See {@link SectionSchema} for more information
    */
   getSectionSchema?: (name: string) => Promise<SectionSchema | undefined>;
+
+  /**
+   * (In theme app extension mode)
+   * Asynchronously get the block schema for 'blocks/${name}.liquid'
+   * May return undefined when the theme isn't preloaded.
+   * See {@link AppBlockSchema} for more information
+   */
+  getAppBlockSchema?: (name: string) => Promise<AppBlockSchema | undefined>;
 }
 
-export type ValidateJSON<T extends SourceCodeType> = (
-  file: SourceCode<T>,
+export type ValidateJSON = (
+  uri: string,
   jsonString: string,
 ) => Promise<{ message: string; startIndex: number; endIndex: number }[]>;
+
+export type IsValidSchema = (uri: string, jsonString: string) => Promise<boolean>;
 
 export interface AugmentedDependencies extends Dependencies {
   fileExists: (uri: UriString) => Promise<boolean>;
@@ -346,6 +356,7 @@ export interface AugmentedDependencies extends Dependencies {
   getDefaultSchemaLocale: () => Promise<string>;
   getDefaultTranslations(): Promise<Translations>;
   getDefaultSchemaTranslations(): Promise<Translations>;
+  mode: Mode;
 }
 
 type StaticContextProperties<T extends SourceCodeType> = T extends SourceCodeType
@@ -354,7 +365,7 @@ type StaticContextProperties<T extends SourceCodeType> = T extends SourceCodeTyp
       toRelativePath(uri: UriString): RelativePath;
       toUri(relativePath: RelativePath): UriString;
       file: SourceCode<T>;
-      validateJSON?: ValidateJSON<T>;
+      validateJSON?: ValidateJSON;
     }
   : never;
 

--- a/packages/theme-check-common/src/types/schemas/index.ts
+++ b/packages/theme-check-common/src/types/schemas/index.ts
@@ -1,0 +1,3 @@
+export { ThemeBlock } from './theme-block';
+export { Section } from './section';
+export { Setting } from './setting';

--- a/packages/theme-check-common/src/types/schemas/section.ts
+++ b/packages/theme-check-common/src/types/schemas/section.ts
@@ -1,0 +1,107 @@
+import { Setting } from './setting';
+
+export declare namespace Section {
+  /** {% schema %} */
+  export interface Schema {
+    name?: string;
+    tag?: 'article' | 'aside' | 'div' | 'footer' | 'header' | 'section';
+    class?: string;
+    limit?: number;
+    settings?: Setting.Any[];
+    max_blocks?: number;
+    blocks?: Block[];
+    presets?: Preset[];
+    default?: Default;
+    locales?: Record<string, Record<string, string>>;
+    enabled_on?: SectionToggle;
+    disabled_on?: SectionToggle;
+  }
+
+  // Block definitions
+  export type Block = ThemeBlock | AppBlock | SpecificThemeBlock | LocalBlock;
+
+  export type ThemeBlock = {
+    type: '@theme';
+  };
+
+  export type AppBlock = {
+    type: '@app';
+  };
+
+  export type SpecificThemeBlock = {
+    type: string;
+    limit?: number;
+    template?: string;
+  };
+
+  export type LocalBlock = {
+    type: string;
+    name: string;
+    settings?: Setting.Any[];
+  };
+
+  // Preset definitions
+  export interface Preset {
+    name: string;
+    settings?: Record<string, string | number | boolean | string[]>;
+    blocks?: PresetBlocks;
+  }
+
+  // Default section configuration (kind of like presets)
+  export interface Default {
+    settings?: Record<string, string | number | boolean | string[]>;
+    blocks?: Array<{
+      type: string;
+      settings?: Record<string, string | number | boolean | string[]>;
+    }>;
+  }
+
+  // Reuse the block preset types from ThemeBlock namespace
+  export type PresetBlocks = BlockPresetArrayElement[] | BlockPresetHash;
+
+  export type BlockPresetHash = Record<string, BlockPresetBase>;
+  export type BlockPresetArrayElement = BlockPresetBase | BlockPresetStatic;
+
+  export type BlockPresetStatic = BlockPresetBase & {
+    static: true;
+    id: string;
+  };
+
+  export type BlockPresetBase = {
+    type: string;
+    settings?: Setting.Values;
+    blocks?: PresetBlocks;
+  };
+
+  // Section toggle interface
+  export interface SectionToggle {
+    templates?: TemplateType[];
+    groups?: string[];
+  }
+
+  // Template types for section toggle
+  export type TemplateType =
+    | '*'
+    | '404'
+    | 'article'
+    | 'blog'
+    | 'captcha'
+    | 'cart'
+    | 'collection'
+    | 'customers/account'
+    | 'customers/activate_account'
+    | 'customers/addresses'
+    | 'customers/login'
+    | 'customers/order'
+    | 'customers/register'
+    | 'customers/reset_password'
+    | 'gift_card'
+    | 'index'
+    | 'list-collections'
+    | 'metaobject'
+    | 'page'
+    | 'password'
+    | 'policy'
+    | 'product'
+    | 'search';
+}

--- a/packages/theme-check-common/src/types/schemas/setting.ts
+++ b/packages/theme-check-common/src/types/schemas/setting.ts
@@ -1,0 +1,320 @@
+export declare namespace Setting {
+  /** Setting values are  */
+  export type Values = Record<string, string | number | boolean | string[]>;
+
+  /** Union type of all setting types */
+  export type Any = InputSetting | SideBarSetting;
+
+  /** Settings used for display */
+  export type SideBarSetting = Header | Paragraph;
+
+  /** Settings with data */
+  export type InputSetting =
+    | Article
+    | Blog
+    | Collection
+    | Page
+    | Product
+    | CollectionList
+    | ProductList
+    | MetaobjectList
+    | Text
+    | Textarea
+    | Richtext
+    | InlineRichtext
+    | Html
+    | Url
+    | TextAlignment
+    | Number
+    | Range
+    | Checkbox
+    | Radio
+    | Select
+    | Color
+    | ColorBackground
+    | ColorScheme
+    | ColorSchemeGroup
+    | ImagePicker
+    | Video
+    | VideoUrl
+    | FontPicker
+    | LinkList
+    | Liquid
+    | Metaobject
+    | StyleLayoutPanel
+    | StyleSizePanel
+    | StyleSpacingPanel;
+
+  export enum Type {
+    // Resource Settings
+    Article = 'article',
+    Blog = 'blog',
+    Collection = 'collection',
+    Page = 'page',
+    Product = 'product',
+
+    // Resource List Settings
+    CollectionList = 'collection_list',
+    ProductList = 'product_list',
+    MetaobjectList = 'metaobject_list',
+
+    // Text Settings
+    Text = 'text',
+    Textarea = 'textarea',
+    Richtext = 'richtext',
+    InlineRichtext = 'inline_richtext',
+    Html = 'html',
+    Url = 'url',
+    TextAlignment = 'text_alignment',
+
+    // Number Settings
+    Number = 'number',
+    Range = 'range',
+
+    // Choice Settings
+    Checkbox = 'checkbox',
+    Radio = 'radio',
+    Select = 'select',
+
+    // Color Settings
+    Color = 'color',
+    ColorBackground = 'color_background',
+    ColorScheme = 'color_scheme',
+    ColorSchemeGroup = 'color_scheme_group',
+
+    // Media Settings
+    ImagePicker = 'image_picker',
+    Video = 'video',
+    VideoUrl = 'video_url',
+
+    // Special Settings
+    FontPicker = 'font_picker',
+    LinkList = 'link_list',
+    Liquid = 'liquid',
+    Metaobject = 'metaobject',
+
+    // Style Panel Settings
+    StyleLayoutPanel = 'style.layout_panel',
+    StyleSizePanel = 'style.size_panel',
+    StyleSpacingPanel = 'style.spacing_panel',
+
+    // Sidebar Settings
+    Header = 'header',
+    Paragraph = 'paragraph',
+  }
+
+  // Base Setting Interface
+  export interface Base<T extends Type> {
+    type: T;
+    id: string;
+    label?: string;
+    info?: string;
+  }
+
+  // Sidebar Settings
+  export interface Header extends Base<Type.Header> {
+    content: string;
+  }
+
+  export interface Paragraph extends Base<Type.Paragraph> {
+    content: string;
+  }
+
+  // Resource Settings
+  export interface Resource<T extends Type> extends Base<T> {
+    default?: string;
+  }
+
+  export interface Article extends Resource<Type.Article> {}
+  export interface Blog extends Resource<Type.Blog> {}
+  export interface Collection extends Resource<Type.Collection> {}
+  export interface Page extends Resource<Type.Page> {}
+  export interface Product extends Resource<Type.Product> {}
+
+  // Resource List Settings
+  export interface ResourceList<T extends Type> extends Base<T> {
+    limit?: number;
+  }
+
+  export interface CollectionList extends ResourceList<Type.CollectionList> {}
+  export interface ProductList extends ResourceList<Type.ProductList> {}
+  export interface MetaobjectList extends ResourceList<Type.MetaobjectList> {
+    metaobject_type: string;
+  }
+
+  // Text Settings
+  export interface TextBase<T extends Type> extends Base<T> {
+    default?: string;
+    placeholder?: string;
+  }
+
+  export interface Text extends TextBase<Type.Text> {}
+  export interface Textarea extends TextBase<Type.Textarea> {}
+  export interface Richtext extends TextBase<Type.Richtext> {}
+  export interface InlineRichtext extends TextBase<Type.InlineRichtext> {}
+  export interface Html extends TextBase<Type.Html> {}
+  export interface Url extends TextBase<Type.Url> {}
+
+  export interface TextAlignment extends Base<Type.TextAlignment> {
+    default?: 'left' | 'center' | 'right' | 'justify';
+  }
+
+  // Number Settings
+  export interface NumberBase<T extends Type> extends Base<T> {
+    default?: number;
+    min?: number;
+    max?: number;
+    step?: number;
+    unit?: string;
+  }
+
+  export interface Number extends NumberBase<Type.Number> {}
+  export interface Range extends NumberBase<Type.Range> {}
+
+  // Choice Settings
+  export interface Checkbox extends Base<Type.Checkbox> {
+    default?: boolean;
+  }
+
+  export interface ChoiceOption {
+    value: string;
+    label: string;
+  }
+
+  export interface ChoiceBase<T extends Type> extends Base<T> {
+    options: ChoiceOption[];
+    default?: string;
+  }
+
+  export interface Radio extends ChoiceBase<Type.Radio> {}
+  export interface Select extends ChoiceBase<Type.Select> {}
+
+  // Color Settings
+  export interface ColorBase<T extends Type> extends Base<T> {
+    default?: string;
+  }
+
+  export interface Color extends ColorBase<Type.Color> {}
+  export interface ColorBackground extends ColorBase<Type.ColorBackground> {}
+  export interface ColorScheme extends Base<Type.ColorScheme> {
+    default?: string;
+  }
+  export interface ColorSchemeGroup extends Base<Type.ColorSchemeGroup> {}
+
+  // Media Settings
+  export interface ImagePicker extends Base<Type.ImagePicker> {
+    default?: string;
+  }
+
+  export interface Video extends Base<Type.Video> {
+    default?: string;
+  }
+
+  export interface VideoUrl extends Base<Type.VideoUrl> {
+    default?: string;
+    accept: Array<'youtube' | 'vimeo'>;
+  }
+
+  // Special Settings
+  export interface FontPicker extends Base<Type.FontPicker> {
+    default?: string;
+  }
+
+  export interface LinkList extends Base<Type.LinkList> {
+    default?: string;
+  }
+
+  export interface Liquid extends Base<Type.Liquid> {
+    default?: string;
+  }
+
+  export interface Metaobject extends Base<Type.Metaobject> {
+    metaobject_type: string;
+  }
+
+  // Style Panel Settings
+  export interface StyleLayoutPanel extends Base<Type.StyleLayoutPanel> {
+    default?: {
+      'flex-direction'?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
+      'flex-wrap'?: 'nowrap' | 'wrap' | 'wrap-reverse';
+      'justify-content'?:
+        | 'flex-start'
+        | 'flex-end'
+        | 'start'
+        | 'end'
+        | 'left'
+        | 'right'
+        | 'center'
+        | 'space-between'
+        | 'space-around'
+        | 'space-evenly';
+      'align-items'?:
+        | 'stretch'
+        | 'flex-start'
+        | 'start'
+        | 'self-start'
+        | 'flex-end'
+        | 'end'
+        | 'self-end'
+        | 'center'
+        | 'baseline';
+      'align-content'?:
+        | 'stretch'
+        | 'flex-start'
+        | 'start'
+        | 'flex-end'
+        | 'end'
+        | 'center'
+        | 'space-between'
+        | 'space-around'
+        | 'space-evenly';
+      gap?: string;
+      'row-gap'?: string;
+      'column-gap'?: string;
+      '@media (--mobile)'?: Partial<StyleLayoutPanel['default']>;
+    };
+  }
+
+  export interface StyleSizePanel extends Base<Type.StyleSizePanel> {
+    default?: {
+      width?: string;
+      'min-width'?: string;
+      'max-width'?: string;
+      height?: string;
+      'min-height'?: string;
+      'max-height'?: string;
+      'flex-grow'?: string;
+      'flex-shrink'?: string;
+      'flex-basis'?: string;
+      '@media (--mobile)'?: Partial<StyleSizePanel['default']>;
+    };
+  }
+
+  export interface StyleSpacingPanel extends Base<Type.StyleSpacingPanel> {
+    default?: {
+      padding?: string;
+      'padding-top'?: string;
+      'padding-right'?: string;
+      'padding-bottom'?: string;
+      'padding-left'?: string;
+      'padding-block'?: string;
+      'padding-block-start'?: string;
+      'padding-block-end'?: string;
+      'padding-inline'?: string;
+      'padding-inline-start'?: string;
+      'padding-inline-end'?: string;
+      margin?: string;
+      'margin-top'?: string;
+      'margin-right'?: string;
+      'margin-bottom'?: string;
+      'margin-left'?: string;
+      'margin-block'?: string;
+      'margin-block-start'?: string;
+      'margin-block-end'?: string;
+      'margin-inline'?: string;
+      'margin-inline-start'?: string;
+      'margin-inline-end'?: string;
+      '@media (--mobile)'?: Partial<StyleSpacingPanel['default']>;
+    };
+  }
+}

--- a/packages/theme-check-common/src/types/schemas/theme-block.ts
+++ b/packages/theme-check-common/src/types/schemas/theme-block.ts
@@ -1,0 +1,68 @@
+import { Setting } from './setting';
+
+export declare namespace ThemeBlock {
+  /** Typed content of {% schema %} after passing validation */
+  export interface Schema {
+    name?: string;
+    settings?: Setting.Any[];
+    blocks?: Block[];
+    presets?: Preset[];
+    class?: string;
+    tag?: string | null;
+  }
+
+  export type ThemeBlock = {
+    type: '@theme';
+  };
+
+  export type AppBlock = {
+    type: '@app';
+  };
+
+  export type SpecificThemeBlock = {
+    /** blocks/{type}.liquid */
+    type: string;
+  };
+
+  // prettier-ignore
+  export type Block = (
+    | ThemeBlock
+    | AppBlock
+    | SpecificThemeBlock
+  );
+
+  // The preset type that uses the above
+  export interface Preset {
+    name: string;
+    settings?: Setting.Values;
+    blocks?: BlockPresets;
+  }
+
+  // Union type that represents either format
+  export type BlockPresets = BlockPresetArrayElement[] | BlockPresetHash;
+
+  // Hash format for blocks
+  export type BlockPresetHash = {
+    [id: string]: BlockPresetBase & {
+      blocks?: BlockPresets;
+    };
+  };
+
+  // Array element format for blocks
+  export type BlockPresetArrayElement = (BlockPresetBase | BlockPresetStatic) & {
+    blocks?: BlockPresets; // Recursive
+  };
+
+  /** Base type for presets */
+  export type BlockPresetBase = {
+    /** Refers to a block type. blocks/{type}.liquid */
+    type: string;
+    settings?: Setting.Values;
+  };
+
+  /** Static blocks */
+  export type BlockPresetStatic = BlockPresetBase & {
+    static: true;
+    id: string;
+  };
+}

--- a/packages/theme-check-common/src/types/theme-schemas.ts
+++ b/packages/theme-check-common/src/types/theme-schemas.ts
@@ -1,9 +1,12 @@
 import { SourceCode, SourceCodeType } from '../types';
+import { Section, ThemeBlock } from './schemas';
 
-/** Doubles as the folder name */
+export * from './schemas';
+
 export enum ThemeSchemaType {
-  Block = 'blocks',
-  Section = 'sections',
+  AppBlock = 'app-block',
+  Block = 'block',
+  Section = 'section',
 }
 
 /**
@@ -29,7 +32,34 @@ export interface ThemeSchema<T extends ThemeSchemaType> {
 }
 
 /** See {@link ThemeSchema} */
-export interface BlockSchema extends ThemeSchema<ThemeSchemaType.Block> {}
+export interface ThemeBlockSchema extends ThemeSchema<ThemeSchemaType.Block> {
+  /**
+   * @example
+   * const schema = await context.getBlockSchema('product');
+   * const validSchema = schema?.validSchema;
+   * if (!validSchema || validSchema instanceof Error) return;
+   *
+   * for (const block of validSchema.blocks ?? []) {
+   *  // do something
+   * }
+   */
+  validSchema: ThemeBlock.Schema | Error;
+}
 
 /** See {@link ThemeSchema} */
-export interface SectionSchema extends ThemeSchema<ThemeSchemaType.Section> {}
+export interface SectionSchema extends ThemeSchema<ThemeSchemaType.Section> {
+  /**
+   * @example
+   * const schema = await context.getSectionSchema('product');
+   * const validSchema = schema?.validSchema;
+   * if (!validSchema || validSchema instanceof Error) return;
+   *
+   * for (const block of validSchema.blocks ?? []) {
+   *  // do something
+   * }
+   */
+  validSchema: Section.Schema | Error;
+}
+
+/** TODO setup validSchema like the other ones. */
+export interface AppBlockSchema extends ThemeSchema<ThemeSchemaType.AppBlock> {}

--- a/packages/theme-check-common/src/types/theme-schemas.ts
+++ b/packages/theme-check-common/src/types/theme-schemas.ts
@@ -1,0 +1,35 @@
+import { SourceCode, SourceCodeType } from '../types';
+
+/** Doubles as the folder name */
+export enum ThemeSchemaType {
+  Block = 'blocks',
+  Section = 'sections',
+}
+
+/**
+ * A ThemeSchema represents the `{% schema %}` contents of a block or section file.
+ *
+ * `ast` and `parsed` will be instances of `Error` if there was an error parsing
+ * the Liquid file or the JSON.
+ *
+ * There is no guarantee that the `ast` or `parsed` fields are backend-valid.
+ */
+export interface ThemeSchema<T extends ThemeSchemaType> {
+  /** section or block */
+  type: T;
+
+  /** `section/${name}.liquid` */
+  name: string;
+
+  /** Parsed as an AST (with position information) or an Error */
+  ast: SourceCode<SourceCodeType.JSON>['ast'] | Error;
+
+  /** Parsed as a JavaScript object or an Error */
+  parsed: any | Error;
+}
+
+/** See {@link ThemeSchema} */
+export interface BlockSchema extends ThemeSchema<ThemeSchemaType.Block> {}
+
+/** See {@link ThemeSchema} */
+export interface SectionSchema extends ThemeSchema<ThemeSchemaType.Section> {}

--- a/packages/theme-check-common/src/utils/file-utils.ts
+++ b/packages/theme-check-common/src/utils/file-utils.ts
@@ -56,7 +56,3 @@ export async function hasLocalAssetSizeExceededThreshold<
 
   return fileExceedsThreshold;
 }
-
-export function deepGet(obj: any, path: string[]): any {
-  return path.reduce((acc, key) => acc?.[key], obj);
-}

--- a/packages/theme-check-common/src/utils/index.ts
+++ b/packages/theme-check-common/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './object';
 export * from './array';
 export * from './position';
 export * from './error';

--- a/packages/theme-check-common/src/utils/object.ts
+++ b/packages/theme-check-common/src/utils/object.ts
@@ -1,0 +1,3 @@
+export function deepGet(obj: any, path: string[]): any {
+  return path.reduce((acc, key) => acc?.[key], obj);
+}

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.spec.ts
@@ -1,8 +1,7 @@
 import { LiquidHtmlNode } from '@shopify/theme-check-common';
 import { describe, expect, it } from 'vitest';
 import { CompletionParams, Position } from 'vscode-languageserver';
-import { DocumentManager } from '../../documents';
-import { AugmentedLiquidSourceCode } from '../../documents/DocumentManager';
+import { DocumentManager, AugmentedLiquidSourceCode } from '../../documents';
 import { createLiquidCompletionParams } from './LiquidCompletionParams';
 
 describe('Module: LiquidCompletionParams', async () => {

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -1,5 +1,5 @@
 import {
-  BlockSchema,
+  ThemeBlockSchema,
   check,
   findRoot,
   makeFileExists,
@@ -51,19 +51,24 @@ export function makeRunChecks(
         themeDocset,
         jsonValidationSet,
         getMetafieldDefinitions,
+
+        // TODO should do something for app blocks?
         async getBlockSchema(name) {
           // We won't preload here. If it's available, we'll give it. Otherwise expect nothing.
           const uri = path.join(config.rootUri, 'blocks', `${name}.liquid`);
           const doc = documentManager.get(uri);
           if (doc?.type !== SourceCodeType.LiquidHtml) return undefined;
-          return doc.schema as BlockSchema;
+          const schema = await doc.getSchema();
+          return schema as ThemeBlockSchema | undefined;
         },
+
         async getSectionSchema(name) {
           // We won't preload here. If it's available, we'll give it. Otherwise expect nothing.
           const uri = path.join(config.rootUri, 'sections', `${name}.liquid`);
           const doc = documentManager.get(uri);
           if (doc?.type !== SourceCodeType.LiquidHtml) return undefined;
-          return doc.schema as SectionSchema;
+          const schema = await doc.getSchema();
+          return schema as SectionSchema | undefined;
         },
       });
 

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -1,4 +1,12 @@
-import { check, findRoot, makeFileExists } from '@shopify/theme-check-common';
+import {
+  BlockSchema,
+  check,
+  findRoot,
+  makeFileExists,
+  path,
+  SectionSchema,
+  SourceCodeType,
+} from '@shopify/theme-check-common';
 
 import { DocumentManager } from '../documents';
 import { Dependencies } from '../types';
@@ -39,10 +47,24 @@ export function makeRunChecks(
       const config = await loadConfig(configFileRootUri, fs);
       const theme = documentManager.theme(config.rootUri);
       const offenses = await check(theme, config, {
-        jsonValidationSet,
-        themeDocset,
         fs,
+        themeDocset,
+        jsonValidationSet,
         getMetafieldDefinitions,
+        async getBlockSchema(name) {
+          // We won't preload here. If it's available, we'll give it. Otherwise expect nothing.
+          const uri = path.join(config.rootUri, 'blocks', `${name}.liquid`);
+          const doc = documentManager.get(uri);
+          if (doc?.type !== SourceCodeType.LiquidHtml) return undefined;
+          return doc.schema as BlockSchema;
+        },
+        async getSectionSchema(name) {
+          // We won't preload here. If it's available, we'll give it. Otherwise expect nothing.
+          const uri = path.join(config.rootUri, 'sections', `${name}.liquid`);
+          const doc = documentManager.get(uri);
+          if (doc?.type !== SourceCodeType.LiquidHtml) return undefined;
+          return doc.schema as SectionSchema;
+        },
       });
 
       // We iterate over the theme files (as opposed to offenses) because if

--- a/packages/theme-language-server-common/src/documents/DocumentManager.spec.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.spec.ts
@@ -1,4 +1,11 @@
-import { path } from '@shopify/theme-check-common';
+import {
+  AbstractFileSystem,
+  path,
+  Section,
+  Setting,
+  ThemeBlock,
+  ThemeSchemaType,
+} from '@shopify/theme-check-common';
 import { MockFileSystem } from '@shopify/theme-check-common/src/test';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { URI, Utils } from 'vscode-uri';
@@ -9,6 +16,8 @@ import { ClientCapabilities } from '../ClientCapabilities';
 describe('Module: DocumentManager', () => {
   const mockRoot = 'mock-fs:';
   let documentManager: DocumentManager;
+  let connection: ReturnType<typeof mockConnection>;
+  let fs: AbstractFileSystem;
 
   beforeEach(() => {
     documentManager = new DocumentManager();
@@ -30,8 +39,7 @@ describe('Module: DocumentManager', () => {
     expect(theme[0].uri).to.equal(path.normalize(fileUri));
   });
 
-  describe('when initialized and preloaded with an abstract file system', () => {
-    let fs: MockFileSystem;
+  describe('when initialized with an abstract file system', () => {
     beforeEach(async () => {
       fs = new MockFileSystem(
         {
@@ -42,145 +50,227 @@ describe('Module: DocumentManager', () => {
       );
       documentManager = new DocumentManager(fs);
       vi.spyOn(fs, 'readFile');
-      await documentManager.preload('mock-fs:/');
     });
 
-    it('preloads source codes with a version of undefined', async () => {
-      const sc = documentManager.get('mock-fs:/snippet/foo.liquid');
-      assert(sc);
-      expect(sc.version).to.equal(undefined);
-    });
-
-    it('returns defined versions of opened files', () => {
-      documentManager.open('mock-fs:/snippet/foo.liquid', 'hello {% render "bar" %}', 0);
-      const sc = documentManager.get('mock-fs:/snippet/foo.liquid');
-      assert(sc);
-      expect(sc.version).to.equal(0);
-    });
-
-    describe('Unit: theme(rootUri, includeFilesFromDisk)', () => {
-      it('only returns the source codes of the opened files by default', () => {
-        const theme = documentManager.theme('mock-fs:/');
-        expect(theme).to.have.lengthOf(0);
+    describe('when the abstract file system is preloaded', () => {
+      beforeEach(async () => {
+        await documentManager.preload('mock-fs:/');
       });
 
-      it('returns all the files when called with includeFilesFromDisk', async () => {
-        const theme = documentManager.theme('mock-fs:/', true);
-        expect(theme).to.have.lengthOf(2);
-      });
-    });
-
-    describe('Unit: close(uri)', () => {
-      it('sets the source version to undefined (value is on disk)', () => {
-        documentManager.open('mock-fs:/snippet/foo.liquid', 'hello {% render "bar" %}', 10);
-        documentManager.close('mock-fs:/snippet/foo.liquid');
+      it('preloads source codes with a version of undefined', async () => {
         const sc = documentManager.get('mock-fs:/snippet/foo.liquid');
         assert(sc);
-        expect(sc.source).to.equal('hello {% render "bar" %}');
         expect(sc.version).to.equal(undefined);
       });
-    });
 
-    describe('Unit: delete(uri)', () => {
-      it('deletes the source code from the document manager', () => {
-        // as though the file no longer exists
-        documentManager.open('mock-fs:/snippet/foo.liquid', 'hello {% render "bar" %}', 10);
-        documentManager.delete('mock-fs:/snippet/foo.liquid');
+      it('returns defined versions of opened files', () => {
+        documentManager.open('mock-fs:/snippet/foo.liquid', 'hello {% render "bar" %}', 0);
         const sc = documentManager.get('mock-fs:/snippet/foo.liquid');
-        assert(!sc);
+        assert(sc);
+        expect(sc.version).to.equal(0);
+      });
+
+      describe('Unit: theme(rootUri, includeFilesFromDisk)', () => {
+        it('only returns the source codes of the opened files by default', () => {
+          const theme = documentManager.theme('mock-fs:/');
+          expect(theme).to.have.lengthOf(0);
+        });
+
+        it('returns all the files when called with includeFilesFromDisk', async () => {
+          const theme = documentManager.theme('mock-fs:/', true);
+          expect(theme).to.have.lengthOf(2);
+        });
+      });
+
+      describe('Unit: close(uri)', () => {
+        it('sets the source version to undefined (value is on disk)', () => {
+          documentManager.open('mock-fs:/snippet/foo.liquid', 'hello {% render "bar" %}', 10);
+          documentManager.close('mock-fs:/snippet/foo.liquid');
+          const sc = documentManager.get('mock-fs:/snippet/foo.liquid');
+          assert(sc);
+          expect(sc.source).to.equal('hello {% render "bar" %}');
+          expect(sc.version).to.equal(undefined);
+        });
+      });
+
+      describe('Unit: delete(uri)', () => {
+        it('deletes the source code from the document manager', () => {
+          // as though the file no longer exists
+          documentManager.open('mock-fs:/snippet/foo.liquid', 'hello {% render "bar" %}', 10);
+          documentManager.delete('mock-fs:/snippet/foo.liquid');
+          const sc = documentManager.get('mock-fs:/snippet/foo.liquid');
+          assert(!sc);
+        });
+      });
+
+      describe('Unit: preload(rootUri)', () => {
+        it('should be memoized and only run once', async () => {
+          await documentManager.preload('mock-fs:/');
+          await documentManager.preload('mock-fs:/');
+          await documentManager.preload('mock-fs:/');
+          await documentManager.preload('mock-fs:/');
+          expect(vi.mocked(fs.readFile)).toHaveBeenCalledTimes(
+            documentManager.theme('mock-fs:/', true).length,
+          );
+        });
       });
     });
+  });
 
-    describe('Unit: preload(rootUri)', () => {
-      it('should be memoized and only run once', async () => {
-        await documentManager.preload('mock-fs:/');
-        await documentManager.preload('mock-fs:/');
-        await documentManager.preload('mock-fs:/');
-        await documentManager.preload('mock-fs:/');
-        expect(vi.mocked(fs.readFile)).toHaveBeenCalledTimes(
-          documentManager.theme('mock-fs:/', true).length,
-        );
+  describe('when initialized with a connection & hasProgressSupport', () => {
+    beforeEach(() => {
+      const capabilities = new ClientCapabilities();
+      capabilities.setup({
+        window: {
+          workDoneProgress: true,
+        },
+      });
+      connection = mockConnection(mockRoot);
+      connection.spies.onRequest.mockImplementationOnce(async (method) => {
+        switch (method) {
+          case 'window/workDoneProgress/create':
+            return 'ok';
+          default:
+            throw new Error(`Unexpected method: ${method}`);
+        }
       });
 
-      describe('When initialized with a connection & hasProgressSupport', () => {
-        let connection: ReturnType<typeof mockConnection>;
+      fs = new MockFileSystem(
+        {
+          'snippet/1.liquid': `hello {% render 'bar' %}`,
+          'snippet/2.liquid': `hello {% render 'bar' %}`,
+          'snippet/3.liquid': `hello {% render 'bar' %}`,
+          'snippet/4.liquid': `hello {% render 'bar' %}`,
+          'snippet/5.liquid': `hello {% render 'bar' %}`,
+          'snippet/6.liquid': `hello {% render 'bar' %}`,
+          'snippet/7.liquid': `hello {% render 'bar' %}`,
+          'snippet/8.liquid': `hello {% render 'bar' %}`,
+          'snippet/9.liquid': `hello {% render 'bar' %}`,
+          'snippet/10.liquid': `hello {% render 'bar' %}`,
+        },
+        mockRoot,
+      );
+      vi.spyOn(fs, 'readFile');
 
-        beforeEach(() => {
-          const capabilities = new ClientCapabilities();
-          capabilities.setup({
-            window: {
-              workDoneProgress: true,
-            },
-          });
-          connection = mockConnection(mockRoot);
-          connection.spies.onRequest.mockImplementationOnce(async (method) => {
-            switch (method) {
-              case 'window/workDoneProgress/create':
-                return 'ok';
-              default:
-                throw new Error(`Unexpected method: ${method}`);
-            }
-          });
+      documentManager = new DocumentManager(fs, connection, capabilities);
+    });
 
-          fs = new MockFileSystem(
-            {
-              'snippet/1.liquid': `hello {% render 'bar' %}`,
-              'snippet/2.liquid': `hello {% render 'bar' %}`,
-              'snippet/3.liquid': `hello {% render 'bar' %}`,
-              'snippet/4.liquid': `hello {% render 'bar' %}`,
-              'snippet/5.liquid': `hello {% render 'bar' %}`,
-              'snippet/6.liquid': `hello {% render 'bar' %}`,
-              'snippet/7.liquid': `hello {% render 'bar' %}`,
-              'snippet/8.liquid': `hello {% render 'bar' %}`,
-              'snippet/9.liquid': `hello {% render 'bar' %}`,
-              'snippet/10.liquid': `hello {% render 'bar' %}`,
-            },
-            mockRoot,
-          );
-          vi.spyOn(fs, 'readFile');
+    it('should report progress while preloading', async () => {
+      await documentManager.preload(mockRoot);
+      expect(connection.spies.sendProgress).toHaveBeenCalledTimes(4);
+      expect(connection.spies.sendProgress).toHaveBeenCalledWith(
+        expect.anything(),
+        'preload#mock-fs:',
+        {
+          kind: 'begin',
+          title: 'Initializing Liquid LSP',
+        },
+      );
+      expect(connection.spies.sendProgress).toHaveBeenCalledWith(
+        expect.anything(),
+        'preload#mock-fs:',
+        {
+          kind: 'report',
+          message: 'Preloading files',
+          percentage: 10,
+        },
+      );
+      expect(connection.spies.sendProgress).toHaveBeenCalledWith(
+        expect.anything(),
+        'preload#mock-fs:',
+        {
+          kind: 'report',
+          message: 'Preloading files [10/10]',
+          percentage: 100,
+        },
+      );
+      expect(connection.spies.sendProgress).toHaveBeenCalledWith(
+        expect.anything(),
+        'preload#mock-fs:',
+        {
+          kind: 'end',
+          message: 'Completed',
+        },
+      );
+    });
+  });
 
-          documentManager = new DocumentManager(fs, connection, capabilities);
-        });
+  describe('when initialized with a fs, getModeForURI, and isValidSchema', () => {
+    const mockFsRoot = path.normalize('mock-fs:/theme');
+    const sectionSchema: Section.Schema = {
+      name: 'hello',
+      settings: [{ type: 'number' as Setting.Type.Number, id: 'my_num' }],
+      default: { settings: { my_num: 1 } },
+    };
+    const blockSchema: ThemeBlock.Schema = {
+      name: 'world',
+      blocks: [{ type: '@theme' }],
+    };
 
-        it('should report progress while preloading', async () => {
-          await documentManager.preload(mockRoot);
-          expect(connection.spies.sendProgress).toHaveBeenCalledTimes(4);
-          expect(connection.spies.sendProgress).toHaveBeenCalledWith(
-            expect.anything(),
-            'preload#mock-fs:',
-            {
-              kind: 'begin',
-              title: 'Initializing Liquid LSP',
-            },
-          );
-          expect(connection.spies.sendProgress).toHaveBeenCalledWith(
-            expect.anything(),
-            'preload#mock-fs:',
-            {
-              kind: 'report',
-              message: 'Preloading files',
-              percentage: 10,
-            },
-          );
-          expect(connection.spies.sendProgress).toHaveBeenCalledWith(
-            expect.anything(),
-            'preload#mock-fs:',
-            {
-              kind: 'report',
-              message: 'Preloading files [10/10]',
-              percentage: 100,
-            },
-          );
-          expect(connection.spies.sendProgress).toHaveBeenCalledWith(
-            expect.anything(),
-            'preload#mock-fs:',
-            {
-              kind: 'end',
-              message: 'Completed',
-            },
-          );
-        });
-      });
+    beforeEach(async () => {
+      fs = new MockFileSystem(
+        {
+          'sections/foo.liquid': `
+             {% schema %}
+               ${JSON.stringify(sectionSchema, null, 2)}
+             {% endschema %}`,
+          'blocks/bar.liquid': `
+            {% schema %}
+              ${JSON.stringify(blockSchema, null, 2)}
+            {% endschema %}`,
+        },
+        mockFsRoot,
+      );
+      documentManager = new DocumentManager(
+        fs,
+        undefined,
+        undefined,
+        async () => 'theme',
+        async () => true, // let's assume they are valid for testing purposes...
+      );
+      await documentManager.preload(mockFsRoot);
+    });
+
+    it('should augment section files with a getSchema property that resolves to a type-safe schema', async () => {
+      const section = documentManager.get(path.join(mockFsRoot, 'sections/foo.liquid'));
+      assert(section);
+      assert(section.type === 'LiquidHtml');
+      const schema = await section.getSchema();
+      assert(schema);
+      assert(schema.type === ThemeSchemaType.Section);
+      expect(schema.parsed).to.eql(sectionSchema);
+      const validSchema = schema.validSchema;
+      assert(!(validSchema instanceof Error));
+
+      // Note below that validSchema.name is accessed in a type-safe manner
+      expect(validSchema.name).to.equal(sectionSchema.name);
+      assert(validSchema.settings);
+      for (const setting of validSchema.settings) {
+        assert(setting.type);
+        assert(setting.id);
+      }
+
+      // Default is a section-only property
+      assert(validSchema.default);
+    });
+
+    it('should augment block files with a getSchema property that resolves to a type-safe schema', async () => {
+      const block = documentManager.get(path.join(mockFsRoot, 'blocks/bar.liquid'));
+      assert(block);
+      assert(block.type === 'LiquidHtml');
+      const schema = await block.getSchema();
+      assert(schema);
+      assert(schema.type === ThemeSchemaType.Block);
+      expect(schema.parsed).to.eql(blockSchema);
+      const validSchema = schema.validSchema;
+      assert(!(validSchema instanceof Error));
+
+      // Note below that validSchema.name is accessed in a type-safe manner
+      expect(validSchema.name).to.equal(blockSchema.name);
+      assert(validSchema.blocks);
+      for (const block of validSchema.blocks) {
+        assert(block.type);
+      }
     });
   });
 });

--- a/packages/theme-language-server-common/src/documents/index.ts
+++ b/packages/theme-language-server-common/src/documents/index.ts
@@ -1,6 +1,2 @@
-export {
-  DocumentManager,
-  AugmentedSourceCode,
-  AugmentedJsonSourceCode,
-  AugmentedLiquidSourceCode,
-} from './DocumentManager';
+export { DocumentManager } from './DocumentManager';
+export * from './types';

--- a/packages/theme-language-server-common/src/documents/types.ts
+++ b/packages/theme-language-server-common/src/documents/types.ts
@@ -2,7 +2,8 @@ import {
   SourceCodeType,
   SourceCode,
   SectionSchema,
-  BlockSchema,
+  ThemeBlockSchema,
+  AppBlockSchema,
 } from '@shopify/theme-check-common';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
@@ -21,7 +22,7 @@ export type AugmentedJsonSourceCode = _AugmentedSourceCode<SourceCodeType.JSON>;
  * about cache invalidation and will mean we'll parse the schema at most once.
  */
 export type AugmentedLiquidSourceCode = _AugmentedSourceCode<SourceCodeType.LiquidHtml> & {
-  schema?: SectionSchema | BlockSchema;
+  getSchema: () => Promise<SectionSchema | ThemeBlockSchema | AppBlockSchema | undefined>;
 };
 
 /**

--- a/packages/theme-language-server-common/src/documents/types.ts
+++ b/packages/theme-language-server-common/src/documents/types.ts
@@ -1,0 +1,40 @@
+import {
+  SourceCodeType,
+  SourceCode,
+  SectionSchema,
+  BlockSchema,
+} from '@shopify/theme-check-common';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+/** Util type to add the common `textDocument` property to the SourceCode. */
+type _AugmentedSourceCode<SCT extends SourceCodeType = SourceCodeType> = SourceCode<SCT> & {
+  textDocument: TextDocument;
+};
+
+/** JsonSourceCode + textDocument */
+export type AugmentedJsonSourceCode = _AugmentedSourceCode<SourceCodeType.JSON>;
+
+/**
+ * AugmentedLiquidSourceCode may hold the schema for the section or block.
+ *
+ * We'll use the SourceCode as the source of truth since we won't need to care
+ * about cache invalidation and will mean we'll parse the schema at most once.
+ */
+export type AugmentedLiquidSourceCode = _AugmentedSourceCode<SourceCodeType.LiquidHtml> & {
+  schema?: SectionSchema | BlockSchema;
+};
+
+/**
+ * AugmentedSourceCode is a union of the two augmented source codes.
+ *
+ * When passed a specific SourceCodeType, it will return the correct AugmentedSourceCode.
+ *
+ * @example
+ * AugmentedSourceCode -> AugmentedJsonSourceCode | AugmentedLiquidSourceCode
+ * AugmentedSourceCode<SourceCodeType.JSON> -> AugmentedJsonSourceCode
+ * AugmentedSourceCode<SourceCodeType.LiquidHtml> -> AugmentedLiquidSourceCode
+ */
+export type AugmentedSourceCode<SCT extends SourceCodeType = SourceCodeType> = {
+  [SourceCodeType.JSON]: AugmentedJsonSourceCode;
+  [SourceCodeType.LiquidHtml]: AugmentedLiquidSourceCode;
+}[SCT];

--- a/packages/theme-language-server-common/src/json/JSONLanguageService.spec.ts
+++ b/packages/theme-language-server-common/src/json/JSONLanguageService.spec.ts
@@ -401,6 +401,44 @@ describe('Module: JSONLanguageService', () => {
     });
   });
 
+  describe('isValidSchema', () => {
+    it('should return true for a valid schema', async () => {
+      const params = getParams(
+        documentManager,
+        'sections/section.liquid',
+        `
+          <div>hello world</div>
+          {% schema %}
+            { "name": "hello world" }
+          {% endschema %}
+        `,
+      );
+      const isValid = await jsonLanguageService.isValidSchema(
+        params.textDocument.uri,
+        '{ "name": "hello world" }',
+      );
+      expect(isValid).to.be.true;
+    });
+
+    it('should return false for an invalid schema', async () => {
+      const params = getParams(
+        documentManager,
+        'sections/section.liquid',
+        `
+          <div>hello world</div>
+          {% schema %}
+            { "invalid": true }
+          {% endschema %}
+        `,
+      );
+      const isValid = await jsonLanguageService.isValidSchema(
+        params.textDocument.uri,
+        '{ "invalid": true }',
+      );
+      expect(isValid).to.be.false;
+    });
+  });
+
   function getParams(
     documentManager: DocumentManager,
     relativePath: string,

--- a/packages/theme-language-server-common/src/json/JSONLanguageService.ts
+++ b/packages/theme-language-server-common/src/json/JSONLanguageService.ts
@@ -1,11 +1,13 @@
 import { LiquidRawTag, NodeTypes } from '@shopify/liquid-html-parser';
 import {
+  IsValidSchema,
   JsonValidationSet,
   Mode,
   Modes,
   SchemaDefinition,
   SourceCodeType,
-  indexBy,
+  findCurrentNode,
+  isValid,
 } from '@shopify/theme-check-common';
 import { JSONDocument, LanguageService, getLanguageService } from 'vscode-json-languageservice';
 import {
@@ -18,10 +20,9 @@ import {
 } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DocumentManager } from '../documents';
-import { findCurrentNode } from '@shopify/theme-check-common';
-import { TranslationFileContributions } from './TranslationFileContributions';
-import { SchemaTranslationContributions } from './SchemaTranslationContributions';
 import { GetTranslationsForURI } from '../translations';
+import { SchemaTranslationContributions } from './SchemaTranslationContributions';
+import { TranslationFileContributions } from './TranslationFileContributions';
 
 export class JSONLanguageService {
   // We index by Mode here because I don't want to reconfigure the service depending on the URI.
@@ -114,6 +115,13 @@ export class JSONLanguageService {
     const [jsonTextDocument, jsonDocument] = documents;
     return service.doHover(jsonTextDocument, params.position, jsonDocument);
   }
+
+  public isValidSchema: IsValidSchema = async (uri: string, jsonString: string) => {
+    const mode = await this.getModeForURI(uri);
+    const service = this.services[mode];
+    if (!service) return false;
+    return isValid(service, uri, jsonString);
+  };
 
   private getDocuments(
     params: HoverParams | CompletionParams,


### PR DESCRIPTION
## What are you adding in this PR?

- **Add `getSectionSchema` and `getBlockSchema` context utils in theme check**
  - The `validSchema` property of the returned value (when no errors happened parsing and the schema is validated by our JSON schema) is a type-safe representation of the schema.
- **Add {ThemeBlock,Section}.Schema TypeScript types**
- **Provide better building blocks for dealing with schemas**
- Refactor `ValidSchemaName` as a proof of concept


https://github.com/user-attachments/assets/1cc23b2c-65eb-414a-ae2e-9953c91b6fba



## What's next? Any followup issues?

- [ ] Translate the app block schemas into typescript interfaces and fill in the blanks for app blocks
- [ ] Figure out a way to avoid breaking drift btn Shopify/theme-liquid-docs JSON schemas & our types.

## Before you deploy

- [x] I included a minor bump `changeset`

    _The getBlockSchema & getSectionSchema_ are technically in the public API even though you don't need to provide them in theme-check-node nor to theme-language-server
