### PR TITLE
Update filter param tests

### DIFF
--- a/.changeset/wild-hornets-crash.md
+++ b/.changeset/wild-hornets-crash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Use CURSOR variable instead of hardcoded string

--- a/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.spec.ts
@@ -1,7 +1,10 @@
 import { FilterEntry, MetafieldDefinitionMap, ObjectEntry } from '@shopify/theme-check-common';
+import { InsertTextFormat, type TextEdit } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
+import { CURSOR } from '../params';
 
 const filters: FilterEntry[] = [
   {
@@ -174,25 +177,25 @@ describe('Module: FilterCompletionProvider', async () => {
       //                  char 12 ⌄   ⌄ char 16
       const liquid = '{{ string | defa█ }}';
 
+      const textEdit: TextEdit = {
+        newText: 'default',
+        range: {
+          end: { line: 0, character: 16 },
+          start: { line: 0, character: 12 },
+        },
+      };
+
       await expect(provider).to.complete(liquid, [
         expect.objectContaining({
           label: 'default',
-          insertTextFormat: 1,
-          textEdit: expect.objectContaining({
-            newText: 'default',
-            range: {
-              end: {
-                line: 0,
-                character: 16,
-              },
-              start: {
-                line: 0,
-                character: 12,
-              },
-            },
-          }),
+          insertTextFormat: InsertTextFormat.PlainText,
+          textEdit,
         }),
       ]);
+
+      const textDocument = TextDocument.create('', 'liquid', 0, liquid.replace(CURSOR, ''));
+
+      expect(TextDocument.applyEdits(textDocument, [textEdit])).toBe('{{ string | default }}');
     });
   });
 
@@ -201,25 +204,27 @@ describe('Module: FilterCompletionProvider', async () => {
       //                  char 12 ⌄  ⌄ char 15
       const liquid = '{{ string | hig█ }}';
 
+      const textEdit: TextEdit = {
+        newText: "highlight: '${1:highlighted_term}'",
+        range: {
+          end: { line: 0, character: 15 },
+          start: { line: 0, character: 12 },
+        },
+      };
+
       await expect(provider).to.complete(liquid, [
         expect.objectContaining({
           label: 'highlight',
-          insertTextFormat: 2,
-          textEdit: expect.objectContaining({
-            newText: "highlight: '${1:highlighted_term}'",
-            range: {
-              end: {
-                line: 0,
-                character: 15,
-              },
-              start: {
-                line: 0,
-                character: 12,
-              },
-            },
-          }),
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit,
         }),
       ]);
+
+      const textDocument = TextDocument.create('', 'liquid', 0, liquid.replace(CURSOR, ''));
+
+      expect(TextDocument.applyEdits(textDocument, [textEdit])).toBe(
+        "{{ string | highlight: '${1:highlighted_term}' }}",
+      );
     });
   });
 
@@ -228,25 +233,27 @@ describe('Module: FilterCompletionProvider', async () => {
       //                  char 12 ⌄  ⌄ char 15
       const liquid = '{{ string | pre█ }}';
 
+      const textEdit: TextEdit = {
+        newText: "preload_tag: as: '$1'",
+        range: {
+          end: { line: 0, character: 15 },
+          start: { line: 0, character: 12 },
+        },
+      };
+
       await expect(provider).to.complete(liquid, [
         expect.objectContaining({
           label: 'preload_tag',
-          insertTextFormat: 2,
-          textEdit: expect.objectContaining({
-            newText: "preload_tag: as: '$1'",
-            range: {
-              end: {
-                line: 0,
-                character: 15,
-              },
-              start: {
-                line: 0,
-                character: 12,
-              },
-            },
-          }),
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit,
         }),
       ]);
+
+      const textDocument = TextDocument.create('', 'liquid', 0, liquid.replace(CURSOR, ''));
+
+      expect(TextDocument.applyEdits(textDocument, [textEdit])).toBe(
+        "{{ string | preload_tag: as: '$1' }}",
+      );
     });
   });
 
@@ -256,25 +263,27 @@ describe('Module: FilterCompletionProvider', async () => {
         //                  char 12 ⌄          ⌄ char 23
         const liquid = '{{ string | prel█oad_tag: as: "p" }}';
 
+        const textEdit: TextEdit = {
+          newText: 'preload_tag',
+          range: {
+            end: { line: 0, character: 23 },
+            start: { line: 0, character: 12 },
+          },
+        };
+
         await expect(provider).to.complete(liquid, [
           expect.objectContaining({
             label: 'preload_tag',
-            insertTextFormat: 1,
-            textEdit: expect.objectContaining({
-              newText: 'preload_tag',
-              range: {
-                end: {
-                  line: 0,
-                  character: 23,
-                },
-                start: {
-                  line: 0,
-                  character: 12,
-                },
-              },
-            }),
+            insertTextFormat: InsertTextFormat.PlainText,
+            textEdit,
           }),
         ]);
+
+        const textDocument = TextDocument.create('', 'liquid', 0, liquid.replace(CURSOR, ''));
+
+        expect(TextDocument.applyEdits(textDocument, [textEdit])).toBe(
+          '{{ string | preload_tag: as: "p" }}',
+        );
       });
     });
 
@@ -284,42 +293,44 @@ describe('Module: FilterCompletionProvider', async () => {
         const liquid = '{{ string | d█efault: true }}';
         //                                 ⌃ char 19
 
+        const downcaseTextEdit: TextEdit = {
+          newText: 'downcase',
+          range: {
+            end: { line: 0, character: 25 },
+            start: { line: 0, character: 12 },
+          },
+        };
+
+        const defaultTextEdit: TextEdit = {
+          newText: 'default',
+          range: {
+            end: { line: 0, character: 19 },
+            start: { line: 0, character: 12 },
+          },
+        };
+
         await expect(provider).to.complete(liquid, [
           expect.objectContaining({
             label: 'downcase',
-            insertTextFormat: 1,
-            textEdit: expect.objectContaining({
-              newText: 'downcase',
-              range: {
-                end: {
-                  line: 0,
-                  character: 25,
-                },
-                start: {
-                  line: 0,
-                  character: 12,
-                },
-              },
-            }),
+            insertTextFormat: InsertTextFormat.PlainText,
+            textEdit: downcaseTextEdit,
           }),
           expect.objectContaining({
             label: 'default',
-            insertTextFormat: 1,
-            textEdit: expect.objectContaining({
-              newText: 'default',
-              range: {
-                end: {
-                  line: 0,
-                  character: 19,
-                },
-                start: {
-                  line: 0,
-                  character: 12,
-                },
-              },
-            }),
+            insertTextFormat: InsertTextFormat.PlainText,
+            textEdit: defaultTextEdit,
           }),
         ]);
+
+        const textDocument = TextDocument.create('', 'liquid', 0, liquid.replace(CURSOR, ''));
+
+        expect(TextDocument.applyEdits(textDocument, [downcaseTextEdit])).toBe(
+          '{{ string | downcase }}',
+        );
+
+        expect(TextDocument.applyEdits(textDocument, [defaultTextEdit])).toBe(
+          '{{ string | default: true }}',
+        );
       });
     });
   });

--- a/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.ts
@@ -110,7 +110,7 @@ export class FilterCompletionProvider implements Provider {
     // options and should not replace any text.
     // e.g. `{{ product | █image_url: crop: 'center' }}`
     // e.g. `{{ product | █ }}`
-    if (node.name === '█') {
+    if (node.name === CURSOR) {
       end = start;
     }
 


### PR DESCRIPTION
## What are you adding in this PR?

This is a follow up to https://github.com/Shopify/theme-tools/pull/522 where I'm just updating the filter completion tests that I added to be a little more robust.

We were previously asserting only against the fact that the text edits were what we expected but we can have a lot more confidence if we also test that the application of the text edit is what we expect.

This PR hooks into TextDocument and lets us use `applyEdits` to test that the modified string looks as we expect it to.

## Before you deploy

- [x] I included a patch bump `changeset`
