### PR TITLE
Added missing schema check for theme app extension

### DIFF
--- a/.changeset/dirty-terms-refuse.md
+++ b/.changeset/dirty-terms-refuse.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Added MissingSchema theme check to identify missing schemas in theme app extensions.

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -40,6 +40,7 @@ import { ValidSchema } from './valid-schema';
 import { ValidSchemaName } from './valid-schema-name';
 import { ValidStaticBlockType } from './valid-static-block-type';
 import { VariableName } from './variable-name';
+import { MissingSchema } from './missing-schema';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
@@ -62,6 +63,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   MatchingTranslations,
   MissingAsset,
   MissingTemplate,
+  MissingSchema,
   PaginationSize,
   ParserBlockingScript,
   RemoteAsset,

--- a/packages/theme-check-common/src/checks/missing-schema/index.spec.ts
+++ b/packages/theme-check-common/src/checks/missing-schema/index.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { runLiquidCheck } from '../../test';
+import { MissingSchema } from './index';
+import { Config } from '../../types';
+
+describe('MissingSchema', () => {
+  it('should report an error when schema tag is missing on a theme app extension', async () => {
+    const sourceCode = `
+      <footer class="footer">
+        {% for block in section.blocks %}
+          {% case block.type %}
+            {% when 'link' %}
+              <div class="link" {{ block.shopify_attributes }}>
+                {{ block.settings.linktext | link_to: block.settings.linkurl }}
+              </div>
+
+            {% when 'custom-text' %}
+              <div class="text" {{ block.shopify_attributes }}>
+                {{ block.settings.custom-text-field }}
+              </div>
+          {% endcase %}
+        {% endfor %}
+      </footer>
+    `;
+
+    const offenses = await runLiquidCheck(MissingSchema, sourceCode);
+    expect(offenses).to.have.lengthOf(1);
+  });
+
+  it('should not report when the schema is present on a theme app extension', async () => {
+    const sourceCode = `
+<footer class="footer">
+  {% for block in section.blocks %}
+    {% case block.type %}
+      {% when 'link' %}
+        <div class="link" {{ block.shopify_attributes }}>
+          {{ block.settings.linktext | link_to: block.settings.linkurl }}
+        </div>
+
+      {% when 'custom-text' %}
+        <div class="text" {{ block.shopify_attributes }}>
+          {{ block.settings.custom-text-field }}
+        </div>
+    {% endcase %}
+  {% endfor %}
+</footer>
+
+{% schema %}
+{
+  "name": "Footer",
+  "max_blocks": 8,
+  "blocks": [
+    {
+      "type": "link",
+      "name": "Link",
+      "settings": [
+        {
+          "id": "linkurl",
+          "type": "url",
+          "label": "URL link"
+        },
+        {
+          "id": "linktext",
+          "type": "text",
+          "label": "Link text"
+        }
+      ]
+    },
+    {
+      "type": "custom-text",
+      "name": "Custom Text",
+      "settings": [
+        {
+          "id": "custom-text-field",
+          "type": "textarea",
+          "label": "Text"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}`;
+
+    const offenses = await runLiquidCheck(MissingSchema, sourceCode);
+    expect(offenses).to.have.lengthOf(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/missing-schema/index.ts
+++ b/packages/theme-check-common/src/checks/missing-schema/index.ts
@@ -1,0 +1,37 @@
+import { ConfigTarget, LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+
+export const MissingSchema: LiquidCheckDefinition = {
+  meta: {
+    code: 'MissingSchema',
+    name: 'Missing schema definitions in theme app extensions should be avoided',
+    docs: {
+      description: 'Report missing schema definitions in theme app extensions',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/missing-schema',
+    },
+    severity: Severity.ERROR,
+    type: SourceCodeType.LiquidHtml,
+    schema: {},
+    targets: [ConfigTarget.ThemeAppExtension],
+  },
+
+  create(context) {
+    let foundSchema = false;
+
+    return {
+      async LiquidRawTag(node) {
+        if (node.name == 'schema') foundSchema = true;
+      },
+
+      async onCodePathEnd() {
+        if (!foundSchema) {
+          context.report({
+            message: `The schema does not exist`,
+            startIndex: 0,
+            endIndex: 0,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -64,6 +64,9 @@ MatchingTranslations:
 MissingAsset:
   enabled: true
   severity: 0
+MissingSchema:
+  enabled: false
+  severity: 0
 MissingTemplate:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/theme-app-extension.yml
+++ b/packages/theme-check-node/configs/theme-app-extension.yml
@@ -16,6 +16,9 @@ AssetSizeAppBlockJavaScript:
   enabled: true
   severity: 0
   thresholdInBytes: 10000
+MissingSchema:
+  enabled: true
+  severity: 0
 RequiredLayoutThemeObject:
   enabled: false
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?

cc (collab): @itsjustriley 

Closes https://github.com/Shopify/theme-tools/issues/402. 

Shopify dev docs PR: https://github.com/Shopify/shopify-dev/pull/50817

Adds a theme check on theme app extensions for missing schema. 

## What's next? Any followup issues?

No followup issues. 

## What did you learn?

Cannot pass `context` into `codePathStart()` or `codePathEnd()`. Theme app extensions cannot currently be tophatted in Horizon. 

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [x] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
