### PR TITLE
Import types for `ValidBlockTarget`

### DIFF
--- a/.changeset/strange-sheep-hang.md
+++ b/.changeset/strange-sheep-hang.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Import Section and ThemeBlock types.

--- a/packages/theme-check-common/src/checks/valid-block-target/index.ts
+++ b/packages/theme-check-common/src/checks/valid-block-target/index.ts
@@ -1,4 +1,11 @@
-import { LiquidCheckDefinition, Severity, SourceCodeType, Preset } from '../../types';
+import {
+  LiquidCheckDefinition,
+  Severity,
+  SourceCodeType,
+  Preset,
+  Section,
+  ThemeBlock,
+} from '../../types';
 import { LiteralNode } from 'json-to-ast';
 import { nodeAtPath } from '../../json';
 import { getSchema } from '../../to-schema';


### PR DESCRIPTION
## What are you adding in this PR?

This PR aims to address CI jobs failing from missing `Section` and `ThemeBlock` imports in `ValidBlockTarget`.

## What's next? Any followup issues?

N/A

## What did you learn?

N/A

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
