### PR TITLE
Add `EmptyBlockContent` Check

### DIFF
--- a/.changeset/khaki-pillows-punch.md
+++ b/.changeset/khaki-pillows-punch.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Add EmptyBlockContent Check

--- a/packages/theme-check-common/src/checks/empty-block-content/index.spec.ts
+++ b/packages/theme-check-common/src/checks/empty-block-content/index.spec.ts
@@ -73,7 +73,7 @@ describe('Module: EmptyBlockContent', () => {
       expect(erroredContent).to.equal("{% content_for 'blocks' %}");
     });
 
-    it(`should not report offenses when the blocks array has not been defined in ${path}`, async () => {
+    it(`should report offenses when the blocks array has not been defined in ${path}`, async () => {
       const theme: MockTheme = {
         [`${path}/test_block.liquid`]: `
           <div> 
@@ -88,7 +88,10 @@ describe('Module: EmptyBlockContent', () => {
       };
 
       const offenses = await check(theme, [EmptyBlockContent]);
-      expect(offenses).to.be.empty;
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal(
+        "The 'content_for blocks' tag is present, but the blocks array is not defined.",
+      );
     });
 
     it(`should not report offenses when 'content_for blocks' is not present in ${path}`, async () => {

--- a/packages/theme-check-common/src/checks/empty-block-content/index.spec.ts
+++ b/packages/theme-check-common/src/checks/empty-block-content/index.spec.ts
@@ -47,7 +47,7 @@ describe('Module: EmptyBlockContent', () => {
       const offenses = await check(theme, [EmptyBlockContent]);
       expect(offenses).to.have.length(1);
       expect(offenses[0].message).to.equal(
-        "The 'content_for blocks' tag is present, but the blocks array is empty.",
+        `The 'content_for "blocks"' tag is present, but the blocks array is empty.`,
       );
     });
 
@@ -90,7 +90,7 @@ describe('Module: EmptyBlockContent', () => {
       const offenses = await check(theme, [EmptyBlockContent]);
       expect(offenses).to.have.length(1);
       expect(offenses[0].message).to.equal(
-        "The 'content_for blocks' tag is present, but the blocks array is not defined.",
+        `The 'content_for "blocks"' tag is present, but the blocks array is not defined.`,
       );
     });
 

--- a/packages/theme-check-common/src/checks/empty-block-content/index.spec.ts
+++ b/packages/theme-check-common/src/checks/empty-block-content/index.spec.ts
@@ -1,0 +1,114 @@
+import { expect, describe, it } from 'vitest';
+import { EmptyBlockContent } from '.';
+import { check, MockTheme } from '../../test';
+
+describe('Module: EmptyBlockContent', () => {
+  const paths = ['sections', 'blocks'];
+
+  paths.forEach((path) => {
+    it(`should not report offenses when the blocks array is not empty in ${path}`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test_block.liquid`]: `
+          <div> 
+              {% content_for 'blocks' %}
+          </div>
+          {% schema %}
+          {
+              "name": "Test",
+              "blocks": [
+                {
+                  "type": "test-block"
+                }
+              ]
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [EmptyBlockContent]);
+      expect(offenses).to.have.length(0);
+    });
+
+    it(`should report offenses when the blocks array is empty in ${path}`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test_block.liquid`]: `
+          <div> 
+              {% content_for 'blocks' %}
+          </div>
+          {% schema %}
+          {
+              "name": "Test",
+              "blocks": []
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [EmptyBlockContent]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal(
+        "The 'content_for blocks' tag is present, but the blocks array is empty.",
+      );
+    });
+
+    it(`should report offenses when the blocks array is empty with the correct indices in ${path}`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test_block.liquid`]: `
+          <div> 
+              {% content_for 'blocks' %}
+          </div>
+          {% schema %}
+          {
+              "name": "Test",
+              "blocks": []
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [EmptyBlockContent]);
+      expect(offenses).to.have.length(1);
+      const content = theme[`${path}/test_block.liquid`];
+      const erroredContent = content.slice(offenses[0].start.index, offenses[0].end.index);
+      expect(erroredContent).to.equal("{% content_for 'blocks' %}");
+    });
+
+    it(`should not report offenses when the blocks array has not been defined in ${path}`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test_block.liquid`]: `
+          <div> 
+              {% content_for 'blocks' %}
+          </div>
+          {% schema %}
+          {
+              "name": "Test"
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [EmptyBlockContent]);
+      expect(offenses).to.be.empty;
+    });
+
+    it(`should not report offenses when 'content_for blocks' is not present in ${path}`, async () => {
+      const theme: MockTheme = {
+        [`${path}/test_block.liquid`]: `
+          {% schema %}
+          {
+              "name": "Test",
+              "blocks": [
+                  {
+                      "type": "test-block"
+                  }
+              ]
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [EmptyBlockContent]);
+      expect(offenses).to.be.empty;
+    });
+  });
+});

--- a/packages/theme-check-common/src/checks/empty-block-content/index.ts
+++ b/packages/theme-check-common/src/checks/empty-block-content/index.ts
@@ -1,0 +1,65 @@
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { isBlock, isSection } from '../../to-schema';
+import { basename } from '../../path';
+
+export const EmptyBlockContent: LiquidCheckDefinition = {
+  meta: {
+    code: 'EmptyBlockContent',
+    name: 'Prevent empty block content',
+    docs: {
+      description:
+        'This check exists to warn you when the blocks array at the root level of the schema is empty.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/empty-block-content',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    function getSchema() {
+      const name = basename(context.file.uri, '.liquid');
+      switch (true) {
+        case isBlock(context.file.uri):
+          return context.getBlockSchema?.(name);
+        case isSection(context.file.uri):
+          return context.getSectionSchema?.(name);
+        default:
+          return undefined;
+      }
+    }
+
+    let contentForBlocksLocation: { start: number; end: number } | undefined;
+    return {
+      async LiquidTag(node) {
+        if (node.name !== 'content_for') return;
+
+        const nodeMarkup = node.markup;
+        if (typeof nodeMarkup === 'object' && nodeMarkup.contentForType.value === 'blocks') {
+          contentForBlocksLocation = {
+            start: node.blockStartPosition.start,
+            end: node.blockStartPosition.end,
+          };
+        }
+      },
+
+      async onCodePathEnd() {
+        const schema = await getSchema();
+        const { validSchema, ast } = schema ?? {};
+        if (!validSchema || validSchema instanceof Error) return;
+        if (!ast || ast instanceof Error) return;
+
+        const blocks = validSchema.blocks;
+        if (contentForBlocksLocation && blocks && blocks.length === 0) {
+          context.report({
+            message: "The 'content_for blocks' tag is present, but the blocks array is empty.",
+            startIndex: contentForBlocksLocation.start,
+            endIndex: contentForBlocksLocation.end,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/empty-block-content/index.ts
+++ b/packages/theme-check-common/src/checks/empty-block-content/index.ts
@@ -43,14 +43,13 @@ export const EmptyBlockContent: LiquidCheckDefinition = {
         const blocks = validSchema.blocks;
         if (isContentForBlocksLocationSet && !blocks) {
           context.report({
-            message:
-              "The 'content_for blocks' tag is present, but the blocks array is not defined.",
+            message: `The 'content_for "blocks"' tag is present, but the blocks array is not defined.`,
             startIndex: contentForBlocksLocation.start,
             endIndex: contentForBlocksLocation.end,
           });
         } else if (isContentForBlocksLocationSet && blocks && blocks.length === 0) {
           context.report({
-            message: "The 'content_for blocks' tag is present, but the blocks array is empty.",
+            message: `The 'content_for "blocks"' tag is present, but the blocks array is empty.`,
             startIndex: contentForBlocksLocation.start,
             endIndex: contentForBlocksLocation.end,
           });

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -15,6 +15,7 @@ import { DeprecateBgsizes } from './deprecate-bgsizes';
 import { DeprecateLazysizes } from './deprecate-lazysizes';
 import { DeprecatedFilter } from './deprecated-filter';
 import { DeprecatedTag } from './deprecated-tag';
+import { EmptyBlockContent } from './empty-block-content';
 import { ImgWidthAndHeight } from './img-width-and-height';
 import { JSONSyntaxError } from './json-syntax-error';
 import { LiquidFreeSettings } from './liquid-free-settings';
@@ -58,6 +59,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   DeprecatedFilter,
   DeprecatedTag,
   DeprecateLazysizes,
+  EmptyBlockContent,
   ImgWidthAndHeight,
   JSONSyntaxError,
   LiquidFreeSettings,

--- a/packages/theme-check-common/src/checks/valid-block-target/index.ts
+++ b/packages/theme-check-common/src/checks/valid-block-target/index.ts
@@ -1,15 +1,7 @@
-import {
-  LiquidCheckDefinition,
-  Section,
-  ThemeBlock,
-  Severity,
-  SourceCodeType,
-  Preset,
-} from '../../types';
+import { LiquidCheckDefinition, Severity, SourceCodeType, Preset } from '../../types';
 import { LiteralNode } from 'json-to-ast';
 import { nodeAtPath } from '../../json';
-import { basename } from '../../path';
-import { isBlock, isSection } from '../../to-schema';
+import { getSchema } from '../../to-schema';
 import {
   getBlocks,
   isInvalidPresetBlock,
@@ -39,24 +31,12 @@ export const ValidBlockTarget: LiquidCheckDefinition = {
   },
 
   create(context) {
-    function getSchema() {
-      const name = basename(context.file.uri, '.liquid');
-      switch (true) {
-        case isBlock(context.file.uri):
-          return context.getBlockSchema?.(name);
-        case isSection(context.file.uri):
-          return context.getSectionSchema?.(name);
-        default:
-          return undefined;
-      }
-    }
-
     return {
       async LiquidRawTag(node) {
         if (node.name !== 'schema' || node.body.kind !== 'json') return;
 
         const offset = node.blockStartPosition.end;
-        const schema = await getSchema();
+        const schema = await getSchema(context);
         const { validSchema, ast } = schema ?? {};
         if (!validSchema || validSchema instanceof Error) return;
         if (!ast || ast instanceof Error) return;

--- a/packages/theme-check-common/src/checks/valid-local-blocks/index.ts
+++ b/packages/theme-check-common/src/checks/valid-local-blocks/index.ts
@@ -1,7 +1,7 @@
 import { LiquidCheckDefinition, Preset, Severity, SourceCodeType } from '../../types';
 import { LiteralNode } from 'json-to-ast';
 import { nodeAtPath } from '../../json';
-import { basename } from '../../path';
+import { getSchema } from '../../to-schema';
 import { isBlock, isSection } from '../../to-schema';
 import { getBlocks, reportWarning } from './valid-block-utils';
 
@@ -27,24 +27,12 @@ export const ValidLocalBlocks: LiquidCheckDefinition = {
   },
 
   create(context) {
-    function getSchema() {
-      const name = basename(context.file.uri, '.liquid');
-      switch (true) {
-        case isBlock(context.file.uri):
-          return context.getBlockSchema?.(name);
-        case isSection(context.file.uri):
-          return context.getSectionSchema?.(name);
-        default:
-          return undefined;
-      }
-    }
-
     return {
       async LiquidRawTag(node) {
         if (node.name !== 'schema' || node.body.kind !== 'json') return;
 
         const offset = node.blockStartPosition.end;
-        const schema = await getSchema();
+        const schema = await getSchema(context);
         const { validSchema, ast } = schema ?? {};
         if (!validSchema || validSchema instanceof Error) return;
         if (!ast || ast instanceof Error) return;

--- a/packages/theme-check-common/src/checks/valid-schema-name/index.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-name/index.ts
@@ -1,7 +1,6 @@
 import { LiteralNode } from 'json-to-ast';
 import { getLocEnd, getLocStart, nodeAtPath } from '../../json';
-import { basename } from '../../path';
-import { isBlock, isSection } from '../../to-schema';
+import { getSchema } from '../../to-schema';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { deepGet } from '../../utils';
 
@@ -23,18 +22,6 @@ export const ValidSchemaName: LiquidCheckDefinition = {
   },
 
   create(context) {
-    function getSchema() {
-      const name = basename(context.file.uri, '.liquid');
-      switch (true) {
-        case isBlock(context.file.uri):
-          return context.getBlockSchema?.(name);
-        case isSection(context.file.uri):
-          return context.getSectionSchema?.(name);
-        default:
-          return undefined;
-      }
-    }
-
     return {
       async LiquidRawTag(node) {
         if (node.name !== 'schema' || node.body.kind !== 'json') {
@@ -42,7 +29,7 @@ export const ValidSchemaName: LiquidCheckDefinition = {
         }
 
         const offset = node.blockStartPosition.end;
-        const schema = await getSchema();
+        const schema = await getSchema(context);
         const { validSchema, ast } = schema ?? {};
         if (!validSchema || validSchema instanceof Error) return;
         if (!ast || ast instanceof Error) return;

--- a/packages/theme-check-common/src/to-schema.ts
+++ b/packages/theme-check-common/src/to-schema.ts
@@ -13,6 +13,8 @@ import {
   ThemeBlock,
   ThemeSchemaType,
   UriString,
+  Context,
+  Schema,
 } from './types';
 import { visit } from './visitor';
 
@@ -137,6 +139,18 @@ function toSchemaNode(ast: LiquidHtmlNode | Error): LiquidRawTag | Error {
       },
     })[0] ?? new Error('No schema tag found')
   );
+}
+
+export function getSchema(context: Context<SourceCodeType.LiquidHtml, Schema>) {
+  const name = path.basename(context.file.uri, '.liquid');
+  switch (true) {
+    case isBlock(context.file.uri):
+      return context.getBlockSchema?.(name);
+    case isSection(context.file.uri):
+      return context.getSectionSchema?.(name);
+    default:
+      return undefined;
+  }
 }
 
 function toParsed(schemaNode: LiquidRawTag | Error): any | Error {

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -49,6 +49,9 @@ DeprecatedFilter:
 DeprecatedTag:
   enabled: true
   severity: 1
+EmptyBlockContent:
+  enabled: true
+  severity: 1
 ImgWidthAndHeight:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -30,6 +30,9 @@ DeprecatedFilter:
 DeprecatedTag:
   enabled: true
   severity: 1
+EmptyBlockContent:
+  enabled: true
+  severity: 1
 ImgWidthAndHeight:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?

Resolves https://github.com/Shopify/theme-tools/issues/629

This PR introduces enhancesd validation checks for `blocks`, specifically ensuring that `blocks` at the root-level of the liquid schema is not an empty array if the body contains `content for 'blocks'`.

![image](https://github.com/user-attachments/assets/c780b026-6402-4f0f-b515-b1ad347b652c)

![image](https://github.com/user-attachments/assets/201a10ad-d464-4dff-bd9b-02009e386c31)


## What's next? Any followup issues?

With this being a new check, we will want to update https://github.com/Shopify/shopify-dev so users can understand their errors. Developer Docs changes: https://github.com/Shopify/shopify-dev/pull/51107

## What did you learn?

When writing this check I learned how to check if file contains `content for 'blocks'` in a robust manner.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
