### PR TITLE
Add parsing + prettier support for dash-seperator in liquidDoc Param Descriptions

### DIFF
--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -395,7 +395,7 @@ LiquidDoc <: Helpers {
     | fallbackNode
 
   fallbackNode = "@" anyExceptStar<newline>
-  paramNode = "@param" space* (paramType)? space* (paramName)? paramDescription?
+  paramNode = "@param" space* (paramType)? space* (paramName)? space* "-"? paramDescription?
   paramType = "{" anyExceptStar<"}"> "}"
   paramName = identifierCharacter+
   paramDescription = (~newline identifierCharacter | space)+

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1058,6 +1058,19 @@ describe('Unit: Stage 1 (CST)', () => {
           );
         });
 
+        it('should parse @param with description seperated by a dash', () => {
+          const testStr = `{% doc %}
+            @param dashWithSpace - param with description
+            @param dashWithNoSpace -param with description
+            @param notDashSeparated param with description
+          {% enddoc %}`;
+          cst = toCST(testStr);
+
+          expectPath(cst, '0.children.0.paramDescription.dashSeparated').to.equal(true);
+          expectPath(cst, '0.children.1.paramDescription.dashSeparated').to.equal(true);
+          expectPath(cst, '0.children.2.paramDescription.dashSeparated').to.equal(false);
+        });
+
         it('should parse unsupported doc tags as text nodes', () => {
           const testStr = `{% doc %} @unsupported this tag is not supported {% enddoc %}`;
           cst = toCST(testStr);

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -113,8 +113,14 @@ export interface ConcreteLiquidDocParamNode
   name: string;
   value: string;
   paramName: ConcreteTextNode;
-  paramDescription: ConcreteTextNode;
+  paramDescription: ConcreteLiquidDocParamDescription;
   paramType: ConcreteTextNode;
+}
+
+export interface ConcreteLiquidDocParamDescription
+  extends ConcreteBasicNode<ConcreteNodeTypes.TextNode> {
+  dashSeparated: boolean;
+  value: string;
 }
 
 export interface ConcreteHtmlNodeBase<T> extends ConcreteBasicNode<T> {
@@ -1358,13 +1364,15 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
         };
       },
       paramDescription: function (nodes: Node[]) {
-        const descriptionNode = nodes[5];
+        const dashNode = nodes[6];
+        const descriptionNode = nodes[7];
         return {
           type: ConcreteNodeTypes.TextNode,
           value: descriptionNode.sourceString.trim(),
           source,
           locStart: offset + descriptionNode.source.startIdx,
           locEnd: offset + descriptionNode.source.endIdx,
+          dashSeparated: dashNode.sourceString.trim() === '-',
         };
       },
     },

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1232,7 +1232,7 @@ describe('Unit: Stage 2 (AST)', () => {
       ast = toLiquidAST(`
         {% doc -%}
         @param asdf
-        @param {String} paramWithDescription param with description
+        @param {String} paramWithDescription - param with description
         @unsupported this node falls back to a text node
         {%- enddoc %}
       `);
@@ -1244,18 +1244,18 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.body.nodes.0.paramName.value').to.eql('asdf');
       expectPath(ast, 'children.0.body.nodes.0.paramDescription.type').to.eql('TextNode');
       expectPath(ast, 'children.0.body.nodes.0.paramDescription.value').to.eql('');
-
+      expectPath(ast, 'children.0.body.nodes.0.paramDescription.dashSeparated').to.eql(false);
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocParamNode');
       expectPath(ast, 'children.0.body.nodes.1.name').to.eql('@param');
       expectPath(ast, 'children.0.body.nodes.1.paramName.type').to.eql('TextNode');
       expectPath(ast, 'children.0.body.nodes.1.paramName.value').to.eql('paramWithDescription');
       expectPath(ast, 'children.0.body.nodes.1.paramDescription.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.1.paramDescription.dashSeparated').to.eql(true);
       expectPath(ast, 'children.0.body.nodes.1.paramDescription.value').to.eql(
         'param with description',
       );
       expectPath(ast, 'children.0.body.nodes.1.paramType.type').to.eql('TextNode');
       expectPath(ast, 'children.0.body.nodes.1.paramType.value').to.eql('String');
-
       expectPath(ast, 'children.0.body.nodes.2.type').to.eql('TextNode');
       expectPath(ast, 'children.0.body.nodes.2.value').to.eql(
         '@unsupported this node falls back to a text node',

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -758,9 +758,14 @@ export interface TextNode extends ASTNode<NodeTypes.TextNode> {
 export interface LiquidDocParamNode extends ASTNode<NodeTypes.LiquidDocParamNode> {
   name: string;
   value: string;
-  paramDescription: TextNode;
+  paramDescription: LiquidDocParamDescription;
   paramName: TextNode;
   paramType: TextNode;
+}
+
+export interface LiquidDocParamDescription extends ASTNode<NodeTypes.TextNode> {
+  dashSeparated: boolean;
+  value: string;
 }
 
 export interface ASTNode<T> {
@@ -1295,6 +1300,7 @@ function buildAst(
             value: node.paramDescription.value,
             position: position(node.paramDescription),
             source: node.paramDescription.source,
+            dashSeparated: node.paramDescription.dashSeparated,
           },
           paramType: {
             type: NodeTypes.TextNode,

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -524,7 +524,11 @@ export function printLiquidDocParam(
   }
 
   if (node.paramDescription.value) {
-    parts.push(' ', node.paramDescription.value);
+    if (node.paramDescription.dashSeparated) {
+      parts.push(' - ', node.paramDescription.value);
+    } else {
+      parts.push(' ', node.paramDescription.value);
+    }
   }
 
   return parts;

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
@@ -17,3 +17,8 @@ It should format the param type
 {% doc %}
   @param {string} paramName param with description
 {% enddoc %}
+
+It should format the param description with a dash separator
+{% doc %}
+  @param paramName - param with description
+{% enddoc %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
@@ -10,10 +10,15 @@ It should not dedent to root
 
 It should trim whitespace between nodes
 {% doc %}
-@param paramName       param with description
+@param paramName param with description
 {% enddoc %}
 
 It should format the param type
 {% doc %}
-    @param      { string      }      paramName param with description
+@param { string } paramName param with description
+{% enddoc %}
+
+It should format the param description with a dash separator
+{% doc %}
+@param paramName  -   param with description
 {% enddoc %}


### PR DESCRIPTION
## What are you adding in this PR?

<!-- Describe your changes. Provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Remember to use `fixes` or `solves` keywords to close issues automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

## What's next? Any followup issues?

<!-- Outline follow up tasks with links to issues so they're tracked. -->

## What did you learn?

<!-- Totally optional. But... If you learned something interesting, why not share it? -->

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
