### PR TITLE
`settings.type` bug fix

### DIFF
--- a/.changeset/shiny-schools-cross.md
+++ b/.changeset/shiny-schools-cross.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Bug fix to support older themes.

--- a/packages/theme-check-common/src/checks/valid-block-target/block-utils.ts
+++ b/packages/theme-check-common/src/checks/valid-block-target/block-utils.ts
@@ -2,7 +2,7 @@ import { LiquidRawTag } from '@shopify/liquid-html-parser';
 import { Context, SourceCodeType, Schema, JSONNode } from '../../types';
 import { doesFileExist } from '../../utils/file-utils';
 import { visit } from '../../visitor';
-import { LiteralNode } from 'json-to-ast';
+import { LiteralNode, PropertyNode } from 'json-to-ast';
 
 type BlockTypeMap = { [key: string]: Location[] };
 
@@ -11,16 +11,31 @@ type Location = {
   endIndex: number;
 };
 
+type NestedBlockLocation = {
+  location: Location;
+  parentBlockTypes: string[];
+};
+
+type NestedPresetBlockMap = {
+  [key: string]: NestedBlockLocation[];
+};
+
 type BlockValidationResult = {
-  rootBlockTypes: BlockTypeMap;
+  hasLocalBlocks: boolean;
+  rootThemeBlockTypes: BlockTypeMap;
   presetBlockTypes: BlockTypeMap;
+  nestedPresetBlockTypes: NestedPresetBlockMap;
 };
 
 function isLiteralNode(node: JSONNode): node is LiteralNode {
   return node.type === 'Literal';
 }
 
-// Function to determine if a node is in an array with a specific parent key
+function isPropertyNode(node: JSONNode): node is PropertyNode {
+  return node.type === 'Property';
+}
+
+// Check if a node is within an array that has a specific parent key
 function isInArrayWithParentKey(ancestors: JSONNode[], parentKey: string): boolean {
   return ancestors.some((ancestor, index) => {
     const parent = ancestors[index - 1];
@@ -30,6 +45,26 @@ function isInArrayWithParentKey(ancestors: JSONNode[], parentKey: string): boole
       parent.key?.value === parentKey
     );
   });
+}
+
+function isInBlocksArray(ancestors: JSONNode[]): boolean {
+  const thirdAncestor = ancestors[ancestors.length - 3];
+  const fourthAncestor = ancestors[ancestors.length - 4];
+
+  return (
+    (isPropertyNode(thirdAncestor) && thirdAncestor.key?.value === 'blocks') ||
+    (isPropertyNode(fourthAncestor) && fourthAncestor.key?.value === 'blocks')
+  );
+}
+
+function isInPresetsArray(ancestors: JSONNode[]): boolean {
+  const sixthAncestor = ancestors[ancestors.length - 6];
+  const seventhAncestor = ancestors[ancestors.length - 7];
+
+  return (
+    (isPropertyNode(sixthAncestor) && sixthAncestor.key?.value === 'presets') ||
+    (isPropertyNode(seventhAncestor) && seventhAncestor.key?.value === 'presets')
+  );
 }
 
 export const reportError =
@@ -42,36 +77,75 @@ export const reportError =
     });
   };
 
-export function collectAndValidateBlockTypes(jsonFile: JSONNode): BlockValidationResult {
-  const rootBlockTypes: BlockTypeMap = {};
-  const presetBlockTypes: BlockTypeMap = {};
+function getParentBlockTypes(ancestors: JSONNode[]): string[] {
+  // TODO: Implement this
+  return [];
+}
 
+export function collectAndValidateBlockTypes(jsonFile: JSONNode): BlockValidationResult {
+  const rootThemeBlockTypes: BlockTypeMap = {};
+  const rootLocalBlockTypes: BlockTypeMap = {};
+  const presetBlockTypes: BlockTypeMap = {};
+  const nestedPresetBlockTypes: NestedPresetBlockMap = {};
   visit<SourceCodeType.JSON, void>(jsonFile, {
     Property(node, ancestors) {
-      // Only process type and name properties within blocks
+      // Process 'type' and 'name' properties within 'blocks'
       if (!isInArrayWithParentKey(ancestors, 'blocks') || !isLiteralNode(node.value)) return;
 
-      if (node.key.value === 'type') {
+      const parentObject = ancestors[ancestors.length - 1];
+      const hasNameProperty =
+        parentObject.type === 'Object' &&
+        parentObject.children.some(
+          (child) => child.type === 'Property' && child.key.value === 'name',
+        );
+
+      if (node.key.value === 'type' && isInBlocksArray(ancestors)) {
         const typeValue = node.value.value;
         const typeLocation = {
           startIndex: node.value.loc!.start.offset,
           endIndex: node.value.loc!.end.offset,
         };
 
-        // Add to appropriate map
+        // Determine the target map for block types based on their context
+        type TargetMapType = BlockTypeMap | NestedPresetBlockMap | undefined;
+
+        // Determine the target map for block types based on their context
+        let targetMap: TargetMapType;
         const inPresets = isInArrayWithParentKey(ancestors, 'presets');
-        const targetMap = inPresets ? presetBlockTypes : rootBlockTypes;
-        if (typeof typeValue === 'string') {
-          targetMap[typeValue] = targetMap[typeValue] || [];
-          targetMap[typeValue].push(typeLocation);
+
+        if (inPresets && !isInPresetsArray(ancestors)) {
+          targetMap = nestedPresetBlockTypes;
+        } else if (inPresets && isInPresetsArray(ancestors)) {
+          targetMap = presetBlockTypes;
+        } else if (hasNameProperty) {
+          targetMap = rootLocalBlockTypes;
+        } else {
+          targetMap = rootThemeBlockTypes;
+        }
+
+        // Add the block type to the appropriate map
+        if (targetMap && typeof typeValue === 'string') {
+          if (targetMap === nestedPresetBlockTypes) {
+            const parentTypes = getParentBlockTypes(ancestors);
+            targetMap[typeValue] = targetMap[typeValue] || [];
+            targetMap[typeValue].push({
+              location: typeLocation,
+              parentBlockTypes: parentTypes,
+            });
+          } else {
+            (targetMap as BlockTypeMap)[typeValue] = (targetMap as BlockTypeMap)[typeValue] || [];
+            (targetMap as BlockTypeMap)[typeValue].push(typeLocation);
+          }
         }
       }
     },
   });
 
   return {
-    rootBlockTypes,
+    hasLocalBlocks: Object.keys(rootLocalBlockTypes).length > 0,
+    rootThemeBlockTypes,
     presetBlockTypes,
+    nestedPresetBlockTypes,
   };
 }
 

--- a/packages/theme-check-common/src/checks/valid-block-target/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-block-target/index.spec.ts
@@ -481,4 +481,27 @@ describe('Module: ValidBlockTarget', () => {
       });
     });
   });
+
+  describe('Local Block Targeting Tests', () => {
+    it('should not report errors for locally scoped blocks at root level', async () => {
+      const theme: MockTheme = {
+        'sections/local-blocks.liquid': `
+          {% schema %}
+          {
+            "name": "Section name",
+            "blocks": [
+              {
+                "type": "local_block",
+                "name": "Local block"
+              }
+            ]
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [ValidBlockTarget]);
+      expect(offenses).to.be.empty;
+    });
+  });
 });

--- a/packages/theme-check-common/src/checks/valid-block-target/index.ts
+++ b/packages/theme-check-common/src/checks/valid-block-target/index.ts
@@ -42,12 +42,12 @@ export const ValidBlockTarget: LiquidCheckDefinition = {
         const jsonFile = toJSONAST(jsonString);
         if (jsonFile instanceof Error) return;
 
-        const { rootBlockTypes, presetBlockTypes } = collectAndValidateBlockTypes(
-          jsonFile as JSONNode,
-        );
+        const { hasLocalBlocks, rootThemeBlockTypes, presetBlockTypes, nestedPresetBlockTypes } =
+          collectAndValidateBlockTypes(jsonFile as JSONNode);
 
+        if (hasLocalBlocks) return;
         let errorsInRootLevelBlocks = false;
-        for (const [blockType, locations] of Object.entries(rootBlockTypes)) {
+        for (const [blockType, locations] of Object.entries(rootThemeBlockTypes)) {
           const exists = await validateBlockFileExistence(blockType, context);
           if (!exists) {
             locations.forEach(
@@ -65,8 +65,8 @@ export const ValidBlockTarget: LiquidCheckDefinition = {
 
         for (const [presetType, locations] of Object.entries(presetBlockTypes)) {
           const isPrivateBlockType = presetType.startsWith('_');
-          const isPresetInRootLevel = presetType in rootBlockTypes;
-          const isThemeInRootLevel = '@theme' in rootBlockTypes;
+          const isPresetInRootLevel = presetType in rootThemeBlockTypes;
+          const isThemeInRootLevel = '@theme' in rootThemeBlockTypes;
           const needsExplicitRootBlock = isPrivateBlockType || !isThemeInRootLevel;
 
           if (!isPresetInRootLevel && needsExplicitRootBlock) {
@@ -88,6 +88,8 @@ export const ValidBlockTarget: LiquidCheckDefinition = {
             }
           }
         }
+
+        // TODO: Validate nested preset block types via cross file check
       },
     };
   },

--- a/packages/theme-check-common/src/checks/valid-local-blocks/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-local-blocks/index.spec.ts
@@ -329,3 +329,41 @@ describe('ValidLocalBlocks with hash-style presets', () => {
     expect(offenses[0].message).to.equal('Static theme blocks cannot have a name property.');
   });
 });
+
+describe('ValidLocalBlocks only reports errors for blocks', () => {
+  it('should not report errors for block setting types', async () => {
+    const theme: MockTheme = {
+      'sections/local-blocks.liquid': `
+        {% schema %}
+        {
+          "name": "Section name",
+          "blocks": [
+            {
+              "type": "@app"
+            },
+            {
+              "type": "link_list",
+              "name": "Link list",
+              "settings": [
+                {
+                  "type": "inline_richtext",
+                  "id": "heading",
+                  "default": "Heading"
+                },
+                {
+                  "type": "link_list",
+                  "id": "menu",
+                  "default": "Footer"
+                }
+              ]
+            }
+          ]
+        }
+        {% endschema %}
+      `,
+    };
+
+    const offenses = await check(theme, [ValidLocalBlocks]);
+    expect(offenses).to.be.empty;
+  });
+});

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -81,6 +81,9 @@ UnknownFilter:
 UnusedAssign:
   enabled: true
   severity: 1
+ValidBlockTarget:
+  enabled: true
+  severity: 0
 ValidContentForArguments:
   enabled: true
   severity: 0
@@ -88,6 +91,9 @@ ValidHTMLTranslation:
   enabled: true
   severity: 1
 ValidJSON:
+  enabled: true
+  severity: 0
+ValidLocalBlocks:
   enabled: true
   severity: 0
 ValidSchema:


### PR DESCRIPTION
## What are you adding in this PR?

Resolves https://github.com/Shopify/theme-tools/issues/605 and https://github.com/Shopify/theme-tools/issues/608

This PR is meant to ensure that checks do not blow up existent themes. To do so, we are adding preliminary checks to make sure that we are only using theme blocks, and if so, proceed with the checks.

## What's next? Any followup issues?

There are a couple directions in which we can follow up with this issue.
1) Right now, we are only checking preset blocks at the first level (not nested levels). The reason being is that nested preset checks will require cross file validation which would we should follow up on.
2) Once content with these changes, worthwhile to change the check recommendations to true.

## What did you learn?

I learned about the difference between how older and newer (with theme block) themes are written, as well as more information about nested preset blocks and how their validation needs to occur.

## Before you deploy

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
