### PR TITLE
Add parsing + prettier support for param name and description in doc tags

### DIFF
--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -395,8 +395,9 @@ LiquidDoc <: Helpers {
     | fallbackNode
 
   fallbackNode = "@" anyExceptStar<newline>
-  paramNode = "@param" space* paramNodeName
-  paramNodeName = anyExceptStar<newline>
+  paramNode = "@param" space* (paramName)? (space+ (paramDescription))?
+  paramName = identifierCharacter+
+  paramDescription = (~newline identifierCharacter | space)+
 }
 
 LiquidHTML <: Liquid {

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -107,10 +107,13 @@ export interface ConcreteBasicNode<T> {
   locEnd: number;
 }
 
+// todo: change param and description to concrete nodes
 export interface ConcreteLiquidDocParamNode
   extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocParamNode> {
   name: string;
   value: string;
+  paramName: ConcreteTextNode;
+  paramDescription: ConcreteTextNode;
 }
 
 export interface ConcreteHtmlNodeBase<T> extends ConcreteBasicNode<T> {
@@ -1329,15 +1332,35 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
     paramNode: {
       type: ConcreteNodeTypes.LiquidDocParamNode,
       name: 0,
-      value: 2,
+      value: 0,
       locStart,
       locEnd,
       source,
+      paramName: function (nodes: Node[]) {
+        const nameNode = nodes[2];
+        return {
+          type: ConcreteNodeTypes.TextNode,
+          value: nameNode.sourceString.trim(),
+          source,
+          locStart: offset + nameNode.source.startIdx,
+          locEnd: offset + nameNode.source.endIdx,
+        };
+      },
+      paramDescription: function (nodes: Node[]) {
+        const descriptionNode = nodes[4];
+        return {
+          type: ConcreteNodeTypes.TextNode,
+          value: descriptionNode.sourceString.trim(),
+          source,
+          locStart: offset + descriptionNode.source.startIdx,
+          locEnd: offset + descriptionNode.source.endIdx,
+        };
+      },
     },
     fallbackNode: {
       type: ConcreteNodeTypes.TextNode,
       value: function () {
-        return (this as any).sourceString;
+        return (this as any).sourceString.trim();
       },
       locStart,
       locEnd,

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1232,6 +1232,7 @@ describe('Unit: Stage 2 (AST)', () => {
       ast = toLiquidAST(`
         {% doc -%}
         @param asdf
+        @param paramWithDescription param with description
         @unsupported this node falls back to a text node
         {%- enddoc %}
       `);
@@ -1239,9 +1240,22 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.name').to.eql('doc');
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocParamNode');
       expectPath(ast, 'children.0.body.nodes.0.name').to.eql('@param');
+      expectPath(ast, 'children.0.body.nodes.0.paramName.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.0.paramName.value').to.eql('asdf');
+      expectPath(ast, 'children.0.body.nodes.0.paramDescription.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.0.paramDescription.value').to.eql('');
 
-      expectPath(ast, 'children.0.body.nodes.1.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.1.value').to.eql(
+      expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocParamNode');
+      expectPath(ast, 'children.0.body.nodes.1.name').to.eql('@param');
+      expectPath(ast, 'children.0.body.nodes.1.paramName.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.1.paramName.value').to.eql('paramWithDescription');
+      expectPath(ast, 'children.0.body.nodes.1.paramDescription.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.1.paramDescription.value').to.eql(
+        'param with description',
+      );
+
+      expectPath(ast, 'children.0.body.nodes.2.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.2.value').to.eql(
         '@unsupported this node falls back to a text node',
       );
     });

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -758,6 +758,8 @@ export interface TextNode extends ASTNode<NodeTypes.TextNode> {
 export interface LiquidDocParamNode extends ASTNode<NodeTypes.LiquidDocParamNode> {
   name: string;
   value: string;
+  paramDescription: TextNode;
+  paramName: TextNode;
 }
 
 export interface ASTNode<T> {
@@ -1281,6 +1283,18 @@ function buildAst(
           position: position(node),
           source: node.source,
           value: node.value,
+          paramName: {
+            type: NodeTypes.TextNode,
+            value: node.paramName.value,
+            position: position(node.paramName),
+            source: node.paramName.source,
+          },
+          paramDescription: {
+            type: NodeTypes.TextNode,
+            value: node.paramDescription.value,
+            position: position(node.paramDescription),
+            source: node.paramDescription.source,
+          },
         });
         break;
       }

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -1,4 +1,10 @@
-import { NodeTypes, NamedTags, isBranchedTag, RawMarkup } from '@shopify/liquid-html-parser';
+import {
+  NodeTypes,
+  NamedTags,
+  isBranchedTag,
+  RawMarkup,
+  LiquidDocParamNode,
+} from '@shopify/liquid-html-parser';
 import { Doc, doc } from 'prettier';
 
 import {
@@ -497,7 +503,22 @@ export function printLiquidDoc(
   _args: LiquidPrinterArgs,
 ) {
   const body = path.map((p: any) => print(p), 'nodes');
-  return [indent([hardline, body]), hardline];
+  return [indent([hardline, join(hardline, body)]), hardline];
+}
+
+export function printLiquidDocParam(
+  path: AstPath<LiquidDocParamNode>,
+  _options: LiquidParserOptions,
+  _print: LiquidPrinter,
+  _args: LiquidPrinterArgs,
+): Doc {
+  const node = path.getValue();
+  return [
+    node.name,
+    ' ',
+    node.paramName.value,
+    node.paramDescription.value ? ' ' + node.paramDescription.value : '',
+  ];
 }
 
 function innerLeadingWhitespace(node: LiquidTag | LiquidBranch) {

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -46,6 +46,7 @@ import {
   printLiquidRawTag,
   printLiquidTag,
   printLiquidVariableOutput,
+  printLiquidDocParam,
 } from './print/liquid';
 import { printClosingTagSuffix, printOpeningTagPrefix } from './print/tag';
 import { bodyLines, hasLineBreakInRange, isEmpty, isTextLikeNode, reindent } from './utils';
@@ -555,7 +556,7 @@ function printNode(
     }
 
     case NodeTypes.LiquidDocParamNode: {
-      return [node.name, ' ', node.value];
+      return printLiquidDocParam(path as AstPath<LiquidDocParamNode>, options, print, args);
     }
 
     default: {

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
@@ -1,9 +1,14 @@
 It should indent the body
 {% doc %}
-  @param body
+  @param paramName param with description
 {% enddoc %}
 
 It should not dedent to root
 {% doc %}
-  @param body
+  @param paramName param with description
+{% enddoc %}
+
+It should trim whitespace between nodes
+{% doc %}
+  @param paramName param with description
 {% enddoc %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
@@ -1,9 +1,14 @@
 It should indent the body
 {% doc %}
-@param body
+@param paramName param with description
 {% enddoc %}
 
 It should not dedent to root
 {% doc %}
-    @param body
+@param paramName param with description
+{% enddoc %}
+
+It should trim whitespace between nodes
+{% doc %}
+@param paramName       param with description
 {% enddoc %}


### PR DESCRIPTION
## What are you adding in this PR?

<!-- Describe your changes. Provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Remember to use `fixes` or `solves` keywords to close issues automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

## What's next? Any followup issues?

<!-- Outline follow up tasks with links to issues so they're tracked. -->

## What did you learn?

<!-- Totally optional. But... If you learned something interesting, why not share it? -->

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
