### PR TITLE
Update `PropertyNode` import

### DIFF
--- a/.changeset/big-bananas-shout.md
+++ b/.changeset/big-bananas-shout.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Import fix for PropertyNode in JSONMissingBlock.

--- a/packages/theme-check-common/src/checks/json-missing-block/missing-block-utils.ts
+++ b/packages/theme-check-common/src/checks/json-missing-block/missing-block-utils.ts
@@ -1,5 +1,5 @@
 import { Context, SourceCodeType, JSONNode } from '../../types';
-import { PropertyNode } from 'json-to-ast';
+import { PropertyNode } from '../../jsonc/types';
 import { getLocEnd, getLocStart, nodeAtPath } from '../../json';
 import { doesFileExist } from '../../utils/file-utils';
 


### PR DESCRIPTION
## What are you adding in this PR?

CI pipeline had an error because `PropertyNode` was not getting imported correctly in `JSONMissingBlock`.

## What's next? Any followup issues?

Follow up would be to eventually package a release with all the new checks that we have added.

## What did you learn?

For some reason, running `yarn build` did not catch this error.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
