### PR TITLE
Add theme block type completion in `{% schema %}`

### DIFF
--- a/.changeset/happy-flowers-scream.md
+++ b/.changeset/happy-flowers-scream.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': minor
+'theme-check-vscode': minor
+---
+
+Add theme block type completion in `{% schema %}`

--- a/packages/theme-language-server-common/src/documents/DocumentManager.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.ts
@@ -167,6 +167,7 @@ export class DocumentManager {
           /** Lazy and only computed once per file version */
           getSchema: memo(async () => {
             if (!this.getModeForUri || !this.isValidSchema) return undefined;
+
             const mode = await this.getModeForUri!(uri);
             return toSchema(mode, uri, sourceCode, this.isValidSchema);
           }),

--- a/packages/theme-language-server-common/src/json/JSONContributions.ts
+++ b/packages/theme-language-server-common/src/json/JSONContributions.ts
@@ -8,6 +8,10 @@ import {
 import { AugmentedSourceCode, DocumentManager } from '../documents';
 import { GetTranslationsForURI } from '../translations';
 import { JSONCompletionProvider } from './completions/JSONCompletionProvider';
+import {
+  BlockTypeCompletionProvider,
+  GetThemeBlockNames,
+} from './completions/providers/BlockTypeCompletionProvider';
 import { SchemaTranslationsCompletionProvider } from './completions/providers/SchemaTranslationCompletionProvider';
 import { JSONHoverProvider } from './hover/JSONHoverProvider';
 import { SchemaTranslationHoverProvider } from './hover/providers/SchemaTranslationHoverProvider';
@@ -17,6 +21,8 @@ import { findSchemaNode } from './utils';
 
 /** The getInfoContribution API will only fallback if we return undefined synchronously */
 const SKIP_CONTRIBUTION = undefined as any;
+
+export { GetThemeBlockNames };
 
 /**
  * I'm not a fan of how json-languageservice does its feature contributions. It's too different
@@ -32,6 +38,7 @@ export class JSONContributions implements JSONWorkerContribution {
   constructor(
     private documentManager: DocumentManager,
     getDefaultSchemaTranslations: GetTranslationsForURI,
+    getThemeBlockNames: GetThemeBlockNames,
   ) {
     this.hoverProviders = [
       new TranslationPathHoverProvider(),
@@ -39,6 +46,7 @@ export class JSONContributions implements JSONWorkerContribution {
     ];
     this.completionProviders = [
       new SchemaTranslationsCompletionProvider(getDefaultSchemaTranslations),
+      new BlockTypeCompletionProvider(getThemeBlockNames),
     ];
   }
 

--- a/packages/theme-language-server-common/src/json/JSONLanguageService.ts
+++ b/packages/theme-language-server-common/src/json/JSONLanguageService.ts
@@ -21,7 +21,7 @@ import {
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DocumentManager } from '../documents';
 import { GetTranslationsForURI } from '../translations';
-import { JSONContributions } from './JSONContributions';
+import { JSONContributions, GetThemeBlockNames } from './JSONContributions';
 
 export class JSONLanguageService {
   // We index by Mode here because I don't want to reconfigure the service depending on the URI.
@@ -39,6 +39,7 @@ export class JSONLanguageService {
     private jsonValidationSet: JsonValidationSet,
     private getDefaultSchemaTranslations: GetTranslationsForURI,
     private getModeForURI: (uri: string) => Promise<Mode>,
+    private getThemeBlockNames: GetThemeBlockNames,
   ) {
     this.services = Object.fromEntries(Modes.map((mode) => [mode, null])) as typeof this.services;
     this.schemas = {};
@@ -71,7 +72,11 @@ export class JSONLanguageService {
           },
 
           contributions: [
-            new JSONContributions(this.documentManager, this.getDefaultSchemaTranslations),
+            new JSONContributions(
+              this.documentManager,
+              this.getDefaultSchemaTranslations,
+              this.getThemeBlockNames,
+            ),
           ],
         });
 

--- a/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, assert, beforeEach } from 'vitest';
+import { JSONLanguageService } from '../../JSONLanguageService';
+import { DocumentManager } from '../../../documents';
+import { getRequestParams, isCompletionList } from '../../test/test-helpers';
+
+/**
+ * We only need this because I want to show in the test that @theme and @app are
+ * completed by the schema... If you write a test that doesn't have a JOIN on
+ * the completions, feel free to not copy paste this...
+ */
+const simplifiedBlockSchema = JSON.stringify({
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    blocks: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            oneOf: [
+              // blocks[].type is @app, @theme or a string
+              { const: '@app' },
+              { const: '@theme' },
+              {
+                if: { not: { enum: ['@theme', '@app'] } },
+                then: { type: 'string' },
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+});
+
+describe('Unit: BlockTypeCompletionProvider', () => {
+  let jsonLanguageService: JSONLanguageService;
+  let documentManager: DocumentManager;
+  const blockNames = ['block-1', 'block-2', 'custom-block'];
+
+  beforeEach(async () => {
+    documentManager = new DocumentManager(
+      undefined, // don't need a fs
+      undefined, // don't need a connection
+      undefined, // don't need client capabilities
+      async () => 'theme', // 'theme' mode
+      async () => false, // schema is invalid for tests
+    );
+    jsonLanguageService = new JSONLanguageService(
+      documentManager,
+      {
+        schemas: async () => [
+          {
+            uri: 'https://shopify.dev/block-schema.json',
+            schema: simplifiedBlockSchema,
+            fileMatch: ['**/{blocks,sections}/*.liquid'], // cheating a little here...
+          },
+        ],
+      },
+      async () => ({}),
+      async () => 'theme',
+      async () => blockNames,
+    );
+
+    await jsonLanguageService.setup({
+      textDocument: {
+        completion: {
+          contextSupport: true,
+          completionItem: {
+            snippetSupport: true,
+            commitCharactersSupport: true,
+            documentationFormat: ['markdown'],
+            deprecatedSupport: true,
+            preselectSupport: true,
+          },
+        },
+      },
+    });
+  });
+
+  describe('when there are no local blocks', () => {
+    it('completes theme block names', async () => {
+      const source = `
+      hello world
+      {% schema %}
+      {
+        "blocks": [
+          { "type": "█" }
+        ]
+      }
+      {% endschema %}
+      `;
+      const params = getRequestParams(documentManager, 'sections/section.liquid', source);
+
+      const completions = await jsonLanguageService.completions(params);
+
+      assert(isCompletionList(completions));
+      // @app & @theme come from the JSON schema. There's no way to not include them.
+      expect(completions.items).to.have.lengthOf(blockNames.length + ['@app', '@theme'].length);
+      expect(completions.items.map((item) => item.label)).to.include.members([
+        '"@app"',
+        '"@theme"',
+        ...blockNames.map((x) => `"${x}"`),
+      ]);
+    });
+  });
+
+  describe('when there are local blocks', () => {
+    it('does not completes theme block names', async () => {
+      const source = `
+      hello world
+      {% schema %}
+      {
+        "blocks": [
+          { "type": "user-defined", "name": "user defined" }
+          { "type": "█" }
+        ]
+      }
+      {% endschema %}
+      `;
+      const params = getRequestParams(documentManager, 'sections/section.liquid', source);
+
+      const completions = await jsonLanguageService.completions(params);
+
+      assert(isCompletionList(completions));
+      expect(completions.items).to.have.lengthOf(['@app', '@theme'].length);
+      expect(completions.items.map((item) => item.label)).not.to.include.members([
+        ...blockNames.map((x) => `"${x}"`),
+      ]);
+    });
+  });
+});

--- a/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.ts
@@ -1,0 +1,107 @@
+import {
+  AppBlockSchema,
+  deepGet,
+  isError,
+  SectionSchema,
+  ThemeBlockSchema,
+  ThemeSchemaType,
+} from '@shopify/theme-check-common';
+import { JSONPath } from 'vscode-json-languageservice';
+import { JSONCompletionItem } from 'vscode-json-languageservice/lib/umd/jsonContributions';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
+import { isLiquidRequestContext, RequestContext } from '../../RequestContext';
+import { fileMatch } from '../../utils';
+import { JSONCompletionProvider } from '../JSONCompletionProvider';
+
+export type GetThemeBlockNames = (uri: string) => Promise<string[]>;
+
+/**
+ * The BlockTypeCompletionProvider offers value completions of the
+ * `blocks.[].type` property inside section and theme block `{% schema %}` tags.
+ *
+ * @example
+ * {% schema %}
+ * {
+ *   "blocks": [
+ *     { "type": "█" },
+ *   ]
+ * }
+ * {% endschema %}
+ */
+export class BlockTypeCompletionProvider implements JSONCompletionProvider {
+  private uriPatterns = [/^.*\/(sections|blocks)\/[^\/]*\.liquid$/];
+
+  constructor(private getThemeBlockNames: GetThemeBlockNames) {}
+
+  async completeValue(context: RequestContext, path: JSONPath): Promise<JSONCompletionItem[]> {
+    if (
+      !fileMatch(context.doc.uri, this.uriPatterns) ||
+      !isLiquidRequestContext(context) ||
+      !isBlockDefinitionPath(path)
+    ) {
+      return [];
+    }
+    const { doc } = context;
+    const schema = await doc.getSchema();
+
+    // Can't complete if we can't parse the schema
+    if (!schema || isError(schema.parsed) || !isSectionOrBlockSchema(schema)) {
+      return [];
+    }
+
+    // Local blocks have their type defined in the schema, there's nothing to complete
+    if (hasLocalBlockDefinitions(schema)) return [];
+
+    const blockNames = await this.getThemeBlockNames(doc.uri);
+
+    return blockNames.map((name) => ({
+      kind: CompletionItemKind.Value,
+      label: `"${name}"`,
+      insertText: `"${name}"`,
+    }));
+  }
+}
+
+export function isBlockDefinitionPath(path: JSONPath) {
+  return path.at(0) === 'blocks';
+}
+
+export function isPresetBlockPath(path: JSONPath) {
+  return path.at(0) === 'presets';
+}
+
+export function isBlockTypePath(path: JSONPath) {
+  // We have these cases to support:
+  // - top level blocks.[].type
+  // - presets.[](recursive .blocks.[].type)
+  // - presets.[](recursive .blocks.{}.type)
+  const topLevel = path.at(0);
+  if (topLevel !== 'blocks' && topLevel !== 'presets') return false;
+  if (path.length < 4) return false; // minimum path length
+  const [shouldBeBlocks, _idOrIndex, shouldBeType] = path.slice(-3);
+  return shouldBeBlocks === 'blocks' && shouldBeType === 'type';
+}
+
+export function hasLocalBlockDefinitions(schema: SectionSchema | ThemeBlockSchema) {
+  if (schema.type !== ThemeSchemaType.Section || isError(schema.parsed)) return false;
+  const blocks = deepGet(schema.parsed, ['blocks']);
+  if (!blocks || !Array.isArray(blocks)) return false;
+  return blocks.some((block) => block && block.name !== undefined);
+}
+
+export function isLocalBlockDefinition(
+  schema: ThemeBlockSchema | SectionSchema,
+  blockTypePath: JSONPath,
+) {
+  if (schema.type !== ThemeSchemaType.Section) return false;
+  const blockNamePath = [...blockTypePath.slice(0, -1), 'name'];
+  const name = deepGet(schema.parsed, blockNamePath);
+  return name !== undefined;
+}
+
+const SectionOrBlockSchemaTypes = [ThemeSchemaType.Section, ThemeSchemaType.Block];
+export function isSectionOrBlockSchema(
+  schema: SectionSchema | ThemeBlockSchema | AppBlockSchema,
+): schema is SectionSchema | ThemeBlockSchema {
+  return SectionOrBlockSchemaTypes.includes(schema.type);
+}

--- a/packages/theme-language-server-common/src/json/test/test-helpers.ts
+++ b/packages/theme-language-server-common/src/json/test/test-helpers.ts
@@ -1,0 +1,30 @@
+import {
+  CompletionItem,
+  CompletionList,
+  CompletionParams,
+  HoverParams,
+} from 'vscode-languageserver-protocol';
+import { DocumentManager } from '../../documents';
+
+export function getRequestParams(
+  documentManager: DocumentManager,
+  relativePath: string,
+  source: string,
+): HoverParams & CompletionParams {
+  const uri = `file:///root/${relativePath}`;
+  const sourceWithoutCursor = source.replace('█', '');
+  documentManager.open(uri, sourceWithoutCursor, 1);
+  const doc = documentManager.get(uri)!.textDocument;
+  const position = doc.positionAt(source.indexOf('█'));
+
+  return {
+    textDocument: { uri: uri },
+    position: position,
+  };
+}
+
+export function isCompletionList(
+  completions: null | CompletionList | CompletionItem[],
+): completions is CompletionList {
+  return completions !== null && !Array.isArray(completions);
+}

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -197,6 +197,12 @@ export function startServer(
     return config.context;
   }
 
+  async function getThemeBlockNames(uri: string) {
+    const rootUri = await findThemeRootURI(uri);
+    const blocks = await fs.readDirectory(path.join(rootUri, 'blocks'));
+    return blocks.map(([uri]) => path.basename(uri, '.liquid'));
+  }
+
   // Defined as a function to solve a circular dependency (doc manager & json
   // lang service both need each other)
   async function isValidSchema(uri: string, jsonString: string) {
@@ -208,6 +214,7 @@ export function startServer(
     jsonValidationSet,
     getSchemaTranslationsForURI,
     getModeForURI,
+    getThemeBlockNames,
   );
   const completionsProvider = new CompletionsProvider({
     documentManager,


### PR DESCRIPTION
## What are you adding in this PR?

The `BlockTypeCompletionProvider` offers value completions of the `blocks.[].type` property inside section and theme block `{% schema %}` tags.

```liquid
{% schema %}
{
  "blocks": [
    { "type": "█" },
  ]
}
{% endschema %}
```

Fixes #627


https://github.com/user-attachments/assets/03c1edd0-619a-492c-8085-369410207917



## What's next? Any followup issues?

https://github.com/Shopify/theme-tools/issues/545

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
