### PR TITLE
Update grammar to allow variables to be detected inside style tags

### DIFF
--- a/.changeset/soft-moose-smell.md
+++ b/.changeset/soft-moose-smell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+[Bug Fix] Update grammar to allow liquid variables to be detected inside style tags

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -202,7 +202,6 @@ Liquid <: Helpers {
     | liquidRawTagImpl<"javascript">
     | liquidRawTagImpl<"schema">
     | liquidRawTagImpl<"stylesheet">
-    | liquidRawTagImpl<"style">
   liquidRawTagImpl<name> =
     "{%" "-"? space* (name endOfIdentifier) space* tagMarkup "-"? "%}"
     anyExceptStar<liquidRawTagClose<name>>
@@ -297,6 +296,7 @@ Liquid <: Helpers {
   blockName =
     // Shopify blocks
     ( "form"
+    | "style"
     | "paginate"
     // Base blocks
     | "capture"


### PR DESCRIPTION
NOTE: DO NOT MERGE YET
- After some testing, I found out that removing it from the raw tag section will format inside the style tag (changing a lot of files)

## What are you adding in this PR?

Fixes https://github.com/Shopify/theme-tools/issues/465

- Style tag was being treated as a "raw" tag where liquid code isn't parsed inside it
  - Removed style tag from this list

## Tophat

| Before | After |
| - | - |
| <img width="413" alt="image" src="https://github.com/user-attachments/assets/425a52ae-bc3e-485d-ba32-e8590ccae7f2" /> | <img width="413" alt="image" src="https://github.com/user-attachments/assets/bdfb20f9-9f4d-44ea-8d61-c58c1d577e6c" /> |

## Before you deploy

- [x] I included a patch bump `changeset`
