### PR TITLE
Theme Tools Release: 09-12-24

### DIFF
--- a/.changeset/nice-kids-fix.md
+++ b/.changeset/nice-kids-fix.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-language-server-common': patch
----
-
-Fixed bug where filter completions wouldn't work on Liquid assignments

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-browser
 
+## 2.3.2
+
+### Patch Changes
+
+- Updated dependencies [2bd19d66]
+  - @shopify/theme-language-server-common@2.3.2
+
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "2.3.1",
+    "@shopify/theme-language-server-common": "2.3.2",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-language-server-common
 
+## 2.3.2
+
+### Patch Changes
+
+- 2bd19d66: Fixed bug where filter completions wouldn't work on Liquid assignments
+
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @shopify/theme-language-server-node
 
+## 2.3.2
+
+### Patch Changes
+
+- Updated dependencies [2bd19d66]
+  - @shopify/theme-language-server-common@2.3.2
+
 ## 2.3.1
 
 ### Patch Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "2.3.1",
+    "@shopify/theme-language-server-common": "2.3.2",
     "@shopify/theme-check-node": "^3.4.0",
     "@shopify/theme-check-docs-updater": "^3.4.0",
     "glob": "^8.0.3",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## theme-check-vscode
 
+## 3.3.2
+
+### Patch Changes
+
+- Patch bump because it depends on:
+  - @shopify/theme-language-server-browser
+  - @shopify/theme-language-server-node
+  - @shopify/theme-language-server-browser@2.3.2
+  - @shopify/theme-language-server-node@2.3.2
+
 ## 3.3.1
 
 ### Patch Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/shopify/theme-tools/issues"
   },
-  "version": "3.3.1",
+  "version": "3.3.2",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -61,8 +61,8 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.2.0",
     "@shopify/prettier-plugin-liquid": "^1.6.3",
-    "@shopify/theme-language-server-browser": "^2.3.1",
-    "@shopify/theme-language-server-node": "^2.3.1",
+    "@shopify/theme-language-server-browser": "^2.3.2",
+    "@shopify/theme-language-server-node": "^2.3.2",
     "@shopify/theme-check-common": "^3.4.0",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0",


### PR DESCRIPTION
# Releases
## `theme-check-vscode`
Patch incremented `3.3.1` -> `3.3.2`
### Changes:
- Patch bump because it depends on:
 - @shopify/theme-language-server-browser
 - @shopify/theme-language-server-node

## `@shopify/theme-language-server-common`
Patch incremented `2.3.1` -> `2.3.2`
### Changes:
- Fixed bug where filter completions wouldn't work on Liquid assignments

## `@shopify/theme-language-server-browser`
Patch incremented `2.3.1` -> `2.3.2`

## `@shopify/theme-language-server-node`
Patch incremented `2.3.1` -> `2.3.2`

