### PR TITLE
Update contentFor tag grammar to properly extract arguments

### DIFF
--- a/.changeset/short-jobs-boil.md
+++ b/.changeset/short-jobs-boil.md
@@ -1,0 +1,7 @@
+---
+'@shopify/liquid-html-parser': minor
+'@shopify/theme-check-common': minor
+---
+
+Update Ohm grammar for ContentFor tag to extract arguments correctly
+Update ValidContentForArguments check to report deprecated context. argument usage

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -127,8 +127,13 @@ Liquid <: Helpers {
   liquidTagLiquidMarkup = tagMarkup
 
   liquidTagContentFor = liquidTagRule<"content_for", liquidTagContentForMarkup>
+  
   liquidTagContentForMarkup =
-    contentForType (argumentSeparatorOptionalComma tagArguments) (space* ",")? space*
+    contentForType (argumentSeparatorOptionalComma contentForTagArgument) (space* ",")? space*
+    
+  contentForTagArgument = listOf<contentForNamedArgument<delimTag>, argumentSeparatorOptionalComma>
+  contentForNamedArgument<delim> = (variableSegment ("." variableSegment)*) space* ":" space* (liquidExpression<delim>)
+
   contentForType = liquidString<delimTag>
 
   liquidTagInclude = liquidTagRule<"include", liquidTagRenderMarkup>

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -604,15 +604,19 @@ describe('Unit: Stage 1 (CST)', () => {
 
       it('should parse content_for "block", id: "my-id", type: "my-block"', () => {
         for (const { toCST, expectPath } of testCases) {
-          cst = toCST(`{% content_for "block", id: "block-id", type: "block-type" -%}`);
+          cst = toCST(
+            `{% content_for "block", closest.product: product, closest.metaobject.test: product, id: "block-id", type: "block-type" -%}`,
+          );
           expectPath(cst, '0.type').to.equal('LiquidTag');
           expectPath(cst, '0.name').to.equal('content_for');
           expectPath(cst, '0.markup.type').to.equal('ContentForMarkup');
           expectPath(cst, '0.markup.contentForType.type').to.equal('String');
           expectPath(cst, '0.markup.contentForType.value').to.equal('block');
           expectPath(cst, '0.markup.contentForType.single').to.equal(false);
-          expectPath(cst, '0.markup.args').to.have.lengthOf(2);
+          expectPath(cst, '0.markup.args').to.have.lengthOf(4);
           const namedArguments = [
+            { name: 'closest.product', valueType: 'VariableLookup' },
+            { name: 'closest.metaobject.test', valueType: 'VariableLookup' },
             { name: 'id', valueType: 'String' },
             { name: 'type', valueType: 'String' },
           ];

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -81,6 +81,7 @@ export enum ConcreteNodeTypes {
   RenderMarkup = 'RenderMarkup',
   PaginateMarkup = 'PaginateMarkup',
   RenderVariableExpression = 'RenderVariableExpression',
+  ContentForNamedArgument = 'ContentForNamedArgument',
 }
 
 export const LiquidLiteralValues = {
@@ -873,11 +874,21 @@ function toCST<T>(
     },
     simpleArgument: 0,
     tagArguments: 0,
+    contentForTagArgument: 0,
     positionalArgument: 0,
     namedArgument: {
       type: ConcreteNodeTypes.NamedArgument,
       name: 0,
       value: 4,
+      locStart,
+      locEnd,
+      source,
+    },
+
+    contentForNamedArgument: {
+      type: ConcreteNodeTypes.NamedArgument,
+      name: (node) => node[0].sourceString + node[1].sourceString,
+      value: 6,
       locStart,
       locEnd,
       source,

--- a/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
+++ b/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
@@ -1,7 +1,8 @@
 import { ContentForMarkup, NodeTypes } from '@shopify/liquid-html-parser';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 
-// content_for "block" and content_for "blocks" only allow `context.*` kwargs.
+// content_for "block" and content_for "blocks" only allow `closest.*` kwargs.
+const isClosestArgument = (argName: string) => argName.startsWith('closest.');
 const isContextArgument = (argName: string) => argName.startsWith('context.');
 
 export const ValidContentForArguments: LiquidCheckDefinition = {
@@ -23,10 +24,19 @@ export const ValidContentForArguments: LiquidCheckDefinition = {
   create(context) {
     const validationStrategies = {
       blocks: (node: ContentForMarkup) => {
-        const problematicArguments = node.args.filter((arg) => !isContextArgument(arg.name));
+        const problematicArguments = node.args.filter((arg) => !isClosestArgument(arg.name));
         for (const arg of problematicArguments) {
           context.report({
-            message: `{% content_for "blocks" %} only accepts 'context.*' arguments`,
+            message: `{% content_for "blocks" %} only accepts 'closest.*' arguments`,
+            startIndex: arg.position.start,
+            endIndex: arg.position.end,
+          });
+        }
+
+        const deprecatedArguments = node.args.filter((arg) => isContextArgument(arg.name));
+        for (const arg of deprecatedArguments) {
+          context.report({
+            message: `{% content_for "blocks" %} only accepts 'closest.*' arguments. The 'context.*' arguments usage has been deprecated.`,
             startIndex: arg.position.start,
             endIndex: arg.position.end,
           });
@@ -62,12 +72,21 @@ export const ValidContentForArguments: LiquidCheckDefinition = {
         }
 
         const problematicArguments = node.args.filter(
-          (arg) => !(requiredArguments.includes(arg.name) || isContextArgument(arg.name)),
+          (arg) => !(requiredArguments.includes(arg.name) || isClosestArgument(arg.name)),
         );
 
         for (const arg of problematicArguments) {
           context.report({
-            message: `{% content_for "block" %} only accepts 'id', 'type' and 'context.*' arguments`,
+            message: `{% content_for "block" %} only accepts 'id', 'type' and 'closest.*' arguments`,
+            startIndex: arg.position.start,
+            endIndex: arg.position.end,
+          });
+        }
+
+        const deprecatedArguments = node.args.filter((arg) => isContextArgument(arg.name));
+        for (const arg of deprecatedArguments) {
+          context.report({
+            message: `{% content_for "block" %} accepts 'closest.*' arguments. The 'context.*' arguments usage has been deprecated.`,
             startIndex: arg.position.start,
             endIndex: arg.position.end,
           });


### PR DESCRIPTION
## What are you adding in this PR?
It seems that the grammar we had for content_for did not properly extract the contentFor liquid tag argument and convert them into array. 

In this PR we have:
1. Updated the grammar for contentFor liquid tag to support arguments that contain `.`
2. Updated ValidContentForArguments check to support `closest.` instead of `context.`
3. Introduced a new `DeprecatedContentForArgument` check that reports a warning when contentFor tag contains `context.`


<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [x] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
