### PR TITLE
Make some of the changesets VS Code Changelog public

### DIFF
--- a/.changeset/bright-dancers-explode.md
+++ b/.changeset/bright-dancers-explode.md
@@ -1,5 +1,6 @@
 ---
 '@shopify/theme-language-server-common': minor
+'theme-check-vscode': minor
 ---
 
-Support schema presets block type completion
+In `{% schema %}` tags, add block type completion in presets

--- a/.changeset/healthy-ads-protect.md
+++ b/.changeset/healthy-ads-protect.md
@@ -1,5 +1,6 @@
 ---
 '@shopify/theme-language-server-common': minor
+'theme-check-vscode': minor
 ---
 
-Support hover and code completion for presets settings properties
+In `{% schema %}` tags, add hover and code completion of presets settings ids

--- a/.changeset/plenty-flowers-eat.md
+++ b/.changeset/plenty-flowers-eat.md
@@ -1,6 +1,7 @@
 ---
 '@shopify/theme-language-server-common': minor
 '@shopify/theme-language-server-node': minor
+'theme-check-vscode': minor
 ---
 
 Fetch metafield definitions on start-up using CLI


### PR DESCRIPTION
Some of the changes should appear on the [VS Code Marketplace Changelog](https://marketplace.visualstudio.com/items/Shopify.theme-check-vscode/changelog)