### PR TITLE
Theme Tools Release: 19-11-24

### DIFF
--- a/.changeset/odd-starfishes-do.md
+++ b/.changeset/odd-starfishes-do.md
@@ -1,6 +1,0 @@
----
-'@shopify/theme-check-common': patch
-'@shopify/theme-check-node': patch
----
-
-Temporarily disable ValidBlockTarget

--- a/packages/theme-check-browser/CHANGELOG.md
+++ b/packages/theme-check-browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-check-browser
 
+## 3.2.1
+
+### Patch Changes
+
+- Updated dependencies [4a18a78]
+  - @shopify/theme-check-common@3.2.1
+
 ## 3.2.0
 
 ### Patch Changes

--- a/packages/theme-check-browser/package.json
+++ b/packages/theme-check-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-browser",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -26,6 +26,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "3.2.0"
+    "@shopify/theme-check-common": "3.2.1"
   }
 }

--- a/packages/theme-check-common/CHANGELOG.md
+++ b/packages/theme-check-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-check-common
 
+## 3.2.1
+
+### Patch Changes
+
+- 4a18a78: Temporarily disable ValidBlockTarget
+
 ## 3.2.0
 
 ### Minor Changes

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-common",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/theme-check-docs-updater/CHANGELOG.md
+++ b/packages/theme-check-docs-updater/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-check-docs-updater
 
+## 3.2.1
+
+### Patch Changes
+
+- Updated dependencies [4a18a78]
+  - @shopify/theme-check-common@3.2.1
+
 ## 3.2.0
 
 ### Patch Changes

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-docs-updater",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Scripts to initialize theme-check data with assets from the theme-liquid-docs repo.",
   "main": "dist/index.js",
   "author": "Albert Chu <albert.chu@shopify.com>",
@@ -30,7 +30,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "^3.2.0",
+    "@shopify/theme-check-common": "^3.2.1",
     "env-paths": "^2.2.1",
     "node-fetch": "^2.6.11"
   },

--- a/packages/theme-check-node/CHANGELOG.md
+++ b/packages/theme-check-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-check-node
 
+## 3.2.1
+
+### Patch Changes
+
+- 4a18a78: Temporarily disable ValidBlockTarget
+- Updated dependencies [4a18a78]
+  - @shopify/theme-check-common@3.2.1
+  - @shopify/theme-check-docs-updater@3.2.1
+
 ## 3.2.0
 
 ### Minor Changes

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-node",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -33,8 +33,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "3.2.0",
-    "@shopify/theme-check-docs-updater": "3.2.0",
+    "@shopify/theme-check-common": "3.2.1",
+    "@shopify/theme-check-docs-updater": "3.2.1",
     "glob": "^8.0.3",
     "vscode-uri": "^3.0.7",
     "yaml": "^2.3.0"

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-language-server-browser
 
+## 2.2.1
+
+### Patch Changes
+
+- @shopify/theme-language-server-common@2.2.1
+
 ## 2.2.0
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "2.2.0",
+    "@shopify/theme-language-server-common": "2.2.1",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-common
 
+## 2.2.1
+
+### Patch Changes
+
+- Updated dependencies [4a18a78]
+  - @shopify/theme-check-common@3.2.1
+
 ## 2.2.0
 
 ### Minor Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.1.1",
-    "@shopify/theme-check-common": "3.2.0",
+    "@shopify/theme-check-common": "3.2.1",
     "@vscode/web-custom-data": "^0.4.6",
     "vscode-json-languageservice": "^5.3.10",
     "vscode-languageserver": "^8.0.2",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @shopify/theme-language-server-node
 
+## 2.2.1
+
+### Patch Changes
+
+- Updated dependencies [4a18a78]
+  - @shopify/theme-check-node@3.2.1
+  - @shopify/theme-language-server-common@2.2.1
+  - @shopify/theme-check-docs-updater@3.2.1
+
 ## 2.2.0
 
 ### Patch Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,9 +27,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "2.2.0",
-    "@shopify/theme-check-node": "^3.2.0",
-    "@shopify/theme-check-docs-updater": "^3.2.0",
+    "@shopify/theme-language-server-common": "2.2.1",
+    "@shopify/theme-check-node": "^3.2.1",
+    "@shopify/theme-check-docs-updater": "^3.2.1",
     "glob": "^8.0.3",
     "node-fetch": "^2.6.11",
     "vscode-languageserver": "^8.0.2",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## theme-check-vscode
 
+## 3.2.1
+
+### Patch Changes
+
+- Patch bump because it depends on:
+  - @shopify/theme-language-server-browser
+  - @shopify/theme-language-server-node
+  - @shopify/theme-check-common
+- Updated dependencies [4a18a78]
+  - @shopify/theme-check-common@3.2.1
+  - @shopify/theme-language-server-browser@2.2.1
+  - @shopify/theme-language-server-node@2.2.1
+
 ## 3.2.0
 
 ### Minor Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/shopify/theme-tools/issues"
   },
-  "version": "3.2.0",
+  "version": "3.2.1",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -61,15 +61,15 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.1.1",
     "@shopify/prettier-plugin-liquid": "^1.6.1",
-    "@shopify/theme-language-server-browser": "^2.2.0",
-    "@shopify/theme-language-server-node": "^2.2.0",
-    "@shopify/theme-check-common": "^3.2.0",
+    "@shopify/theme-language-server-browser": "^2.2.1",
+    "@shopify/theme-language-server-node": "^2.2.1",
+    "@shopify/theme-check-common": "^3.2.1",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0",
     "vscode-uri": "^3.0.8"
   },
   "devDependencies": {
-    "@shopify/theme-check-docs-updater": "^3.2.0",
+    "@shopify/theme-check-docs-updater": "^3.2.1",
     "@types/glob": "^8.0.0",
     "@types/node": "16.x",
     "@types/prettier": "^2.4.2",


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `3.2.0` -> `3.2.1`
### Changes:
- Patch bump because it depends on:
 - @shopify/theme-language-server-browser
 - @shopify/theme-language-server-node
 - @shopify/theme-check-common

## `@shopify/theme-check-common`
Patch incremented `3.2.0` -> `3.2.1`
### Changes:
- Temporarily disable ValidBlockTarget

## `@shopify/theme-check-node`
Patch incremented `3.2.0` -> `3.2.1`
### Changes:
- Temporarily disable ValidBlockTarget

## `@shopify/theme-check-browser`
Patch incremented `3.2.0` -> `3.2.1`

## `@shopify/theme-language-server-common`
Patch incremented `2.2.0` -> `2.2.1`

## `@shopify/theme-language-server-browser`
Patch incremented `2.2.0` -> `2.2.1`

## `@shopify/theme-language-server-node`
Patch incremented `2.2.0` -> `2.2.1`

## `@shopify/theme-check-docs-updater`
Patch incremented `3.2.0` -> `3.2.1`

