### PR TITLE
Check preset blocks_order

### DIFF
--- a/.changeset/smooth-cycles-hear.md
+++ b/.changeset/smooth-cycles-hear.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+'@shopify/theme-check-vscode': minor
+---
+
+Add `SchemaPresetsBlockOrder` check

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -24,6 +24,7 @@ import { MissingAsset } from './missing-asset';
 import { MissingTemplate } from './missing-template';
 import { PaginationSize } from './pagination-size';
 import { ParserBlockingScript } from './parser-blocking-script';
+import { SchemaPresetsBlockOrder } from './schema-presets-block-order';
 import { RemoteAsset } from './remote-asset';
 import { RequiredLayoutThemeObject } from './required-layout-theme-object';
 import { TranslationKeyExists } from './translation-key-exists';
@@ -68,6 +69,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   MissingSchema,
   PaginationSize,
   ParserBlockingScript,
+  SchemaPresetsBlockOrder,
   RemoteAsset,
   RequiredLayoutThemeObject,
   TranslationKeyExists,

--- a/packages/theme-check-common/src/checks/schema-presets-block-order/index.spec.ts
+++ b/packages/theme-check-common/src/checks/schema-presets-block-order/index.spec.ts
@@ -1,0 +1,316 @@
+import { expect, describe, it } from 'vitest';
+import { highlightedOffenses, runLiquidCheck, check } from '../../test';
+import { SchemaPresetsBlockOrder } from './index';
+
+const DEFAULT_FILE_NAME = 'sections/file.liquid';
+
+describe('Module: SchemaPresetsBlockOrder', () => {
+  it('reports no warning when the preset blocks are in the block_order', async () => {
+    const sourceCode = `
+        {% schema %}
+        {
+          "presets": [
+            {
+              "name": "Preset 1",
+              "blocks": {
+                "block-1": {
+                  "type": "text"
+                },
+                "block-2": {
+                  "type": "icon"
+                }
+              },
+              "block_order": ["block-1", "block-2"]
+            }
+          ]
+        }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports a warning when not all preset blocks are in the block_order', async () => {
+    const sourceCode = `
+      {% schema %}
+      {
+        "name": "Test section",
+        "presets": [
+          {
+            "name": "Preset 1",
+            "blocks": {
+              "block-1": {
+                "type": "text"
+              },
+              "block-2": {
+                "type": "icon"
+              }
+            },
+            "block_order": ["block-1"]
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual("block 'block-2' is missing from the block_order");
+
+    const highlights = highlightedOffenses({ [DEFAULT_FILE_NAME]: sourceCode }, offenses);
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toBe('["block-1"]');
+  });
+
+  it('reports no warning when the preset blocks has static blocks that are not in the block_order', async () => {
+    const sourceCode = `
+      {% schema %}
+        {
+          "presets": [
+            {
+              "name": "Preset 1",
+              "blocks": {
+                "block-1": {
+                  "type": "text"
+                },
+                "block-2": {
+                  "type": "icon",
+                  "static": true
+                }
+              },
+              "block_order": ["block-1"]
+            }
+          ]
+        }
+        {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports a warning when preset blocks has static blocks that are in the block_order', async () => {
+    const sourceCode = `
+      {% schema %}
+      {
+        "presets": [
+          {
+            "name": "Preset 1",
+            "blocks": {
+              "block-1": {
+                "type": "text"
+              },
+              "block-2": {
+                "type": "icon",
+                "static": true
+              }
+            },
+            "block_order": ["block-1", "block-2"]
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual("static block 'block-2' cannot be in the block_order");
+
+    const highlights = highlightedOffenses({ [DEFAULT_FILE_NAME]: sourceCode }, offenses);
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toBe('["block-1", "block-2"]');
+  });
+
+  it('reports no warning when the nested preset blocks are in the block_order', async () => {
+    const sourceCode = `
+      {% schema %}
+      {
+        "presets": [
+          {
+            "name": "Preset 1",
+            "blocks": {
+              "block-1": {
+                "type": "text",
+                "blocks": {
+                  "nested-1": {
+                    "type": "nested"
+                  },
+                  "nested-2": {
+                    "type": "nested"
+                  }
+                },
+                "block_order": ["nested-1", "nested-2"]
+              },
+              "block-2": {
+                "type": "icon"
+              }
+            },
+            "block_order": ["block-1", "block-2"]
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports a warning when the nested preset blocks are not in the block_order', async () => {
+    const sourceCode = `
+      {% schema %}
+      {
+        "presets": [
+          {
+            "name": "Preset 1",
+            "blocks": {
+              "block-1": {
+                "type": "text",
+                "blocks": {
+                  "nested-1": {
+                    "type": "nested"
+                  },
+                  "nested-2": {
+                    "type": "nested"
+                  }
+                },
+                "block_order": ["nested-1"]
+              },
+              "block-2": {
+                "type": "icon"
+              }
+            },
+            "block_order": ["block-1", "block-2"]
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual("block 'nested-2' is missing from the block_order");
+
+    const highlights = highlightedOffenses({ [DEFAULT_FILE_NAME]: sourceCode }, offenses);
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toBe('["nested-1"]');
+  });
+
+  it('reports no warning when the nested preset blocks has static blocks that are not in the block_order', async () => {
+    const sourceCode = `
+      {% schema %}
+      {
+        "presets": [
+          {
+            "name": "Preset 1",
+            "blocks": {
+              "block-1": {
+                "type": "text",
+                "blocks": {
+                  "nested-1": {
+                    "type": "nested",
+                    "static": true
+                  },
+                  "nested-2": {
+                    "type": "nested"
+                  }
+                },
+                "block_order": ["nested-2"]
+              },
+              "block-2": {
+                "type": "icon"
+              }
+            },
+            "block_order": ["block-1", "block-2"]
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports a warning when the nested preset blocks has static blocks that are in the block_order', async () => {
+    const sourceCode = `
+      {% schema %}
+      {
+        "presets": [
+          {
+            "name": "Preset 1",
+            "blocks": {
+              "block-1": {
+                "type": "text",
+                "blocks": {
+                  "nested-1": {
+                    "type": "nested",
+                    "static": true
+                  },
+                  "nested-2": {
+                    "type": "nested"
+                  }
+                },
+                "block_order": ["nested-1", "nested-2"]
+              },
+              "block-2": {
+                "type": "icon"
+              }
+            },
+            "block_order": ["block-1", "block-2"]
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual("static block 'nested-1' cannot be in the block_order");
+
+    const highlights = highlightedOffenses({ [DEFAULT_FILE_NAME]: sourceCode }, offenses);
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toBe('["nested-1", "nested-2"]');
+  });
+
+  it('reports a warning when there should be a block_order but it is missing', async () => {
+    const sourceCode = `
+      {% schema %}
+      {
+        "name": "Test section",
+        "presets": [
+          {
+            "name": "Preset 1",
+            "blocks": {
+              "block-1": {
+                "type": "text"
+              }
+            }
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual('block_order is missing');
+
+    const highlights = highlightedOffenses({ [DEFAULT_FILE_NAME]: sourceCode }, offenses);
+    expect(highlights).toHaveLength(1);
+  });
+
+  it('reports no warning we have all static blocks and no block_order', async () => {
+    const sourceCode = `
+        {% schema %}
+        {
+          "presets": [
+            {
+              "name": "Preset 1",
+              "blocks": {
+                "block-1": {
+                  "type": "text",
+                  "static": true
+                }
+              }
+            }
+          ]
+        }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsBlockOrder, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/schema-presets-block-order/index.ts
+++ b/packages/theme-check-common/src/checks/schema-presets-block-order/index.ts
@@ -1,0 +1,149 @@
+import { ArrayNode } from 'json-to-ast';
+import { getLocEnd, getLocStart, nodeAtPath } from '../../json';
+import { basename } from '../../path';
+import { isBlock, isSection } from '../../to-schema';
+import { JSONNode, LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { Preset } from '../../types/schemas/preset';
+import { ThemeBlock } from '../../types/schemas/theme-block';
+import { Context } from '../../types';
+
+export const SchemaPresetsBlockOrder: LiquidCheckDefinition = {
+  meta: {
+    code: 'SchemaPresetsBlockOrder',
+    name: 'Gives recommendations and validations for block_order',
+    docs: {
+      description:
+        'Gives recommendations and validations for block_order for preset blocks as a hash.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/schema-presets-block-order',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    function getSchema() {
+      const name = basename(context.file.uri, '.liquid');
+      switch (true) {
+        case isBlock(context.file.uri):
+          return context.getBlockSchema?.(name);
+        case isSection(context.file.uri):
+          return context.getSectionSchema?.(name);
+        default:
+          return undefined;
+      }
+    }
+
+    return {
+      async LiquidRawTag(node) {
+        if (node.name !== 'schema' || node.body.kind !== 'json') {
+          return;
+        }
+
+        const offset = node.blockStartPosition.end;
+        const schema = await getSchema();
+        const { validSchema, ast } = schema ?? {};
+        if (!validSchema || validSchema instanceof Error) return;
+        if (!ast || ast instanceof Error) return;
+
+        const presets = validSchema.presets;
+        if (!presets) return;
+
+        presets.forEach((preset, index) => {
+          if ('blocks' in preset && preset.blocks) {
+            checkBlockOrder(preset, context, offset, ast, ['presets', String(index)]);
+          }
+        });
+      },
+    };
+  },
+};
+
+function checkBlockOrder(
+  node: Preset.Preset | Preset.PresetBlockForHash,
+  context: Context<SourceCodeType.LiquidHtml>,
+  offset: number,
+  ast: JSONNode,
+  ast_path: string[],
+) {
+  if ('blocks' in node && typeof node.blocks == 'object' && node.blocks) {
+    const blockOrder = 'block_order' in node ? node.block_order : undefined;
+    // check 1: is block_order missing?
+    if (!blockOrder) {
+      if (shouldHaveBlockOrder(node)) {
+        reportWarning(context, offset, ast, ast_path, `block_order is missing`, false);
+      }
+    }
+
+    // check 2: are items in block_order valid/missing?
+    for (const [block_id, block] of Object.entries(node.blocks)) {
+      if (block.static) {
+        // if static block is in the block_order, that's an error
+        if (Array.isArray(blockOrder) && blockOrder.includes(block_id)) {
+          const warning_ast_path = ast_path.concat(['block_order']);
+          reportWarning(
+            context,
+            offset,
+            ast,
+            warning_ast_path,
+            `static block '${block_id}' cannot be in the block_order`,
+          );
+        }
+      } else {
+        // if non-static block is not in the block_order, that's a potential mistake
+        if (Array.isArray(blockOrder) && !blockOrder.includes(block_id)) {
+          const warning_ast_path = ast_path.concat(['block_order']);
+          reportWarning(
+            context,
+            offset,
+            ast,
+            warning_ast_path,
+            `block '${block_id}' is missing from the block_order`,
+          );
+        }
+      }
+
+      //recursive check for nested blocks
+      if (block.blocks) {
+        ast_path.push('blocks', block_id); // so we'll get ['presets', 0, 'blocks', 'my_block1'] for example to do nodeAtPath(schema.ast, ast_path)
+        checkBlockOrder(block, context, offset, ast, ast_path);
+      }
+    }
+  }
+}
+
+function shouldHaveBlockOrder(node: Preset.Preset | Preset.PresetBlockForHash): boolean {
+  if (
+    'blocks' in node &&
+    typeof node.blocks === 'object' &&
+    node.blocks !== null &&
+    !Array.isArray(node.blocks)
+  ) {
+    return Object.entries(node.blocks).some(([_blockId, block]) => {
+      // If static is undefined or false, it's considered non-static
+      return block.static !== true;
+    });
+  }
+
+  return false;
+}
+
+function reportWarning(
+  context: Context<SourceCodeType.LiquidHtml>,
+  offset: number,
+  ast: JSONNode,
+  ast_path: string[],
+  message: string,
+  fullHighlight: boolean = true,
+) {
+  const node = nodeAtPath(ast, ast_path)! as ArrayNode;
+  const startIndex = fullHighlight ? offset + getLocStart(node) : offset + getLocEnd(node) - 1; // start to finish of the node or last char of the node
+  const endIndex = offset + getLocEnd(node);
+  context.report({
+    message: message,
+    startIndex,
+    endIndex,
+  });
+}

--- a/packages/theme-check-common/src/checks/valid-block-target/index.ts
+++ b/packages/theme-check-common/src/checks/valid-block-target/index.ts
@@ -18,7 +18,7 @@ import {
   reportWarning,
 } from './block-utils';
 type BlockNodeWithPath = {
-  node: Preset.BlockPresetBase;
+  node: Section.Block | ThemeBlock.Block | Preset.Block;
   path: string[];
 };
 

--- a/packages/theme-check-common/src/checks/valid-local-blocks/index.ts
+++ b/packages/theme-check-common/src/checks/valid-local-blocks/index.ts
@@ -1,4 +1,4 @@
-import { LiquidCheckDefinition, Preset, Severity, SourceCodeType } from '../../types';
+import { LiquidCheckDefinition, Preset, Severity, SourceCodeType, Section } from '../../types';
 import { LiteralNode } from 'json-to-ast';
 import { nodeAtPath } from '../../json';
 import { basename } from '../../path';
@@ -6,7 +6,7 @@ import { isBlock, isSection } from '../../to-schema';
 import { getBlocks, reportWarning } from './valid-block-utils';
 
 type BlockNodeWithPath = {
-  node: Preset.BlockPresetBase;
+  node: Section.Block | Preset.Block;
   path: string[];
 };
 

--- a/packages/theme-check-common/src/checks/valid-local-blocks/valid-block-utils.ts
+++ b/packages/theme-check-common/src/checks/valid-local-blocks/valid-block-utils.ts
@@ -3,7 +3,7 @@ import { getLocEnd, getLocStart } from '../../json';
 import { Preset, ThemeBlock, Section, Context, SourceCodeType } from '../../types';
 
 type BlockNodeWithPath = {
-  node: Preset.BlockPresetBase;
+  node: Section.Block | ThemeBlock.Block | Preset.Block;
   path: string[];
 };
 
@@ -22,7 +22,10 @@ export function getBlocks(validSchema: ThemeBlock.Schema | Section.Schema): {
   const rootLevelBlocks = validSchema.blocks;
   const presets = validSchema.presets;
 
-  function categorizeBlock(block: Preset.BlockPresetBase, currentPath: string[]) {
+  function categorizeBlock(
+    block: Section.Block | ThemeBlock.Block | Preset.Block,
+    currentPath: string[],
+  ) {
     if (!block) return;
     const hasStatic = 'static' in block;
     const hasName = 'name' in block;
@@ -39,7 +42,7 @@ export function getBlocks(validSchema: ThemeBlock.Schema | Section.Schema): {
 
     if ('blocks' in block) {
       if (Array.isArray(block.blocks)) {
-        block.blocks.forEach((nestedBlock: Preset.BlockPresetBase, index: number) => {
+        block.blocks.forEach((nestedBlock: Preset.PresetBlockForArray, index: number) => {
           categorizeBlock(nestedBlock, currentPath.concat('blocks', String(index)));
         });
       } else if (typeof block.blocks === 'object' && block.blocks !== null) {
@@ -58,9 +61,9 @@ export function getBlocks(validSchema: ThemeBlock.Schema | Section.Schema): {
 
   if (presets) {
     presets.forEach((preset: Preset.Preset, presetIndex: number) => {
-      if (preset.blocks) {
+      if ('blocks' in preset && preset.blocks) {
         if (Array.isArray(preset.blocks)) {
-          preset.blocks.forEach((block: Preset.BlockPresetBase, blockIndex: number) => {
+          preset.blocks.forEach((block: Preset.PresetBlockForArray, blockIndex: number) => {
             categorizeBlock(block, ['presets', String(presetIndex), 'blocks', String(blockIndex)]);
           });
         } else if (typeof preset.blocks === 'object') {

--- a/packages/theme-check-common/src/types/schemas/preset.ts
+++ b/packages/theme-check-common/src/types/schemas/preset.ts
@@ -2,26 +2,51 @@ import { Setting } from './setting';
 
 export declare namespace Preset {
   // Preset definitions
-  export interface Preset {
-    name: string;
-    settings?: Record<string, string | number | boolean | string[]>;
-    blocks?: PresetBlocks;
-  }
+  export type Preset =
+    | {
+        name: string;
+        settings?: Setting.Values;
+        blocks?: PresetBlockHash;
+        block_order?: string[];
+      }
+    | {
+        name: string;
+        settings?: Setting.Values;
+        blocks?: PresetBlockForArray[];
+      }
+    | { name: string; settings?: Setting.Values };
 
   // Reuse the block preset types from ThemeBlock namespace
-  export type PresetBlocks = BlockPresetArrayElement[] | BlockPresetHash;
-
-  export type BlockPresetHash = Record<string, BlockPresetBase>;
-  export type BlockPresetArrayElement = BlockPresetBase | BlockPresetStatic;
-
-  export type BlockPresetStatic = BlockPresetBase & {
-    static: true;
-    id: string;
-  };
-
-  export type BlockPresetBase = {
+  export type PresetBlockBase = {
     type: string;
     settings?: Setting.Values;
-    blocks?: PresetBlocks;
+    static?: boolean;
+    blocks?: PresetBlockHash | PresetBlockForArray[];
   };
+
+  export type PresetBlockForHash = PresetBlockBase & {
+    block_order?: string[];
+  };
+
+  export type PresetBlockForArray = PresetBlockBase & {
+    id?: string;
+  };
+
+  // Hash format for blocks
+  export type PresetBlockHash = {
+    [id: string]: PresetBlockForHash;
+  };
+
+  /** Base type for presets */
+  export type BlockPresetBase = {
+    /** Refers to a block type. blocks/{type}.liquid */
+    type: string;
+    settings?: Setting.Values;
+  };
+
+  // prettier-ignore
+  export type Block = (
+    | PresetBlockForHash
+    | PresetBlockForArray
+  );
 }

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -88,6 +88,9 @@ RemoteAsset:
 RequiredLayoutThemeObject:
   enabled: true
   severity: 0
+SchemaPresetsBlockOrder:
+  enabled: true
+  severity: 1
 TranslationKeyExists:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -66,6 +66,9 @@ RemoteAsset:
 RequiredLayoutThemeObject:
   enabled: true
   severity: 0
+SchemaPresetsBlockOrder:
+  enabled: true
+  severity: 1
 TranslationKeyExists:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?
Note: I'm expecting a conflict with Nav's [PR](https://github.com/Shopify/theme-tools/pull/617/files/1083b2bc9892b1fc9f725955ca68b3538b228f65..9435f2661f3ccc751ac0e6835902e0a2e2497cc0) regarding changes to the types. I've volunteered to be the one who deals with the conflicts.

---- 
Dependent on https://github.com/Shopify/theme-liquid-docs/pull/849 

Solves https://github.com/Shopify/theme-tools/issues/590

1. Checks that block_order is present when it should be (if you have blocks and they aren't all static)

2. When presets have blocks as a hash, they must also be included in the `block_order` array... Unless they are a static block (a block with `static: true`), then they have to NOT be included in the `block_order`.

Note: this check doesn't validate the existence of `block_order`, it assumes it's there to run this check.


To test:
```
"presets": [
    {
      "name": "Slideshow",
      "settings": {
        "title": "Slideshow"
      },
      "blocks": [
        {
          "type": "slide",
          "blocks": [
            {
              "type": "test"
            }
          ]
        },
        {
          "type": "slide"
        }
      ]
    },
    {
      "name": "Preset test 1",
      "blocks": {
        "block1": {
          "type": "test"
        },
        "block2": {
          "type": "slide",
          "static": true
        }
      },
      "block_order": ["block2"]
    },
    {
      "name": "Preset test 1",
      "blocks": {
        "block1": {
          "type": "test",
          "blocks": {
            "nested_block2": {
              "type": "slide"
            }
          },
          "block_order": []
        }
      },
      "block_order": ["block1"]
    },
    {
      "name": "Block order is missing",
      "blocks": {
        "block1": {
          "type": "test"
        }
      }
    },
    {
      "name": "Block_order is correctl missing",
      "blocks": {
        "block1": {
          "type": "test",
          "static": true
        }
      }
    },
    {
      "name": "block_order for nested block is missing",
      "blocks": {
        "block1": {
          "type": "test",
          "static": true,
          "blocks": {
            "nested_block2": {
              "type": "slide"
            }
          }
        }
      }
    }
  ],
```

Note that I updated a lot of the types to better represent the possible cases in presets.


## What did you learn?
To use CP's new building blocks :)

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
