### PR TITLE
Support auto-completion on every preset setting

### DIFF
--- a/.changeset/afraid-singers-guess.md
+++ b/.changeset/afraid-singers-guess.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-language-server-node': patch
+---
+
+[internal] Check workspace folder client capabilities before fetching metafields

--- a/.changeset/plenty-radios-drum.md
+++ b/.changeset/plenty-radios-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+[Bug fix] Support auto-completion on every preset setting

--- a/packages/theme-language-server-common/src/ClientCapabilities.ts
+++ b/packages/theme-language-server-common/src/ClientCapabilities.ts
@@ -23,6 +23,10 @@ export class ClientCapabilities {
     return !!this.capabilities?.workspace?.applyEdit;
   }
 
+  get hasWorkspaceFoldersSupport() {
+    return !!this.capabilities?.workspace?.workspaceFolders;
+  }
+
   get hasDidChangeConfigurationDynamicRegistrationSupport() {
     return !!this.capabilities?.workspace?.didChangeConfiguration?.dynamicRegistration;
   }

--- a/packages/theme-language-server-common/src/json/completions/providers/PresetsSettingsPropertyCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/PresetsSettingsPropertyCompletionProvider.ts
@@ -100,9 +100,5 @@ export class PresetsSettingsPropertyCompletionProvider implements JSONCompletion
 }
 
 function isPresetSettingsPath(path: JSONPath) {
-  return path.at(0) === 'presets' && path.at(1) === 0 && path.at(2) === 'settings';
-}
-
-function isTranslationKey(path: string) {
-  return path.startsWith('t:');
+  return path.at(0) === 'presets' && path.at(2) === 'settings';
 }

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -358,15 +358,17 @@ export function startServer(
       ],
     });
 
-    connection.workspace.getWorkspaceFolders().then(async (folders) => {
-      if (!folders) return;
+    if (clientCapabilities.hasWorkspaceFoldersSupport) {
+      connection.workspace.getWorkspaceFolders().then(async (folders) => {
+        if (!folders) return;
 
-      fetchMetafieldDefinitionsForWorkspaceFolders(folders);
-    });
+        fetchMetafieldDefinitionsForWorkspaceFolders(folders);
+      });
 
-    connection.workspace.onDidChangeWorkspaceFolders(async (params) => {
-      fetchMetafieldDefinitionsForWorkspaceFolders(params.added);
-    });
+      connection.workspace.onDidChangeWorkspaceFolders(async (params) => {
+        fetchMetafieldDefinitionsForWorkspaceFolders(params.added);
+      });
+    }
   });
 
   connection.onDidChangeConfiguration((_params) => {

--- a/packages/theme-language-server-node/src/metafieldDefinitions.ts
+++ b/packages/theme-language-server-node/src/metafieldDefinitions.ts
@@ -8,13 +8,13 @@ const isWin = process.platform === 'win32';
 const shopifyCliPathPromise = getShopifyCliPath();
 
 export async function fetchMetafieldDefinitionsForURI(uri: string) {
-  const path = await shopifyCliPathPromise;
-
-  if (!path) {
-    return;
-  }
-
   try {
+    const path = await shopifyCliPathPromise;
+
+    if (!path) {
+      return;
+    }
+
     await exec(`${path} theme metafields pull`, {
       cwd: new URL(uri),
       timeout: 10_000,


### PR DESCRIPTION
## What are you adding in this PR?

Fixes bug where we only support preset setting auto-completion for the first preset object

## Before you deploy

- [x] I included a patch bump `changeset`
