### PR TITLE
[LiquidDoc] Cache liquidDoc definitions in DocumentManager

### DIFF
--- a/.changeset/dry-donkeys-behave.md
+++ b/.changeset/dry-donkeys-behave.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+---
+
+Cache liquidDoc fetch results

--- a/packages/theme-language-server-common/src/documents/DocumentManager.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.ts
@@ -12,12 +12,14 @@ import {
   IsValidSchema,
   memo,
   Mode,
+  isError,
 } from '@shopify/theme-check-common';
 import { Connection } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { ClientCapabilities } from '../ClientCapabilities';
 import { percent, Progress } from '../progress';
 import { AugmentedSourceCode } from './types';
+import { getSnippetDefinition } from '../liquidDoc';
 
 export class DocumentManager {
   /**
@@ -170,6 +172,12 @@ export class DocumentManager {
 
             const mode = await this.getModeForUri!(uri);
             return toSchema(mode, uri, sourceCode, this.isValidSchema);
+          }),
+          /** Lazy and only computed once per file version */
+          liquidDoc: memo(async (snippetName: string) => {
+            if (isError(sourceCode.ast)) return { name: snippetName };
+
+            return getSnippetDefinition(sourceCode.ast, snippetName);
           }),
         };
       default:

--- a/packages/theme-language-server-common/src/documents/types.ts
+++ b/packages/theme-language-server-common/src/documents/types.ts
@@ -6,6 +6,7 @@ import {
   AppBlockSchema,
 } from '@shopify/theme-check-common';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { SnippetDefinition } from '../liquidDoc';
 
 /** Util type to add the common `textDocument` property to the SourceCode. */
 type _AugmentedSourceCode<SCT extends SourceCodeType = SourceCodeType> = SourceCode<SCT> & {
@@ -23,6 +24,7 @@ export type AugmentedJsonSourceCode = _AugmentedSourceCode<SourceCodeType.JSON>;
  */
 export type AugmentedLiquidSourceCode = _AugmentedSourceCode<SourceCodeType.LiquidHtml> & {
   getSchema: () => Promise<SectionSchema | ThemeBlockSchema | AppBlockSchema | undefined>;
+  liquidDoc: (snippetName: string) => Promise<SnippetDefinition>;
 };
 
 /**

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -185,7 +185,7 @@ export function startServer(
       return { name: snippetName };
     }
 
-    return getSnippetDefinition(snippet.ast, snippetName);
+    return snippet.liquidDoc(snippetName);
   };
 
   const snippetFilter = ([uri]: FileTuple) => /\.liquid$/.test(uri) && /snippets/.test(uri);


### PR DESCRIPTION
## What are you adding in this PR?

Caches fetch results for `liquid doc` definitions in the document manager. This allows us to take advantage of the cache busting and setting mechanism within the document manager.

Subsequent requests for liquid doc definitions for the same URI should return cached result.

The cache should properly get invalidated when a file is modified.


https://github.com/user-attachments/assets/06aa29c1-8cfe-4e10-8998-9e5b364ebaf3



## What's next? Any followup issues?


## What did you learn?

I learned about that the `TextDocument` from the `vscode-language-server-api` tracks a [version](https://github.com/microsoft/vscode-languageserver-node/blob/main/textDocument/src/main.ts#L138-L144) which is incremented for each change.

How we use this:

```mermaid
sequenceDiagram
    participant LSP as Language Server
    participant DM as DocumentManager
    participant ASC as AugmentedSourceCode

    Note over LSP: connection.onDidChangeTextDocument
    LSP->>DM: change(uri, text, version)
    Note over LSP: Send a `change` notification to the DocumentManager

    DM->>DM: set(uri, source, version)
    Note over DM: Update the DocumentManager representation of the file by creating a new AugmentedSourceCode for the given URI

    DM->>ASC: augmentedSourceCode(uri, source, version)
    Note over ASC: 'Cache busting' comes here because we create a new object with<br/>fresh memoized functions:<br/>- getSchema: memo(async()=>...)<br/>- liquidDoc: memo(async()=>...)

    ASC-->>DM: return new AugmentedSourceCode

    DM->>DM: sourceCodes.set(uri, augmentedSourceCode)
    Note over DM: Map now points to new version<br/>with fresh memoization
```

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible