### PR TITLE
New release flow example PR

### DIFF
--- a/.changeset/afraid-donuts-melt.md
+++ b/.changeset/afraid-donuts-melt.md
@@ -1,0 +1,5 @@
+---
+'release-orchestrator': patch
+---
+
+Example bump of something with no dependents

--- a/.changeset/witty-keys-smell.md
+++ b/.changeset/witty-keys-smell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+Example bump of something with LOTS of dependents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - demo/changeset-action-in-action
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -55,10 +56,10 @@ jobs:
         uses: changesets/action@v1
         with:
           # Put date in the title and commit message
-          title: "Theme Tools Release — ${{ steps.date.outputs.date }}"
-          commit: "Theme Rools Release — ${{ steps.date.outputs.date }}"
+          title: "(Demo) Theme Tools Release — ${{ steps.date.outputs.date }}"
+          commit: "(Demo) Theme Rools Release — ${{ steps.date.outputs.date }}"
           # When there are no changesets, this gets called
-          publish: yarn changeset publish
+          publish: echo yarn changeset publish
           # When there are changesets, this gets called and then a PR is opened/updated
           version: yarn release
         env:
@@ -67,4 +68,4 @@ jobs:
 
       - name: VS Code Marketplace publish
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.marketplace-version.outputs.version != steps.package-version.outputs.version
-        run: yarn publish:vsce
+        run: echo yarn publish:vsce


### PR DESCRIPTION
This PR serves as an example "main" for the new changeset/action release flow

What to look at:
- The release workflow run before the release is merged into this branch
  - You should note that nothing is "published"
  - You should note that the Publish to VS Code step is skipped
- The (Demo) release PR
  - You should see all the changelogs and versions being updated
    - Especially the vscode extension being updated in response to the parser being updated
- The release workflow run after the release is merged into this branch
  - After the above PR is merged into here, there are no more changesets to process
    - This is the trigger for `changeset/action` to do a publish
    - You should find the echo'ed `yarn publish` and `yarn vsce publish` in the logs
