### PR TITLE
Support schema presets block type completion

### DIFF
--- a/.changeset/stupid-dolphins-cry.md
+++ b/.changeset/stupid-dolphins-cry.md
@@ -1,0 +1,14 @@
+---
+'@shopify/theme-language-server-browser': minor
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-language-server-node': minor
+'@shopify/theme-check-docs-updater': minor
+'@shopify/prettier-plugin-liquid': minor
+'@shopify/theme-check-browser': minor
+'@shopify/liquid-html-parser': minor
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+'theme-check-vscode': minor
+---
+
+Support schema presets block type completion

--- a/packages/theme-language-server-common/src/json/JSONContributions.ts
+++ b/packages/theme-language-server-common/src/json/JSONContributions.ts
@@ -1,4 +1,10 @@
-import { parseJSON, SourceCodeType } from '@shopify/theme-check-common';
+import {
+  AppBlockSchema,
+  parseJSON,
+  SectionSchema,
+  SourceCodeType,
+  ThemeBlockSchema,
+} from '@shopify/theme-check-common';
 import {
   CompletionsCollector,
   JSONPath,
@@ -8,10 +14,8 @@ import {
 import { AugmentedSourceCode, DocumentManager } from '../documents';
 import { GetTranslationsForURI } from '../translations';
 import { JSONCompletionProvider } from './completions/JSONCompletionProvider';
-import {
-  BlockTypeCompletionProvider,
-  GetThemeBlockNames,
-} from './completions/providers/BlockTypeCompletionProvider';
+import { BlockTypeCompletionProvider } from './completions/providers/BlockTypeCompletionProvider';
+import { PresetsBlockTypeCompletionProvider } from './completions/providers/PresetsBlockTypeCompletionProvider';
 import { SchemaTranslationsCompletionProvider } from './completions/providers/SchemaTranslationCompletionProvider';
 import { JSONHoverProvider } from './hover/JSONHoverProvider';
 import { SchemaTranslationHoverProvider } from './hover/providers/SchemaTranslationHoverProvider';
@@ -22,7 +26,11 @@ import { findSchemaNode } from './utils';
 /** The getInfoContribution API will only fallback if we return undefined synchronously */
 const SKIP_CONTRIBUTION = undefined as any;
 
-export { GetThemeBlockNames };
+export type GetThemeBlockSchema = (
+  uri: string,
+  name: string,
+) => Promise<SectionSchema | ThemeBlockSchema | AppBlockSchema | undefined>;
+export type GetThemeBlockNames = (uri: string) => Promise<string[]>;
 
 /**
  * I'm not a fan of how json-languageservice does its feature contributions. It's too different
@@ -39,6 +47,7 @@ export class JSONContributions implements JSONWorkerContribution {
     private documentManager: DocumentManager,
     getDefaultSchemaTranslations: GetTranslationsForURI,
     getThemeBlockNames: GetThemeBlockNames,
+    getThemeBlockSchema: GetThemeBlockSchema,
   ) {
     this.hoverProviders = [
       new TranslationPathHoverProvider(),
@@ -47,6 +56,7 @@ export class JSONContributions implements JSONWorkerContribution {
     this.completionProviders = [
       new SchemaTranslationsCompletionProvider(getDefaultSchemaTranslations),
       new BlockTypeCompletionProvider(getThemeBlockNames),
+      new PresetsBlockTypeCompletionProvider(getThemeBlockNames, getThemeBlockSchema),
     ];
   }
 

--- a/packages/theme-language-server-common/src/json/JSONLanguageService.spec.ts
+++ b/packages/theme-language-server-common/src/json/JSONLanguageService.spec.ts
@@ -119,6 +119,7 @@ describe('Module: JSONLanguageService', () => {
       () => Promise.resolve(schemaTranslations),
       (uri: string) => Promise.resolve(uri.includes('tae') ? 'app' : 'theme'),
       () => Promise.resolve([]),
+      async () => undefined,
     );
 
     await jsonLanguageService.setup({

--- a/packages/theme-language-server-common/src/json/JSONLanguageService.ts
+++ b/packages/theme-language-server-common/src/json/JSONLanguageService.ts
@@ -21,7 +21,7 @@ import {
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DocumentManager } from '../documents';
 import { GetTranslationsForURI } from '../translations';
-import { JSONContributions, GetThemeBlockNames } from './JSONContributions';
+import { JSONContributions, GetThemeBlockNames, GetThemeBlockSchema } from './JSONContributions';
 
 export class JSONLanguageService {
   // We index by Mode here because I don't want to reconfigure the service depending on the URI.
@@ -40,6 +40,7 @@ export class JSONLanguageService {
     private getDefaultSchemaTranslations: GetTranslationsForURI,
     private getModeForURI: (uri: string) => Promise<Mode>,
     private getThemeBlockNames: GetThemeBlockNames,
+    private getThemeBlockSchema: GetThemeBlockSchema,
   ) {
     this.services = Object.fromEntries(Modes.map((mode) => [mode, null])) as typeof this.services;
     this.schemas = {};
@@ -76,6 +77,7 @@ export class JSONLanguageService {
               this.documentManager,
               this.getDefaultSchemaTranslations,
               this.getThemeBlockNames,
+              this.getThemeBlockSchema,
             ),
           ],
         });

--- a/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.spec.ts
@@ -63,6 +63,7 @@ describe('Unit: BlockTypeCompletionProvider', () => {
       async () => ({}),
       async () => 'theme',
       async () => blockNames,
+      async () => undefined,
     );
 
     await jsonLanguageService.setup({

--- a/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.ts
@@ -12,8 +12,7 @@ import { CompletionItemKind } from 'vscode-languageserver-protocol';
 import { isLiquidRequestContext, RequestContext } from '../../RequestContext';
 import { fileMatch } from '../../utils';
 import { JSONCompletionProvider } from '../JSONCompletionProvider';
-
-export type GetThemeBlockNames = (uri: string) => Promise<string[]>;
+import { GetThemeBlockNames } from '../../JSONContributions';
 
 /**
  * The BlockTypeCompletionProvider offers value completions of the
@@ -54,12 +53,16 @@ export class BlockTypeCompletionProvider implements JSONCompletionProvider {
 
     const blockNames = await this.getThemeBlockNames(doc.uri);
 
-    return blockNames.map((name) => ({
-      kind: CompletionItemKind.Value,
-      label: `"${name}"`,
-      insertText: `"${name}"`,
-    }));
+    return createBlockNameCompletionItems(blockNames);
   }
+}
+
+export function createBlockNameCompletionItems(blockNames: string[]) {
+  return blockNames.map((name) => ({
+    kind: CompletionItemKind.Value,
+    label: `"${name}"`,
+    insertText: `"${name}"`,
+  }));
 }
 
 export function isBlockDefinitionPath(path: JSONPath) {

--- a/packages/theme-language-server-common/src/json/completions/providers/PresetsBlockTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/PresetsBlockTypeCompletionProvider.spec.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, assert, beforeEach } from 'vitest';
+import { JSONLanguageService } from '../../JSONLanguageService';
+import { DocumentManager } from '../../../documents';
+import { getRequestParams, isCompletionList } from '../../test/test-helpers';
+import { SourceCodeType, ThemeBlock } from '@shopify/theme-check-common';
+
+describe('Unit: PresetsBlockTypeCompletionProvider', () => {
+  const rootUri = 'file:///root/';
+  let jsonLanguageService: JSONLanguageService;
+  let documentManager: DocumentManager;
+
+  beforeEach(async () => {
+    documentManager = new DocumentManager(
+      undefined, // don't need a fs
+      undefined, // don't need a connection
+      undefined, // don't need client capabilities
+      async () => 'theme', // 'theme' mode
+      async () => false, // schema is invalid for tests
+    );
+    jsonLanguageService = new JSONLanguageService(
+      documentManager,
+      {
+        schemas: async () => [
+          {
+            uri: 'https://shopify.dev/block-schema.json',
+            schema: JSON.stringify({
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            }),
+            fileMatch: ['**/{blocks,sections}/*.liquid'],
+          },
+        ],
+      },
+      async () => ({}),
+      async () => 'theme',
+      async () => ['block-1', 'block-2', 'custom-block'],
+      async (_uri: string, name: string) => {
+        const blockUri = `${rootUri}/blocks/${name}.liquid`;
+        const doc = documentManager.get(blockUri);
+        if (!doc || doc.type !== SourceCodeType.LiquidHtml) {
+          return;
+        }
+        return doc.getSchema();
+      },
+    );
+
+    await jsonLanguageService.setup({
+      textDocument: {
+        completion: {
+          contextSupport: true,
+          completionItem: {
+            snippetSupport: true,
+            commitCharactersSupport: true,
+            documentationFormat: ['markdown'],
+            deprecatedSupport: true,
+            preselectSupport: true,
+          },
+        },
+      },
+    });
+  });
+
+  const tests = [
+    {
+      description: 'select blocks',
+      configured: [{ type: 'block-1' }],
+      expected: [`"block-1"`],
+    },
+    {
+      description: '@theme block',
+      configured: [{ type: '@theme' }],
+      expected: [`"block-1"`, `"block-2"`, `"custom-block"`],
+    },
+    {
+      description: '@app block',
+      configured: [{ type: '@app' }],
+      expected: [],
+    },
+    {
+      description: 'no blocks',
+      configured: [],
+      expected: [],
+    },
+  ];
+
+  describe('top-level preset blocks', () => {
+    for (const test of tests) {
+      it(`completes preset block type when allowed ${test.description}`, async () => {
+        const source = `
+          {% schema %}
+          {
+            "blocks": ${JSON.stringify(test.configured)},
+            "presets": [{
+              "blocks": [
+                { "type": "█" },
+              ]
+            }]
+          }
+          {% endschema %}
+        `;
+
+        const params = getRequestParams(documentManager, 'sections/section.liquid', source);
+        const completions = await jsonLanguageService.completions(params);
+
+        assert(isCompletionList(completions));
+        expect(completions.items).to.have.lengthOf(test.expected.length);
+        expect(completions.items.map((item) => item.label)).to.include.members(test.expected);
+      });
+    }
+  });
+
+  describe('nested preset blocks', () => {
+    for (const test of tests) {
+      it(`completes preset block type when parent block allows ${test.description}`, async () => {
+        const source = `
+          {% schema %}
+          {
+            "blocks": [{"type": "custom-block"}],
+            "presets": [{
+              "blocks": [
+                {
+                  "type": "custom-block",
+                  "blocks": [{"type": "█"}],
+                },
+              ]
+            }]
+          }
+          {% endschema %}
+        `;
+
+        documentManager.open(
+          `${rootUri}/blocks/custom-block.liquid`,
+          `{% schema %}
+            {
+              "blocks": ${JSON.stringify(test.configured)}
+            }
+          {% endschema %}`,
+          1,
+        );
+
+        const params = getRequestParams(documentManager, 'sections/section.liquid', source);
+        const completions = await jsonLanguageService.completions(params);
+
+        assert(isCompletionList(completions));
+        expect(completions.items).to.have.lengthOf(test.expected.length);
+        expect(completions.items.map((item) => item.label)).to.include.members(test.expected);
+      });
+    }
+  });
+
+  describe('invalid schema', () => {
+    it('does not complete when schema is invalid', async () => {
+      const source = `
+        {% schema %}
+        typo
+        {
+          "blocks": [{"type": "@theme"}],
+          "presets": [{
+            "blocks": [
+              { "type": "█" },
+            ]
+          }]
+        }
+        {% endschema %}
+      `;
+
+      const params = getRequestParams(documentManager, 'sections/section.liquid', source);
+      const completions = await jsonLanguageService.completions(params);
+
+      assert(isCompletionList(completions));
+      expect(completions.items).to.have.lengthOf(0);
+    });
+
+    it('does not complete when parent block schema is invalid', async () => {
+      const source = `
+        {% schema %}
+        {
+          "blocks": [{"type": "custom-block"}],
+          "presets": [{
+            "blocks": [
+              {
+                "type": "custom-block",
+                "blocks": [{"type": "█"}],
+              },
+            ]
+          }]
+        }
+        {% endschema %}
+      `;
+
+      documentManager.open(
+        `${rootUri}/blocks/custom-block.liquid`,
+        `{% schema %}
+          typo
+          {
+            "blocks": [{"type": "@theme"}]
+          }
+        {% endschema %}`,
+        1,
+      );
+
+      const params = getRequestParams(documentManager, 'sections/section.liquid', source);
+      const completions = await jsonLanguageService.completions(params);
+
+      assert(isCompletionList(completions));
+      expect(completions.items).to.have.lengthOf(0);
+    });
+  });
+});

--- a/packages/theme-language-server-common/src/json/completions/providers/PresetsBlockTypeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/PresetsBlockTypeCompletionProvider.ts
@@ -1,0 +1,122 @@
+import {
+  AppBlockSchema,
+  deepGet,
+  isError,
+  SectionSchema,
+  ThemeBlockSchema,
+  ThemeSchemaType,
+} from '@shopify/theme-check-common';
+import { JSONPath } from 'vscode-json-languageservice';
+import { JSONCompletionItem } from 'vscode-json-languageservice/lib/umd/jsonContributions';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
+import { isLiquidRequestContext, RequestContext } from '../../RequestContext';
+import { fileMatch } from '../../utils';
+import { JSONCompletionProvider } from '../JSONCompletionProvider';
+import {
+  createBlockNameCompletionItems,
+  isSectionOrBlockSchema,
+} from './BlockTypeCompletionProvider';
+import { GetThemeBlockNames, GetThemeBlockSchema } from '../../JSONContributions';
+
+/**
+ * The PresetsBlockTypeCompletionProvider offers value completions of the
+ * `presets.[](recursive .blocks.[].type)` keys inside section and theme block `{% schema %}` tags.
+ *
+ * @example
+ * {% schema %}
+ * {
+ *   "presets": [
+ *     {
+ *       "blocks": [
+ *         { "type": "█" },
+ *       ]
+ *     },
+ *   ]
+ * }
+ * {% endschema %}
+ */
+export class PresetsBlockTypeCompletionProvider implements JSONCompletionProvider {
+  private uriPatterns = [/^.*\/(sections|blocks)\/[^\/]*\.liquid$/];
+
+  constructor(
+    private getThemeBlockNames: GetThemeBlockNames,
+    private getThemeBlockSchema: GetThemeBlockSchema,
+  ) {}
+
+  async completeValue(context: RequestContext, path: JSONPath): Promise<JSONCompletionItem[]> {
+    if (
+      !fileMatch(context.doc.uri, this.uriPatterns) ||
+      !isLiquidRequestContext(context) ||
+      !isPresetBlockPath(path)
+    ) {
+      return [];
+    }
+
+    const { doc } = context;
+    const schema = await doc.getSchema();
+
+    if (!schema || isError(schema.parsed) || !isSectionOrBlockSchema(schema)) {
+      return [];
+    }
+
+    let parsedBlockSchema = schema.parsed;
+
+    if (isNestedBlockPath(path)) {
+      const parentBlockName = getParentBlockName(schema.parsed, path);
+      if (!parentBlockName) {
+        return [];
+      }
+
+      const parentBlockSchema = await this.getThemeBlockSchema(doc.uri, parentBlockName);
+
+      if (
+        !parentBlockSchema ||
+        isError(parentBlockSchema.parsed) ||
+        !isSectionOrBlockSchema(parentBlockSchema)
+      ) {
+        return [];
+      }
+
+      parsedBlockSchema = parentBlockSchema.parsed;
+    }
+
+    const blocks: { type: string }[] = parsedBlockSchema.blocks;
+
+    const blockGroups = {
+      themeBlocks: false,
+      selectBlockNames: [] as string[],
+    };
+
+    blocks.reduce((acc, block) => {
+      if (block.type === '@theme') {
+        acc.themeBlocks = true;
+      } else if (!block.type.startsWith('@')) {
+        acc.selectBlockNames.push(block.type);
+      }
+
+      return acc;
+    }, blockGroups);
+
+    let blockNames = blockGroups.selectBlockNames;
+
+    if (blockGroups.themeBlocks) {
+      blockNames = await this.getThemeBlockNames(doc.uri);
+    }
+
+    return createBlockNameCompletionItems(blockNames);
+  }
+}
+
+// `blocks` can be nested within other `blocks`
+// We need to ensure the last leg of the path is { "blocks": [{ "type": "█" }] }
+function isPresetBlockPath(path: JSONPath) {
+  return path.at(0) === 'presets' && path.at(-3) === 'blocks' && path.at(-1) === 'type';
+}
+
+function isNestedBlockPath(path: JSONPath) {
+  return path.at(-5) === 'blocks' && path.at(-3) === 'blocks' && path.at(-1) === 'type';
+}
+
+function getParentBlockName(parsedSchema: any, path: JSONPath) {
+  return deepGet(parsedSchema, [...path.slice(0, -3), 'type']);
+}

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -11,6 +11,7 @@ import {
   parseJSON,
   path,
   recursiveReadDirectory,
+  SourceCodeType,
 } from '@shopify/theme-check-common';
 import {
   Connection,
@@ -203,6 +204,16 @@ export function startServer(
     return blocks.map(([uri]) => path.basename(uri, '.liquid'));
   }
 
+  async function getThemeBlockSchema(uri: string, name: string) {
+    const rootUri = await findThemeRootURI(uri);
+    const blockUri = path.join(rootUri, 'blocks', `${name}.liquid`);
+    const doc = documentManager.get(blockUri);
+    if (!doc || doc.type !== SourceCodeType.LiquidHtml) {
+      return;
+    }
+    return doc.getSchema();
+  }
+
   // Defined as a function to solve a circular dependency (doc manager & json
   // lang service both need each other)
   async function isValidSchema(uri: string, jsonString: string) {
@@ -215,6 +226,7 @@ export function startServer(
     getSchemaTranslationsForURI,
     getModeForURI,
     getThemeBlockNames,
+    getThemeBlockSchema,
   );
   const completionsProvider = new CompletionsProvider({
     documentManager,


### PR DESCRIPTION
## What are you adding in this PR?

Fixes https://github.com/Shopify/theme-tools/issues/628

Add support for completion of `presets` block type.
- Look at the `blocks` section (whether it be locally-defined blocks or block references) to auto-complete block types in the preset area
- Preset blocks can be nested, so we need to fetch block files and read its schema to determine what to auto-complete

Testing
- Checkout Shopify/dawn
- Find a section where it has section blocks defined under `schema`
- In preset, add a `blocks` and see if `type` gets auto-completed by whatever is in `blocks` section

(see all edge cases in the ticket)

## What's next? Any followup issues?

https://github.com/Shopify/theme-tools/issues/624

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
