### PR TITLE
Reference to snippet and blocks

### DIFF
--- a/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.ts
+++ b/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.ts
@@ -1,4 +1,4 @@
-import { LiquidHtmlNode, LiquidString, NodeTypes } from '@shopify/liquid-html-parser';
+import { LiquidHtmlNode, LiquidString, NamedTags, NodeTypes } from '@shopify/liquid-html-parser';
 import { SourceCodeType } from '@shopify/theme-check-common';
 import { DocumentLink, Range } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -61,6 +61,20 @@ function documentLinksVisitor(
           Utils.resolvePath(root, 'sections', sectionName.value + '.liquid').toString(),
         );
       }
+
+      // {% content_for 'block', type: 'block_name' %}
+      if (
+        node.name === NamedTags.content_for &&
+        typeof node.markup !== 'string'
+      ) {
+        const typeArg = node.markup.args.find((arg) => arg.name === 'type');
+        if (typeArg && typeArg.value.type === 'String') {
+          return DocumentLink.create(
+            range(textDocument, typeArg.value),
+            Utils.resolvePath(root, 'blocks', typeArg.value.value + '.liquid').toString(),
+          );
+        }
+      }
     },
 
     // {{ 'theme.js' | asset_url }}
@@ -83,8 +97,8 @@ function documentLinksVisitor(
 }
 
 function range(textDocument: TextDocument, node: { position: LiquidHtmlNode['position'] }): Range {
-  const start = textDocument.positionAt(node.position.start);
-  const end = textDocument.positionAt(node.position.end);
+  const start = textDocument.positionAt(node.position.start + 1);
+  const end = textDocument.positionAt(node.position.end - 1);
   return Range.create(start, end);
 }
 

--- a/packages/theme-language-server-common/src/references/BaseReferencesProvider.ts
+++ b/packages/theme-language-server-common/src/references/BaseReferencesProvider.ts
@@ -1,0 +1,13 @@
+import { LiquidHtmlNode } from '@shopify/liquid-html-parser';
+import {
+  Location,
+  ReferenceParams,
+} from 'vscode-languageserver-protocol';
+
+export interface BaseReferencesProvider {
+  references(
+    node: LiquidHtmlNode,
+    ancestors: LiquidHtmlNode[],
+    params: ReferenceParams,
+  ): Promise<Location[] | undefined>;
+}

--- a/packages/theme-language-server-common/src/references/ReferencesProvider.ts
+++ b/packages/theme-language-server-common/src/references/ReferencesProvider.ts
@@ -1,0 +1,50 @@
+import { Location, ReferenceParams } from "vscode-languageserver-protocol";
+import { AugmentedLiquidSourceCode, DocumentManager } from "../documents";
+import { BaseReferencesProvider } from "./BaseReferencesProvider";
+import { findCurrentNode, SourceCodeType } from "@shopify/theme-check-common";
+import { BlockReferencesProvider } from "./providers/BlockReferencesProvider";
+import { SnippetReferencesProvider } from "./providers/SnippetReferencesProvider";
+
+export type GetLiquidFiles = (rootUri: string) => Promise<AugmentedLiquidSourceCode[]>;
+
+export class ReferencesProvider {
+  private providers: BaseReferencesProvider[];
+
+  constructor(
+    private documentManager: DocumentManager,
+    private getLiquidFiles: GetLiquidFiles,
+  ) {
+    this.providers = [
+      new BlockReferencesProvider(this.documentManager, this.getLiquidFiles),
+      new SnippetReferencesProvider(this.documentManager, this.getLiquidFiles),
+    ];
+  }
+
+  async references(params: ReferenceParams): Promise<Location[] | undefined> {
+    try {
+      const document = this.documentManager.get(params.textDocument.uri)
+  
+      if (!document || document.type !== SourceCodeType.LiquidHtml || document.ast instanceof Error) {
+        return;
+      }
+      
+      const [currentNode, ancestors] = findCurrentNode(document.ast, document.textDocument.offsetAt(params.position));
+
+      const promises = this.providers.map((provider) => provider.references(currentNode, ancestors, params));
+
+      const locations = [];
+
+      for(const promise of promises) {
+        const result = await promise;
+        if (result) {
+          locations.push(...result);
+        }
+      }
+
+      return locations;
+    } catch (error) {
+      console.error(error);
+      return;
+    }
+  }
+}

--- a/packages/theme-language-server-common/src/references/providers/BlockReferencesProvider.ts
+++ b/packages/theme-language-server-common/src/references/providers/BlockReferencesProvider.ts
@@ -1,0 +1,62 @@
+import { Location, ReferenceParams } from "vscode-languageserver-protocol";
+import { DocumentManager } from "../../documents";
+import { BaseReferencesProvider } from "../BaseReferencesProvider";
+import { GetLiquidFiles } from "../ReferencesProvider";
+import { LiquidHtmlNode, LiquidTag, NamedTags } from "@shopify/liquid-html-parser";
+import { SourceCodeType, visit } from "@shopify/theme-check-common";
+import { Range } from "vscode-json-languageservice";
+
+export class BlockReferencesProvider implements BaseReferencesProvider {
+  constructor(private documentManager: DocumentManager, private getLiquidFiles: GetLiquidFiles) {}
+
+  async references(currentNode: LiquidHtmlNode, ancestors: LiquidHtmlNode[], params: ReferenceParams): Promise<Location[] | undefined> {
+    const sources = await this.getLiquidFiles(params.textDocument.uri);
+    const document = this.documentManager.get(params.textDocument.uri)
+
+    if (!document || document.type !== SourceCodeType.LiquidHtml || document.ast instanceof Error) {
+      return;
+    }
+
+    const parentNode = ancestors.at(-1);
+    const grandparentNode = ancestors.at(-2);
+    if (!parentNode || !grandparentNode) return;
+    if (
+      currentNode.type !== 'String' ||
+      parentNode.type !== 'NamedArgument' ||
+      grandparentNode.type !== 'ContentForMarkup'
+    ) return;
+
+    const referenceLocations = [] as Location[]
+
+    for (const source of sources) {
+      if (source.ast instanceof Error) continue;
+
+      referenceLocations.push(...visit<SourceCodeType.LiquidHtml, Location>(source.ast, {
+        LiquidTag(node: LiquidTag) {
+          if (node.name === NamedTags.content_for) {
+            if (typeof node.markup === 'string') return;
+
+            const typeArg = node.markup.args.find((arg) => arg.name === 'type');
+
+            if (!typeArg || typeArg.value.type !== 'String') return;
+
+            if (typeArg.value.value === currentNode.value) {
+              return {
+                uri: source.uri,
+                range: Range.create(
+                  source.textDocument.positionAt(typeArg.value.position.start + 1),
+                  source.textDocument.positionAt(typeArg.value.position.end - 1),
+                ),
+              };
+            }
+          }
+        }
+      }));
+    }
+
+    // TODO: check if the block appears in any schema
+    // Need building blocks to know where in the block it appears (i.e. position)
+
+    return referenceLocations;
+  }
+}

--- a/packages/theme-language-server-common/src/references/providers/SnippetReferencesProvider.ts
+++ b/packages/theme-language-server-common/src/references/providers/SnippetReferencesProvider.ts
@@ -1,0 +1,50 @@
+import { Location, ReferenceParams } from "vscode-languageserver-protocol";
+import { DocumentManager } from "../../documents";
+import { BaseReferencesProvider } from "../BaseReferencesProvider";
+import { GetLiquidFiles } from "../ReferencesProvider";
+import { LiquidHtmlNode, LiquidTag, NamedTags, NodeTypes } from "@shopify/liquid-html-parser";
+import { SourceCodeType, visit } from "@shopify/theme-check-common";
+import { Range } from "vscode-json-languageservice";
+
+export class SnippetReferencesProvider implements BaseReferencesProvider {
+  constructor(private documentManager: DocumentManager, private getLiquidFiles: GetLiquidFiles) {}
+
+  async references(currentNode: LiquidHtmlNode, ancestors: LiquidHtmlNode[], params: ReferenceParams): Promise<Location[] | undefined> {
+    const sources = await this.getLiquidFiles(params.textDocument.uri);
+    const document = this.documentManager.get(params.textDocument.uri)
+
+    if (!document || document.type !== SourceCodeType.LiquidHtml || document.ast instanceof Error) {
+      return;
+    }
+
+    const parentNode = ancestors.at(-1);
+    if (!parentNode || parentNode.type !== 'RenderMarkup' || currentNode.type !== 'String') {
+      return;
+    }
+
+    const referenceLocations = [] as Location[];
+
+    for (const source of sources) {
+      if (source.ast instanceof Error) continue;
+
+      referenceLocations.push(...visit<SourceCodeType.LiquidHtml, Location>(source.ast, {
+        LiquidTag(node: LiquidTag) {
+          if ((node.name === NamedTags.render || node.name === NamedTags.include) && typeof node.markup !== 'string') {
+            const snippet = node.markup.snippet;
+            if (snippet.type === NodeTypes.String && snippet.value === currentNode.value) {
+              return {
+                uri: source.uri,
+                range: Range.create(
+                  source.textDocument.positionAt(snippet.position.start + 1),
+                  source.textDocument.positionAt(snippet.position.end - 1),
+                ),
+              };
+            }
+          }
+        },
+      }))
+    }
+
+    return referenceLocations;
+  }
+}


### PR DESCRIPTION
## What are you adding in this PR?

Support references for snippets and blocks
- Can't merge it yet because we are reading _every_ file to check for references; should we preload them? memoize the references?

## What's next? Any followup issues?

- Support references when you select files in explorer
- Support references found in schemas

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
