### PR TITLE
Support auto-completion for presets' settings

### DIFF
--- a/.changeset/fifty-pugs-confess.md
+++ b/.changeset/fifty-pugs-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+[Internal] Add schema raw value to schema node

--- a/.changeset/healthy-ads-protect.md
+++ b/.changeset/healthy-ads-protect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Support hover and code completion for presets settings properties

--- a/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
@@ -23,6 +23,7 @@ describe('Module: ValidSchemaName', () => {
         name: 'file',
         type: ThemeSchemaType.Section,
         offset: 0,
+        value: '',
       }),
     });
 

--- a/packages/theme-check-common/src/to-schema.ts
+++ b/packages/theme-check-common/src/to-schema.ts
@@ -81,6 +81,7 @@ export async function toBlockSchema(
   const schemaNode = toSchemaNode(liquidAst);
   const parsed = toParsed(schemaNode);
   const ast = toAst(schemaNode);
+
   return {
     type: ThemeSchemaType.Block,
     validSchema: await toValidSchema<ThemeBlock.Schema>(uri, schemaNode, parsed, isValidSchema),
@@ -88,6 +89,7 @@ export async function toBlockSchema(
     name,
     parsed,
     ast,
+    value: schemaNode instanceof Error ? '' : schemaNode.body.value,
   };
 }
 
@@ -103,6 +105,7 @@ export async function toSectionSchema(
   const schemaNode = toSchemaNode(liquidAst);
   const parsed = toParsed(schemaNode);
   const ast = toAst(schemaNode);
+
   return {
     type: ThemeSchemaType.Section,
     validSchema: await toValidSchema(uri, schemaNode, parsed, isValidSchema),
@@ -110,6 +113,7 @@ export async function toSectionSchema(
     name,
     parsed,
     ast,
+    value: schemaNode instanceof Error ? '' : schemaNode.body.value,
   };
 }
 
@@ -122,12 +126,14 @@ export async function toAppBlockSchema(
   const schemaNode = toSchemaNode(liquidAst);
   const parsed = toParsed(schemaNode);
   const ast = toAst(schemaNode);
+
   return {
     type: ThemeSchemaType.AppBlock,
     offset: schemaNode instanceof Error ? 0 : schemaNode.blockStartPosition.end,
     name,
     parsed,
     ast,
+    value: schemaNode instanceof Error ? '' : schemaNode.body.value,
   };
 }
 

--- a/packages/theme-check-common/src/types/theme-schemas.ts
+++ b/packages/theme-check-common/src/types/theme-schemas.ts
@@ -32,6 +32,9 @@ export interface ThemeSchema<T extends ThemeSchemaType> {
 
   /** 0-based index of the start of JSON object in the document */
   offset: number;
+
+  /** schema node value */
+  value: string;
 }
 
 /** See {@link ThemeSchema} */

--- a/packages/theme-language-server-common/src/json/JSONContributions.ts
+++ b/packages/theme-language-server-common/src/json/JSONContributions.ts
@@ -22,6 +22,8 @@ import { SchemaTranslationHoverProvider } from './hover/providers/SchemaTranslat
 import { TranslationPathHoverProvider } from './hover/providers/TranslationPathHoverProvider';
 import { RequestContext } from './RequestContext';
 import { findSchemaNode } from './utils';
+import { PresetsSettingsPropertyCompletionProvider } from './completions/providers/PresetsSettingsPropertyCompletionProvider';
+import { PresetsSettingsHoverProvider } from './hover/providers/PresetsSettingsHoverProvider';
 
 /** The getInfoContribution API will only fallback if we return undefined synchronously */
 const SKIP_CONTRIBUTION = undefined as any;
@@ -52,11 +54,13 @@ export class JSONContributions implements JSONWorkerContribution {
     this.hoverProviders = [
       new TranslationPathHoverProvider(),
       new SchemaTranslationHoverProvider(getDefaultSchemaTranslations),
+      new PresetsSettingsHoverProvider(getDefaultSchemaTranslations),
     ];
     this.completionProviders = [
       new SchemaTranslationsCompletionProvider(getDefaultSchemaTranslations),
       new BlockTypeCompletionProvider(getThemeBlockNames),
       new PresetsBlockTypeCompletionProvider(getThemeBlockNames, getThemeBlockSchema),
+      new PresetsSettingsPropertyCompletionProvider(getDefaultSchemaTranslations),
     ];
   }
 

--- a/packages/theme-language-server-common/src/json/completions/providers/PresetsBlockTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/PresetsBlockTypeCompletionProvider.spec.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, assert, beforeEach } from 'vitest';
 import { JSONLanguageService } from '../../JSONLanguageService';
 import { DocumentManager } from '../../../documents';
-import { getRequestParams, isCompletionList } from '../../test/test-helpers';
+import {
+  getRequestParams,
+  isCompletionList,
+  mockJSONLanguageService,
+} from '../../test/test-helpers';
 import { SourceCodeType, ThemeBlock } from '@shopify/theme-check-common';
 
 describe('Unit: PresetsBlockTypeCompletionProvider', () => {
@@ -17,31 +21,11 @@ describe('Unit: PresetsBlockTypeCompletionProvider', () => {
       async () => 'theme', // 'theme' mode
       async () => false, // schema is invalid for tests
     );
-    jsonLanguageService = new JSONLanguageService(
-      documentManager,
-      {
-        schemas: async () => [
-          {
-            uri: 'https://shopify.dev/block-schema.json',
-            schema: JSON.stringify({
-              $schema: 'http://json-schema.org/draft-07/schema#',
-            }),
-            fileMatch: ['**/{blocks,sections}/*.liquid'],
-          },
-        ],
-      },
-      async () => ({}),
-      async () => 'theme',
-      async () => ['block-1', 'block-2', 'custom-block'],
-      async (_uri: string, name: string) => {
-        const blockUri = `${rootUri}/blocks/${name}.liquid`;
-        const doc = documentManager.get(blockUri);
-        if (!doc || doc.type !== SourceCodeType.LiquidHtml) {
-          return;
-        }
-        return doc.getSchema();
-      },
-    );
+    jsonLanguageService = mockJSONLanguageService(rootUri, documentManager, undefined, async () => [
+      'block-1',
+      'block-2',
+      'custom-block',
+    ]);
 
     await jsonLanguageService.setup({
       textDocument: {

--- a/packages/theme-language-server-common/src/json/completions/providers/PresetsBlockTypeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/PresetsBlockTypeCompletionProvider.ts
@@ -1,14 +1,6 @@
-import {
-  AppBlockSchema,
-  deepGet,
-  isError,
-  SectionSchema,
-  ThemeBlockSchema,
-  ThemeSchemaType,
-} from '@shopify/theme-check-common';
+import { deepGet, isError } from '@shopify/theme-check-common';
 import { JSONPath } from 'vscode-json-languageservice';
 import { JSONCompletionItem } from 'vscode-json-languageservice/lib/umd/jsonContributions';
-import { CompletionItemKind } from 'vscode-languageserver-protocol';
 import { isLiquidRequestContext, RequestContext } from '../../RequestContext';
 import { fileMatch } from '../../utils';
 import { JSONCompletionProvider } from '../JSONCompletionProvider';

--- a/packages/theme-language-server-common/src/json/completions/providers/PresetsSettingsPropertyCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/PresetsSettingsPropertyCompletionProvider.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, assert, beforeEach } from 'vitest';
+import { JSONLanguageService } from '../../JSONLanguageService';
+import { DocumentManager } from '../../../documents';
+import {
+  getRequestParams,
+  isCompletionList,
+  mockJSONLanguageService,
+} from '../../test/test-helpers';
+
+describe('Unit: PresetsSettingsPropertyCompletionProvider', () => {
+  const rootUri = 'file:///root/';
+  let jsonLanguageService: JSONLanguageService;
+  let documentManager: DocumentManager;
+
+  beforeEach(async () => {
+    documentManager = new DocumentManager(
+      undefined, // don't need a fs
+      undefined, // don't need a connection
+      undefined, // don't need client capabilities
+      async () => 'theme', // 'theme' mode
+      async () => false, // schema is invalid for tests
+    );
+    jsonLanguageService = mockJSONLanguageService(
+      rootUri,
+      documentManager,
+      async (uri: string) => ({
+        general: {
+          fake: 'Fake Setting',
+        },
+      }),
+    );
+
+    await jsonLanguageService.setup({
+      textDocument: {
+        completion: {
+          contextSupport: true,
+          completionItem: {
+            snippetSupport: true,
+            commitCharactersSupport: true,
+            documentationFormat: ['markdown'],
+            deprecatedSupport: true,
+            preselectSupport: true,
+          },
+        },
+      },
+    });
+  });
+
+  describe('valid schema', () => {
+    it('completes preset setting property when settings exist', async () => {
+      const source = `
+        {% schema %}
+        {
+          "settings": [
+            {"id": "custom-setting"},
+            {"id": "fake-setting"},
+            {},
+          ],
+          "presets": [{
+            "settings": {
+              "█": "",
+            }
+          }]
+        }
+        {% endschema %}
+      `;
+      const params = getRequestParams(documentManager, 'blocks/block.liquid', source);
+      const completions = await jsonLanguageService.completions(params);
+
+      assert(isCompletionList(completions));
+      expect(completions.items).to.have.lengthOf(2);
+      expect(completions.items.map((item) => item.label)).to.include.members([
+        `"custom-setting"`,
+        `"fake-setting"`,
+      ]);
+    });
+
+    it('offers no suggestions for preset setting property when there are no settings', async () => {
+      const source = `
+        {% schema %}
+        {
+          "presets": [{
+            "settings": {
+              "█": "",
+            }
+          }]
+        }
+        {% endschema %}
+      `;
+      const params = getRequestParams(documentManager, 'blocks/block.liquid', source);
+      const completions = await jsonLanguageService.completions(params);
+
+      assert(isCompletionList(completions));
+      expect(completions.items).to.have.lengthOf(0);
+      expect(completions.items.map((item) => item.label)).to.include.members([]);
+    });
+
+    it('offers presets setting completion with docs from setting.label', async () => {
+      const source = `
+        {% schema %}
+        {
+          "settings": [
+            {"id": "custom-setting", "label": "Custom Setting"},
+            {"id": "fake-setting", "label": "t:general.fake"},
+          ],
+          "presets": [{
+            "settings": {
+              "█": "",
+            }
+          }]
+        }
+        {% endschema %}
+      `;
+      const params = getRequestParams(documentManager, 'blocks/block.liquid', source);
+      const completions = await jsonLanguageService.completions(params);
+
+      assert(isCompletionList(completions));
+      expect(completions.items).to.have.lengthOf(2);
+      expect(completions.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            documentation: { kind: 'markdown', value: 'Custom Setting' },
+          }),
+          expect.objectContaining({
+            documentation: { kind: 'markdown', value: 'Fake Setting' },
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe('invalid schema', () => {
+    it('completes preset setting property when settings exist and schema has small errors', async () => {
+      const source = `
+        {% schema %}
+        {
+          "settings": [
+            {"id": "custom-setting"},
+            {"id": "fake-setting"},
+            {},
+          ],
+          "presets": [{
+            "settings": {
+              "█"
+            }
+          }]
+        }
+        {% endschema %}
+      `;
+      const params = getRequestParams(documentManager, 'blocks/block.liquid', source);
+      const completions = await jsonLanguageService.completions(params);
+
+      assert(isCompletionList(completions));
+      expect(completions.items).to.have.lengthOf(2);
+      expect(completions.items.map((item) => item.label)).to.include.members([
+        `"custom-setting"`,
+        `"fake-setting"`,
+      ]);
+    });
+  });
+});

--- a/packages/theme-language-server-common/src/json/completions/providers/PresetsSettingsPropertyCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/PresetsSettingsPropertyCompletionProvider.ts
@@ -1,0 +1,108 @@
+import { parse as jsonParse } from 'jsonc-parser';
+import { isError, SourceCodeType } from '@shopify/theme-check-common';
+import { JSONPath } from 'vscode-json-languageservice';
+import { JSONCompletionItem } from 'vscode-json-languageservice/lib/umd/jsonContributions';
+import { RequestContext } from '../../RequestContext';
+import { fileMatch } from '../../utils';
+import { JSONCompletionProvider } from '../JSONCompletionProvider';
+import { isSectionOrBlockSchema } from './BlockTypeCompletionProvider';
+import { CompletionItemKind } from 'vscode-languageserver-protocol';
+import { GetTranslationsForURI, renderTranslation, translationValue } from '../../../translations';
+
+/**
+ * The PresetsSettingsPropertyCompletionProvider offers property completions of the
+ * `presets.[].settings.[]` objects inside section and theme block `{% schema %}` tags.
+ *
+ * @example
+ * {% schema %}
+ * {
+ *   "presets": [
+ *     {
+ *       "settings": [
+ *         { "█" },
+ *       ]
+ *     },
+ *   ]
+ * }
+ * {% endschema %}
+ */
+export class PresetsSettingsPropertyCompletionProvider implements JSONCompletionProvider {
+  private uriPatterns = [/^.*\/(sections|blocks)\/[^\/]*\.liquid$/];
+
+  constructor(public getDefaultSchemaTranslations: GetTranslationsForURI) {}
+
+  async completeProperty(context: RequestContext, path: JSONPath): Promise<JSONCompletionItem[]> {
+    if (
+      !fileMatch(context.doc.uri, this.uriPatterns) ||
+      context.doc.type !== SourceCodeType.LiquidHtml ||
+      !isPresetSettingsPath(path)
+    ) {
+      return [];
+    }
+
+    const { doc } = context;
+    const schema = await doc.getSchema();
+
+    if (!schema || !isSectionOrBlockSchema(schema)) {
+      return [];
+    }
+
+    let parsedSchema: any;
+
+    /**
+     * Since we are auto-completing JSON properties, we could be in a state where the schema is invalid.
+     * E.g.
+     * {
+     *   "█"
+     * }
+     *
+     * In that case, we manually parse the schema ourselves with a more fault-tolerant approach.
+     */
+    if (isError(schema.parsed)) {
+      parsedSchema = jsonParse(schema.value);
+    } else {
+      parsedSchema = schema.parsed;
+    }
+
+    if (!parsedSchema?.settings || !Array.isArray(parsedSchema.settings)) {
+      return [];
+    }
+
+    const translations = await this.getDefaultSchemaTranslations(doc.textDocument.uri);
+
+    return parsedSchema.settings
+      .filter((setting: any) => setting.id)
+      .map((setting: any) => {
+        let docValue = '';
+
+        if (setting.label) {
+          if (setting.label.startsWith('t:')) {
+            const translation = translationValue(setting.label.substring(2), translations);
+            if (translation) {
+              docValue = renderTranslation(translation);
+            }
+          } else {
+            docValue = setting.label;
+          }
+        }
+
+        return {
+          kind: CompletionItemKind.Property,
+          label: `"${setting.id}"`,
+          insertText: `"${setting.id}"`,
+          documentation: {
+            kind: 'markdown',
+            value: docValue,
+          },
+        };
+      });
+  }
+}
+
+function isPresetSettingsPath(path: JSONPath) {
+  return path.at(0) === 'presets' && path.at(1) === 0 && path.at(2) === 'settings';
+}
+
+function isTranslationKey(path: string) {
+  return path.startsWith('t:');
+}

--- a/packages/theme-language-server-common/src/json/hover/providers/PresetsSettingsHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/json/hover/providers/PresetsSettingsHoverProvider.spec.ts
@@ -1,0 +1,119 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { DocumentManager } from '../../../documents';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
+import { JSONHoverProvider } from '../JSONHoverProvider';
+import { PresetsSettingsHoverProvider } from './PresetsSettingsHoverProvider';
+import { JSONLanguageService } from '../../JSONLanguageService';
+import { getRequestParams, mockJSONLanguageService } from '../../test/test-helpers';
+
+describe('Module: PresetsSettingsHoverProvider', async () => {
+  const rootUri = 'file:///root/';
+  let jsonLanguageService: JSONLanguageService;
+  let documentManager: DocumentManager;
+
+  beforeEach(async () => {
+    documentManager = new DocumentManager(
+      undefined, // don't need a fs
+      undefined, // don't need a connection
+      undefined, // don't need client capabilities
+      async () => 'theme', // 'theme' mode
+      async () => false, // schema is invalid for tests
+    );
+    jsonLanguageService = mockJSONLanguageService(
+      rootUri,
+      documentManager,
+      async (uri: string) => ({
+        general: {
+          fake: 'Fake Setting',
+        },
+      }),
+    );
+
+    await jsonLanguageService.setup({
+      textDocument: {
+        hover: {},
+        completion: {
+          contextSupport: true,
+          completionItem: {
+            snippetSupport: true,
+            commitCharactersSupport: true,
+            documentationFormat: ['markdown'],
+            deprecatedSupport: true,
+            preselectSupport: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('provide hover for preset setting when setting label contains a translation key', async () => {
+    const source = `
+      {% schema %}
+      {
+        "settings": [
+          {"id": "custom-setting", "label": "Custom Setting"},
+          {"id": "fake-setting", "label": "t:general.fake"},
+        ],
+        "presets": [{
+          "settings": {
+            "fake-setting█": "",
+          }
+        }]
+      }
+      {% endschema %}
+    `;
+    const params = getRequestParams(documentManager, 'blocks/block.liquid', source);
+    const hover = await jsonLanguageService.hover(params);
+
+    expect(hover).not.toBeNull();
+    expect(hover!.contents).to.have.lengthOf(1);
+    expect(hover!.contents).toEqual(['Fake Setting']);
+  });
+
+  it('provide hover for preset setting when setting label is literal text', async () => {
+    const source = `
+      {% schema %}
+      {
+        "settings": [
+          {"id": "custom-setting", "label": "Custom Setting"},
+          {"id": "fake-setting", "label": "t:general.fake"},
+        ],
+        "presets": [{
+          "settings": {
+            "custom-setting█": "",
+          }
+        }]
+      }
+      {% endschema %}
+    `;
+    const params = getRequestParams(documentManager, 'blocks/block.liquid', source);
+    const hover = await jsonLanguageService.hover(params);
+
+    expect(hover).not.toBeNull();
+    expect(hover!.contents).to.have.lengthOf(1);
+    expect(hover!.contents).toEqual(['Custom Setting']);
+  });
+
+  it('provide no hover for preset setting when setting label does not exist', async () => {
+    const source = `
+      {% schema %}
+      {
+        "settings": [
+          {"id": "custom-setting"},
+          {"id": "fake-setting", "label": "t:general.fake"},
+        ],
+        "presets": [{
+          "settings": {
+            "custom-setting█": "",
+          }
+        }]
+      }
+      {% endschema %}
+    `;
+    const params = getRequestParams(documentManager, 'blocks/block.liquid', source);
+    const hover = await jsonLanguageService.hover(params);
+
+    expect(hover).not.toBeNull();
+    expect(hover!.contents).to.have.lengthOf(0);
+  });
+});

--- a/packages/theme-language-server-common/src/json/hover/providers/PresetsSettingsHoverProvider.ts
+++ b/packages/theme-language-server-common/src/json/hover/providers/PresetsSettingsHoverProvider.ts
@@ -1,0 +1,73 @@
+import { isError } from '@shopify/theme-check-common';
+import { JSONPath, MarkedString } from 'vscode-json-languageservice';
+import { GetTranslationsForURI, renderTranslation, translationValue } from '../../../translations';
+import { isLiquidRequestContext, LiquidRequestContext, RequestContext } from '../../RequestContext';
+import { fileMatch } from '../../utils';
+import { JSONHoverProvider } from '../JSONHoverProvider';
+import { AugmentedLiquidSourceCode } from '../../../documents';
+import { isSectionOrBlockSchema } from '../../completions/providers/BlockTypeCompletionProvider';
+
+export class PresetsSettingsHoverProvider implements JSONHoverProvider {
+  private uriPatterns = [/(sections|blocks)\/[^\/]*\.liquid$/];
+
+  constructor(private getDefaultSchemaTranslations: GetTranslationsForURI) {}
+
+  canHover(context: RequestContext, path: JSONPath): context is LiquidRequestContext {
+    return (
+      fileMatch(context.doc.uri, this.uriPatterns) &&
+      isLiquidRequestContext(context) &&
+      path.length !== 0 &&
+      isPresetSettingsPath(path)
+    );
+  }
+
+  async hover(context: RequestContext, path: JSONPath): Promise<MarkedString[]> {
+    if (!this.canHover(context, path)) return [];
+
+    const { doc } = context;
+    const label = await getSettingsLabel(doc, path.at(3) as string);
+
+    if (!label) return [];
+
+    if (!label.startsWith('t:')) {
+      return [label];
+    }
+
+    return this.getDefaultSchemaTranslations(doc.uri).then((translations) => {
+      const path = label.substring(2);
+      const value = translationValue(path, translations);
+      if (!value) return undefined as any;
+
+      return [renderTranslation(value)];
+    });
+  }
+}
+
+function isPresetSettingsPath(path: JSONPath) {
+  return (
+    path.at(0) === 'presets' &&
+    path.at(1) === 0 &&
+    path.at(2) === 'settings' &&
+    path.at(3) !== undefined &&
+    typeof path.at(3) === 'string'
+  );
+}
+
+async function getSettingsLabel(
+  doc: AugmentedLiquidSourceCode,
+  label: string,
+): Promise<string | undefined> {
+  const schema = await doc.getSchema();
+
+  if (
+    !schema ||
+    !isSectionOrBlockSchema(schema) ||
+    isError(schema.parsed) ||
+    schema.parsed.settings === undefined ||
+    !Array.isArray(schema.parsed.settings)
+  ) {
+    return;
+  }
+
+  return schema.parsed.settings.find((setting: any) => setting.id === label)?.label;
+}


### PR DESCRIPTION
## What are you adding in this PR?

Part of https://github.com/Shopify/theme-tools/issues/625
- Support presets settings auto-completion
- Support presets setting hover

Both features should work when `setting.label` contains a translation key OR literal text

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
