### PR TITLE
Theme Tools Release: 10-12-24

### DIFF
--- a/.changeset/big-bananas-shout.md
+++ b/.changeset/big-bananas-shout.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-check-common': patch
----
-
-Import fix for PropertyNode in JSONMissingBlock.

--- a/.changeset/mighty-planets-dream.md
+++ b/.changeset/mighty-planets-dream.md
@@ -1,6 +1,0 @@
----
-'@shopify/theme-check-common': minor
-'@shopify/theme-check-node': minor
----
-
-Add `JsonMissingBlock` check

--- a/.changeset/silly-parrots-behave.md
+++ b/.changeset/silly-parrots-behave.md
@@ -1,7 +1,0 @@
----
-'@shopify/theme-check-common': minor
-'@shopify/theme-check-node': minor
-'theme-check-vscode': minor
----
-
-Add `SchemaPresetsStaticBlocks` check

--- a/.changeset/witty-chairs-kneel.md
+++ b/.changeset/witty-chairs-kneel.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme-check-common': minor
----
-
-[Internal] Add JSONC support to the AST parser

--- a/packages/theme-check-browser/CHANGELOG.md
+++ b/packages/theme-check-browser/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @shopify/theme-check-browser
 
+## 3.5.0
+
+### Patch Changes
+
+- Updated dependencies [8e909870]
+- Updated dependencies [d7436b4a]
+- Updated dependencies [6f1862c8]
+- Updated dependencies [d01e657b]
+  - @shopify/theme-check-common@3.5.0
+
 ## 3.4.0
 
 ### Patch Changes

--- a/packages/theme-check-browser/package.json
+++ b/packages/theme-check-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-browser",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -26,6 +26,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "3.4.0"
+    "@shopify/theme-check-common": "3.5.0"
   }
 }

--- a/packages/theme-check-common/CHANGELOG.md
+++ b/packages/theme-check-common/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @shopify/theme-check-common
 
+## 3.5.0
+
+### Minor Changes
+
+- d7436b4a: Add `JsonMissingBlock` check
+- 6f1862c8: Add `SchemaPresetsStaticBlocks` check
+- d01e657b: [Internal] Add JSONC support to the AST parser
+
+### Patch Changes
+
+- 8e909870: Import fix for PropertyNode in JSONMissingBlock.
+
 ## 3.4.0
 
 ### Minor Changes

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-common",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/theme-check-docs-updater/CHANGELOG.md
+++ b/packages/theme-check-docs-updater/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @shopify/theme-check-docs-updater
 
+## 3.5.0
+
+### Patch Changes
+
+- Updated dependencies [8e909870]
+- Updated dependencies [d7436b4a]
+- Updated dependencies [6f1862c8]
+- Updated dependencies [d01e657b]
+  - @shopify/theme-check-common@3.5.0
+
 ## 3.4.0
 
 ### Patch Changes

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-docs-updater",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Scripts to initialize theme-check data with assets from the theme-liquid-docs repo.",
   "main": "dist/index.js",
   "author": "Albert Chu <albert.chu@shopify.com>",
@@ -30,7 +30,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "^3.4.0",
+    "@shopify/theme-check-common": "^3.5.0",
     "env-paths": "^2.2.1",
     "node-fetch": "^2.6.11"
   },

--- a/packages/theme-check-node/CHANGELOG.md
+++ b/packages/theme-check-node/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @shopify/theme-check-node
 
+## 3.5.0
+
+### Minor Changes
+
+- d7436b4a: Add `JsonMissingBlock` check
+- 6f1862c8: Add `SchemaPresetsStaticBlocks` check
+
+### Patch Changes
+
+- Updated dependencies [8e909870]
+- Updated dependencies [d7436b4a]
+- Updated dependencies [6f1862c8]
+- Updated dependencies [d01e657b]
+  - @shopify/theme-check-common@3.5.0
+  - @shopify/theme-check-docs-updater@3.5.0
+
 ## 3.4.0
 
 ### Patch Changes

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-node",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -33,8 +33,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-check-common": "3.4.0",
-    "@shopify/theme-check-docs-updater": "3.4.0",
+    "@shopify/theme-check-common": "3.5.0",
+    "@shopify/theme-check-docs-updater": "3.5.0",
     "glob": "^8.0.3",
     "vscode-uri": "^3.0.7",
     "yaml": "^2.3.0"

--- a/packages/theme-language-server-browser/CHANGELOG.md
+++ b/packages/theme-language-server-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @shopify/theme-language-server-browser
 
+## 2.3.3
+
+### Patch Changes
+
+- @shopify/theme-language-server-common@2.3.3
+
 ## 2.3.2
 
 ### Patch Changes

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-browser",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,7 +27,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "2.3.2",
+    "@shopify/theme-language-server-common": "2.3.3",
     "vscode-languageserver": "^8.0.2"
   }
 }

--- a/packages/theme-language-server-common/CHANGELOG.md
+++ b/packages/theme-language-server-common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @shopify/theme-language-server-common
 
+## 2.3.3
+
+### Patch Changes
+
+- Updated dependencies [8e909870]
+- Updated dependencies [d7436b4a]
+- Updated dependencies [6f1862c8]
+- Updated dependencies [d01e657b]
+  - @shopify/theme-check-common@3.5.0
+
 ## 2.3.2
 
 ### Patch Changes

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-common",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.2.0",
-    "@shopify/theme-check-common": "3.4.0",
+    "@shopify/theme-check-common": "3.5.0",
     "@vscode/web-custom-data": "^0.4.6",
     "vscode-json-languageservice": "^5.3.10",
     "vscode-languageserver": "^8.0.2",

--- a/packages/theme-language-server-node/CHANGELOG.md
+++ b/packages/theme-language-server-node/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @shopify/theme-language-server-node
 
+## 2.3.3
+
+### Patch Changes
+
+- Updated dependencies [d7436b4a]
+- Updated dependencies [6f1862c8]
+  - @shopify/theme-check-node@3.5.0
+  - @shopify/theme-language-server-common@2.3.3
+  - @shopify/theme-check-docs-updater@3.5.0
+
 ## 2.3.2
 
 ### Patch Changes

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-language-server-node",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "CP Clermont <cp.clermont@shopify.com>",
@@ -27,9 +27,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/theme-language-server-common": "2.3.2",
-    "@shopify/theme-check-node": "^3.4.0",
-    "@shopify/theme-check-docs-updater": "^3.4.0",
+    "@shopify/theme-language-server-common": "2.3.3",
+    "@shopify/theme-check-node": "^3.5.0",
+    "@shopify/theme-check-docs-updater": "^3.5.0",
     "glob": "^8.0.3",
     "node-fetch": "^2.6.11",
     "vscode-languageserver": "^8.0.2",

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Minor Changes
 
 - 6f1862c8: Add `SchemaPresetsStaticBlocks` check
+- d7436b4a: Add `JsonMissingBlock` check
 
 ### Patch Changes
 

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## theme-check-vscode
 
+## 3.4.0
+
+### Minor Changes
+
+- 6f1862c8: Add `SchemaPresetsStaticBlocks` check
+
+### Patch Changes
+
+- Updated dependencies [8e909870]
+- Updated dependencies [d7436b4a]
+- Updated dependencies [6f1862c8]
+- Updated dependencies [d01e657b]
+  - @shopify/theme-check-common@3.5.0
+  - @shopify/theme-language-server-browser@2.3.3
+  - @shopify/theme-language-server-node@2.3.3
+
 ## 3.3.2
 
 ### Patch Changes

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/shopify/theme-tools/issues"
   },
-  "version": "3.3.2",
+  "version": "3.4.0",
   "publisher": "Shopify",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
@@ -61,15 +61,15 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.2.0",
     "@shopify/prettier-plugin-liquid": "^1.6.3",
-    "@shopify/theme-language-server-browser": "^2.3.2",
-    "@shopify/theme-language-server-node": "^2.3.2",
-    "@shopify/theme-check-common": "^3.4.0",
+    "@shopify/theme-language-server-browser": "^2.3.3",
+    "@shopify/theme-language-server-node": "^2.3.3",
+    "@shopify/theme-check-common": "^3.5.0",
     "prettier": "^2.6.2",
     "vscode-languageclient": "^8.1.0",
     "vscode-uri": "^3.0.8"
   },
   "devDependencies": {
-    "@shopify/theme-check-docs-updater": "^3.4.0",
+    "@shopify/theme-check-docs-updater": "^3.5.0",
     "@types/glob": "^8.0.0",
     "@types/node": "16.x",
     "@types/prettier": "^2.4.2",


### PR DESCRIPTION
# Releases
## `@shopify/theme-check-common`
Minor incremented `3.4.0` -> `3.5.0`
### Changes:
- Import fix for PropertyNode in JSONMissingBlock.
- Add `JsonMissingBlock` check
- Add `SchemaPresetsStaticBlocks` check
- [Internal] Add JSONC support to the AST parser

## `@shopify/theme-check-node`
Minor incremented `3.4.0` -> `3.5.0`
### Changes:
- Add `JsonMissingBlock` check
- Add `SchemaPresetsStaticBlocks` check

## `theme-check-vscode`
Minor incremented `3.3.2` -> `3.4.0`
### Changes:
- Add `SchemaPresetsStaticBlocks` check

## `@shopify/theme-check-browser`
Minor incremented `3.4.0` -> `3.5.0`

## `@shopify/theme-language-server-common`
Patch incremented `2.3.2` -> `2.3.3`

## `@shopify/theme-language-server-browser`
Patch incremented `2.3.2` -> `2.3.3`

## `@shopify/theme-language-server-node`
Patch incremented `2.3.2` -> `2.3.3`

## `@shopify/theme-check-docs-updater`
Minor incremented `3.4.0` -> `3.5.0`

