### PR TITLE
static blocks content_for check

### DIFF
--- a/.changeset/silly-parrots-behave.md
+++ b/.changeset/silly-parrots-behave.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+'theme-check-vscode': minor
+---
+
+Add `SchemaPresetsStaticBlocks` check

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -7,7 +7,6 @@ import { AssetSizeAppBlockJavaScript } from './asset-size-app-block-javascript';
 import { AssetSizeCSS } from './asset-size-css';
 import { AssetSizeJavaScript } from './asset-size-javascript';
 import { BlockIdUsage } from './block-id-usage';
-``;
 import { CaptureOnContentForBlock } from './capture-on-content-for-block';
 import { CdnPreconnect } from './cdn-preconnect';
 import { ContentForHeaderModification } from './content-for-header-modification';
@@ -27,6 +26,7 @@ import { MissingTemplate } from './missing-template';
 import { PaginationSize } from './pagination-size';
 import { ParserBlockingScript } from './parser-blocking-script';
 import { SchemaPresetsBlockOrder } from './schema-presets-block-order';
+import { SchemaPresetsStaticBlocks } from './schema-presets-static-blocks';
 import { RemoteAsset } from './remote-asset';
 import { RequiredLayoutThemeObject } from './required-layout-theme-object';
 import { TranslationKeyExists } from './translation-key-exists';
@@ -74,6 +74,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   PaginationSize,
   ParserBlockingScript,
   SchemaPresetsBlockOrder,
+  SchemaPresetsStaticBlocks,
   RemoteAsset,
   RequiredLayoutThemeObject,
   TranslationKeyExists,

--- a/packages/theme-check-common/src/checks/schema-presets-block-order/index.ts
+++ b/packages/theme-check-common/src/checks/schema-presets-block-order/index.ts
@@ -1,6 +1,5 @@
 import { getLocEnd, getLocStart, nodeAtPath } from '../../json';
-import { basename } from '../../path';
-import { isBlock, isSection } from '../../to-schema';
+import { getSchema } from '../../to-schema';
 import {
   ArrayNode,
   Context,
@@ -28,18 +27,6 @@ export const SchemaPresetsBlockOrder: LiquidCheckDefinition = {
   },
 
   create(context) {
-    function getSchema() {
-      const name = basename(context.file.uri, '.liquid');
-      switch (true) {
-        case isBlock(context.file.uri):
-          return context.getBlockSchema?.(name);
-        case isSection(context.file.uri):
-          return context.getSectionSchema?.(name);
-        default:
-          return undefined;
-      }
-    }
-
     return {
       async LiquidRawTag(node) {
         if (node.name !== 'schema' || node.body.kind !== 'json') {
@@ -47,7 +34,7 @@ export const SchemaPresetsBlockOrder: LiquidCheckDefinition = {
         }
 
         const offset = node.blockStartPosition.end;
-        const schema = await getSchema();
+        const schema = await getSchema(context);
         const { validSchema, ast } = schema ?? {};
         if (!validSchema || validSchema instanceof Error) return;
         if (!ast || ast instanceof Error) return;

--- a/packages/theme-check-common/src/checks/schema-presets-static-blocks/index.spec.ts
+++ b/packages/theme-check-common/src/checks/schema-presets-static-blocks/index.spec.ts
@@ -1,0 +1,145 @@
+import { expect, describe, it } from 'vitest';
+import { highlightedOffenses, runLiquidCheck, check } from '../../test';
+import { SchemaPresetsStaticBlocks } from './index';
+
+const DEFAULT_FILE_NAME = 'sections/file.liquid';
+
+describe('Module: SchemaPresetsStaticBlocks', () => {
+  it('reports no errors when there are {% content_for "block" ... %} for each static block in the preset blocks array', async () => {
+    const sourceCode = `
+      {% content_for "block" type:"text" id: "block-1" %}
+      {% content_for "block" type:"icon" id: "block-2" %}
+      {% schema %}
+      {
+        "name": "Test section",
+        "blocks": [{"type": "@theme"}],
+        "presets": [
+          {
+            "name": "Preset with two static blocks",
+            "blocks": [
+              {
+                "type": "text",
+                "static": true,
+                "id": "block-1"
+              },
+              {
+                "type": "icon",
+                "static": true,
+                "id": "block-2"
+              }
+            ]
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsStaticBlocks, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports an error when there are {% content_for "block" ... %} missing for static blocks in the preset blocks array', async () => {
+    const sourceCode = `
+      {% content_for "block" type:"text" id:"block-1" %}
+      {% comment %} here we are missing the other content_for block for block-2 {% endcomment %}
+      {% schema %}
+      {
+        "name": "Test section",
+        "blocks": [{"type": "@theme"}],
+        "presets": [
+          {
+            "name": "Preset with two static blocks",
+            "blocks": [
+              {
+                "type": "text",
+                "static": true,
+                "id": "block-1"
+              },
+              {
+                "type": "icon",
+                "static": true,
+                "id": "block-2"
+              }
+            ]
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsStaticBlocks, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(1);
+    console.log(offenses);
+    expect(offenses[0].message).toEqual(
+      'Static block block-2 is missing a corresponding content_for "block" tag.',
+    );
+
+    const highlights = highlightedOffenses({ [DEFAULT_FILE_NAME]: sourceCode }, offenses);
+    expect(highlights).toHaveLength(1);
+  });
+
+  it('reports no errors when there are {% content_for "block" ... %} for each static block in the preset blocks hash', async () => {
+    const sourceCode = `
+      {% content_for "block" type:"text" id: "block-1" %}
+      {% content_for "block" type:"icon" id: "block-2" %}
+      {% schema %}
+      {
+        "name": "Test section",
+        "blocks": [{"type": "@theme"}],
+        "presets": [
+          {
+            "name": "Preset with two static blocks",
+            "blocks": {
+              "block-1": {
+                "type": "text",
+                "static": true
+              },
+              "block-2": {
+                "type": "icon",
+                "static": true
+              }
+            }
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsStaticBlocks, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports an error when there are {% content_for "block" ... %} missing for static blocks in the preset blocks hash', async () => {
+    const sourceCode = `
+      {% content_for "block" type:"text" id:"block-1" %}
+      {% comment %} here we are missing the other content_for block for block-2 {% endcomment %}
+      {% schema %}
+      {
+        "name": "Test section",
+        "blocks": [{"type": "@theme"}],
+        "presets": [
+          {
+            "name": "Preset with two static blocks",
+            "blocks": {
+              "block-1": {
+                "type": "text",
+                "static": true
+              },
+              "block-2": {
+                "type": "icon",
+                "static": true
+              }
+            }
+          }
+        ]
+      }
+      {% endschema %}`;
+
+    const offenses = await runLiquidCheck(SchemaPresetsStaticBlocks, sourceCode, DEFAULT_FILE_NAME);
+    expect(offenses).toHaveLength(1);
+    console.log(offenses);
+    expect(offenses[0].message).toEqual(
+      'Static block block-2 is missing a corresponding content_for "block" tag.',
+    );
+
+    const highlights = highlightedOffenses({ [DEFAULT_FILE_NAME]: sourceCode }, offenses);
+    expect(highlights).toHaveLength(1);
+  });
+});

--- a/packages/theme-check-common/src/checks/schema-presets-static-blocks/index.ts
+++ b/packages/theme-check-common/src/checks/schema-presets-static-blocks/index.ts
@@ -1,0 +1,126 @@
+import { NamedTags, NodeTypes } from '@shopify/liquid-html-parser';
+import { getLocEnd, getLocStart, nodeAtPath } from '../../json';
+import { getSchema } from '../../to-schema';
+import { ArrayNode, LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { isContentForBlock } from '../../utils/markup';
+
+export const SchemaPresetsStaticBlocks: LiquidCheckDefinition = {
+  meta: {
+    code: 'SchemaPresetsStaticBlocks',
+    name: 'Ensure the preset static blocks are used in the liquid',
+    docs: {
+      description:
+        'Warns if a preset static block does not have a corresponding content_for "block" tag.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/schema-presets-static-blocks',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    type contentForBlock = {
+      id: string;
+      type: string;
+    };
+    type StaticBlock = {
+      id: string;
+      type: string;
+      startIndex: number;
+      endIndex: number;
+    };
+    let contentForBlockList: contentForBlock[] = [];
+    let staticBlockList: StaticBlock[] = [];
+    let offset: number = 0;
+
+    function checkStaticBlocks() {
+      staticBlockList.forEach((block) => {
+        if (
+          !contentForBlockList.some(
+            (contentBlock) => contentBlock.id === block.id && contentBlock.type === block.type,
+          )
+        ) {
+          context.report({
+            message: `Static block ${block.id} is missing a corresponding content_for "block" tag.`,
+            startIndex: block.startIndex,
+            endIndex: block.endIndex,
+          });
+        }
+      });
+    }
+
+    return {
+      async LiquidTag(node) {
+        // Early return if not a content_for block tag
+        if (node.name !== NamedTags.content_for || !isContentForBlock(node.markup)) return;
+
+        // Extract id and type from markup args
+        const idValue = node.markup.args.find((arg) => arg.name === 'id')?.value;
+        const typeArg = node.markup.args.find((arg) => arg.name === 'type')?.value;
+        if (!typeArg || typeArg.type !== NodeTypes.String) {
+          return; // covered by VariableContentForArguments
+        }
+        const typeValue = typeArg.value;
+
+        // Add to list if valid string id
+        if (idValue?.type === NodeTypes.String) {
+          contentForBlockList.push({ id: idValue.value, type: typeValue });
+        }
+      },
+
+      async LiquidRawTag(node) {
+        // when we get the schema tag, get the list of static blocks from each preset
+        if (node.name === 'schema' && node.body.kind === 'json') {
+          offset = node.blockStartPosition.end;
+          const schema = await getSchema(context);
+          const { validSchema, ast } = schema ?? {};
+          if (!validSchema || validSchema instanceof Error) return;
+          if (!ast || ast instanceof Error) return;
+
+          const presets = validSchema.presets;
+          if (!presets) return;
+
+          presets.forEach((preset, index) => {
+            if ('blocks' in preset && preset.blocks) {
+              let ast_path: any[] = ['presets', index, 'blocks'];
+              // blocks as an array
+              if (Array.isArray(preset.blocks)) {
+                preset.blocks.forEach((block, block_index) => {
+                  if (block.static === true && block.id) {
+                    let node = nodeAtPath(ast, ast_path.concat([block_index]))! as ArrayNode;
+                    staticBlockList.push({
+                      id: block.id,
+                      type: block.type,
+                      startIndex: offset + getLocStart(node),
+                      endIndex: offset + getLocEnd(node),
+                    });
+                  }
+                });
+              }
+              // blocks as an object
+              else if (typeof preset.blocks === 'object') {
+                Object.entries(preset.blocks).forEach(([block_id, block]) => {
+                  if (block.static === true) {
+                    let node = nodeAtPath(ast, ast_path.concat(block_id))! as ArrayNode;
+                    staticBlockList.push({
+                      id: block_id,
+                      type: block.type,
+                      startIndex: offset + getLocStart(node),
+                      endIndex: offset + getLocEnd(node),
+                    });
+                  }
+                });
+              }
+            }
+          });
+        }
+      },
+
+      async onCodePathEnd() {
+        checkStaticBlocks();
+      },
+    };
+  },
+};

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -97,6 +97,9 @@ RequiredLayoutThemeObject:
 SchemaPresetsBlockOrder:
   enabled: true
   severity: 1
+SchemaPresetsStaticBlocks:
+  enabled: true
+  severity: 0
 TranslationKeyExists:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -75,6 +75,9 @@ RequiredLayoutThemeObject:
 SchemaPresetsBlockOrder:
   enabled: true
   severity: 1
+SchemaPresetsStaticBlocks:
+  enabled: true
+  severity: 0
 TranslationKeyExists:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?
Addresses https://github.com/Shopify/shopify/issues/559551

The static blocks found at the root level of the preset blocks (meaning, not the nested blocks) need to have a `content_for "block"` for each of those blocks, so that the preset will render correctly. 

![image](https://github.com/user-attachments/assets/ef425d10-3584-498a-ab31-51f6385c11c7)

My section (could be a block) for tophatting:
```
{% content_for 'block', type: 'text', id: 'block1' %}
{% content_for 'block', type: 'text', id: 'block3' %}

{% schema %}
{
  "name": "Slideshow",
  "tag": "section",
  "class": "slideshow",
  "limit": 1,
  "settings": [
    {
      "type": "text",
      "id": "title",
      "label": "Slideshow"
    }
  ],
  "max_blocks": 5,
  "blocks": [
    {
      "type": "text"
    },
    {
      "type": "slide"
    }
  ],
  "presets": [
    {
      "name": "Two blocks, one error",
      "blocks": [
        {
          "type": "text",
          "static": true,
          "id": "block1"
        },
        {
          "type": "slide",
          "static": true,
          "id": "block2"
        }
      ]
    },
    {
      "name": "Single block with an error",
      "blocks": [
        {
          "type": "slide",
          "static": true,
          "id": "block2"
        }
      ]
    },
    {
      "name": "One block, no errors",
      "blocks": [
        {
          "type": "text",
          "static": true,
          "id": "block3"
        }
      ]
    },
    {
      "name": "Blocks Hash: Two blocks, no errors part 2",
      "blocks": {
        "block1": {
          "type": "text",
          "static": true
        },
        "block2": {
          "type": "slide",
          "static": true
        }
      }
    },
    {
      "name": "Blocks Hash: One block, no errors",
      "blocks": {
        "block1": {
          "type": "text",
          "static": true
        }
      }
    },
    {
      "name": "Blocks Hash: One block, one error",
      "blocks": {
        "block2": {
          "type": "slide",
          "static": true
        }
      }
    }
  ]
}
{% endschema %}
```

Note about the approach:
- I debugged and the `LiquidTag` callback worked for `content_for` and not for `schema`
- Vice versa, the `LiquidRawTag` callback worked for `schema` and not for `content_for`

But in the end, it seems to be working well. Both callbacks run before `onCodePathEnd`, at which point we can compare the two lists we've gathered to suss out any missing static block `content_for`s.


<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
