### PR TITLE
Add parsing and prettier support for @example tags in liquid doc

### DIFF
--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -128,10 +128,10 @@ Liquid <: Helpers {
   liquidTagLiquidMarkup = tagMarkup
 
   liquidTagContentFor = liquidTagRule<"content_for", liquidTagContentForMarkup>
-  
+
   liquidTagContentForMarkup =
     contentForType (argumentSeparatorOptionalComma contentForTagArgument) (space* ",")? space*
-    
+
   contentForTagArgument = listOf<contentForNamedArgument<delimTag>, argumentSeparatorOptionalComma>
   contentForNamedArgument<delim> = (variableSegment ("." variableSegment)*) space* ":" space* (liquidExpression<delim>)
 
@@ -217,7 +217,7 @@ Liquid <: Helpers {
   commentBlockStart = "{%" "-"? space* ("comment"    endOfIdentifier) space* tagMarkup "-"? "%}"
   commentBlockEnd   = "{%" "-"? space* ("endcomment" endOfIdentifier) space* tagMarkup "-"? "%}"
 
-  liquidDoc = 
+  liquidDoc =
     liquidDocStart
       liquidDocBody
     liquidDocEnd
@@ -392,20 +392,26 @@ LiquidDoc <: Helpers {
   Node := (LiquidDocNode | TextNode)*
   LiquidDocNode =
     | paramNode
+    | exampleNode
     | fallbackNode
 
   // By default, space matches new lines as well. We override it here to make writing rules easier.
   strictSpace = " " | "\t"
-  // We use this as an escape hatch to stop matching TextNode and try again when one of these characters is encountered 
+  // We use this as an escape hatch to stop matching TextNode and try again when one of these characters is encountered
   openControl:= "@" | end
 
-  fallbackNode = "@" anyExceptStar<endOfParam>
   paramNode = "@param" strictSpace* paramType? strictSpace* paramName (strictSpace* "-")? strictSpace* paramDescription
   paramType = "{" strictSpace* paramTypeContent strictSpace* "}"
   paramTypeContent = anyExceptStar<("}"| strictSpace)>
   paramName = identifierCharacter+
   paramDescription = anyExceptStar<endOfParam>
   endOfParam = strictSpace* (newline | end)
+
+  exampleNode = "@example" strictSpace* exampleContent
+  exampleContent = anyExceptStar<endOfExample>
+  endOfExample =  strictSpace* ("@" | end)
+
+  fallbackNode = "@" anyExceptStar<endOfParam>
 }
 
 LiquidHTML <: Liquid {

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1154,7 +1154,9 @@ describe('Unit: Stage 1 (CST)', () => {
           cst = toCST(testStr);
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocExampleNode');
           expectPath(cst, '0.children.0.name').to.equal('example');
-          expectPath(cst, '0.children.0.exampleContent.value').to.equal('\n          This is an example\n');
+          expectPath(cst, '0.children.0.exampleContent.value').to.equal(
+            '\n          This is an example\n',
+          );
           expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
           expectPath(cst, '0.children.1.paramName.value').to.equal('param1');
         });

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1140,11 +1140,8 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.name').to.equal('doc');
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocExampleNode');
           expectPath(cst, '0.children.0.name').to.equal('example');
-          expectPath(cst, '0.children.0.exampleContent.value').toEqual(
-            expect.stringContaining('This is an example'),
-          );
-          expectPath(cst, '0.children.0.exampleContent.value').toEqual(
-            expect.stringContaining('It supports multiple lines'),
+          expectPath(cst, '0.children.0.exampleContent.value').to.equal(
+            '\n          This is an example\n          It supports multiple lines\n',
           );
         });
 
@@ -1157,9 +1154,7 @@ describe('Unit: Stage 1 (CST)', () => {
           cst = toCST(testStr);
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocExampleNode');
           expectPath(cst, '0.children.0.name').to.equal('example');
-          expectPath(cst, '0.children.0.exampleContent.value').toEqual(
-            expect.stringContaining('This is an example'),
-          );
+          expectPath(cst, '0.children.0.exampleContent.value').to.equal('\n          This is an example\n');
           expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
           expectPath(cst, '0.children.1.paramName.value').to.equal('param1');
         });
@@ -1175,14 +1170,8 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.name').to.equal('doc');
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocExampleNode');
           expectPath(cst, '0.children.0.name').to.equal('example');
-          expectPath(cst, '0.children.0.exampleContent.value').toEqual(
-            expect.stringContaining('hello      there        my    friend'),
-          );
-          expectPath(cst, '0.children.0.exampleContent.value').toEqual(
-            expect.stringContaining('This is an example'),
-          );
-          expectPath(cst, '0.children.0.exampleContent.value').toEqual(
-            expect.stringContaining('It supports multiple lines'),
+          expectPath(cst, '0.children.0.exampleContent.value').to.equal(
+            'hello      there        my    friend\n          This is an example\n          It supports multiple lines\n',
           );
         });
       }

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -85,6 +85,7 @@ export enum ConcreteNodeTypes {
   ContentForNamedArgument = 'ContentForNamedArgument',
 
   LiquidDocParamNode = 'LiquidDocParamNode',
+  LiquidDocExampleNode = 'LiquidDocExampleNode',
 }
 
 export const LiquidLiteralValues = {
@@ -113,6 +114,12 @@ export interface ConcreteLiquidDocParamNode
   paramName: ConcreteTextNode;
   paramDescription: ConcreteTextNode | null;
   paramType: ConcreteTextNode | null;
+}
+
+export interface ConcreteLiquidDocExampleNode
+  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocExampleNode> {
+  name: 'example';
+  exampleContent: ConcreteTextNode;
 }
 
 export interface ConcreteHtmlNodeBase<T> extends ConcreteBasicNode<T> {
@@ -454,7 +461,7 @@ export type LiquidHtmlCST = LiquidHtmlConcreteNode[];
 
 export type LiquidCST = LiquidConcreteNode[];
 
-export type LiquidDocConcreteNode = ConcreteLiquidDocParamNode;
+export type LiquidDocConcreteNode = ConcreteLiquidDocParamNode | ConcreteLiquidDocExampleNode;
 
 interface Mapping {
   [k: string]: number | TemplateMapping | TopLevelFunctionMapping;
@@ -1346,6 +1353,15 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
     paramTypeContent: textNode,
     paramName: textNode,
     paramDescription: textNode,
+    exampleNode: {
+      type: ConcreteNodeTypes.LiquidDocExampleNode,
+      name: 'example',
+      locStart,
+      locEnd,
+      source,
+      exampleContent: 2,
+    },
+    exampleContent: textNode,
     fallbackNode: textNode,
   };
 

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1258,6 +1258,55 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.body.nodes.2.value').to.eql(
         '@unsupported this node falls back to a text node',
       );
+
+      ast = toLiquidAST(`
+        {% doc -%}
+        @example simple inline example
+        {%- enddoc %}
+      `);
+      expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
+      expectPath(ast, 'children.0.name').to.eql('doc');
+      expectPath(ast, 'children.0.body.nodes.0.name').to.eql('example');
+      expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocExampleNode');
+      expectPath(ast, 'children.0.body.nodes.0.exampleContent.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.0.exampleContent.value').to.eql(
+        'simple inline example',
+      );
+
+      ast = toLiquidAST(`
+        {% doc -%}
+        @example including inline code
+        This is a valid example
+        It can have multiple lines
+        {% enddoc %}
+      `);
+      expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocExampleNode');
+      expectPath(ast, 'children.0.body.nodes.0.name').to.eql('example');
+      expectPath(ast, 'children.0.body.nodes.0.exampleContent.value').to.eql(
+        'including inline code\nThis is a valid example\nIt can have multiple lines',
+      );
+
+      ast = toLiquidAST(`
+        {% doc -%}
+        @example
+        This is a valid example
+        It can have multiple lines
+        @param {String} paramWithDescription - param with description
+        {% enddoc %}
+      `);
+      expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
+      expectPath(ast, 'children.0.name').to.eql('doc');
+      expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocExampleNode');
+      expectPath(ast, 'children.0.body.nodes.0.name').to.eql('example');
+      expectPath(ast, 'children.0.body.nodes.0.exampleContent.value').to.eql(
+        'This is a valid example\nIt can have multiple lines',
+      );
+      expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocParamNode');
+      expectPath(ast, 'children.0.body.nodes.1.name').to.eql('param');
+      expectPath(ast, 'children.0.body.nodes.1.paramName.value').to.eql('paramWithDescription');
+      expectPath(ast, 'children.0.body.nodes.1.paramDescription.value').to.eql(
+        'param with description',
+      );
     });
 
     it('should parse unclosed tables with assignments', () => {

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1210,7 +1210,6 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.markup.0.name').to.eql('assign');
       expectPath(ast, 'children.0.markup.0.markup.name').to.eql('var1');
 
-
       expectPath(ast, 'children.0.markup.1.type').to.eql('LiquidTag');
       expectPath(ast, 'children.0.markup.1.name').to.eql('if');
 

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1210,6 +1210,7 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.markup.0.name').to.eql('assign');
       expectPath(ast, 'children.0.markup.0.markup.name').to.eql('var1');
 
+
       expectPath(ast, 'children.0.markup.1.type').to.eql('LiquidTag');
       expectPath(ast, 'children.0.markup.1.name').to.eql('if');
 
@@ -1270,7 +1271,7 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.0.exampleContent.type').to.eql('TextNode');
       expectPath(ast, 'children.0.body.nodes.0.exampleContent.value').to.eql(
-        'simple inline example',
+        'simple inline example\n',
       );
 
       ast = toLiquidAST(`
@@ -1283,7 +1284,7 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.0.name').to.eql('example');
       expectPath(ast, 'children.0.body.nodes.0.exampleContent.value').to.eql(
-        'including inline code\nThis is a valid example\nIt can have multiple lines',
+        'including inline code\n        This is a valid example\n        It can have multiple lines\n',
       );
 
       ast = toLiquidAST(`
@@ -1299,7 +1300,7 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.0.name').to.eql('example');
       expectPath(ast, 'children.0.body.nodes.0.exampleContent.value').to.eql(
-        'This is a valid example\nIt can have multiple lines',
+        '\n        This is a valid example\n        It can have multiple lines\n',
       );
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocParamNode');
       expectPath(ast, 'children.0.body.nodes.1.name').to.eql('param');

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -108,7 +108,8 @@ export type LiquidHtmlNode =
   | LiquidLogicalExpression
   | LiquidComparison
   | TextNode
-  | LiquidDocParamNode;
+  | LiquidDocParamNode
+  | LiquidDocExampleNode;
 
 /** The root node of all LiquidHTML ASTs. */
 export interface DocumentNode extends ASTNode<NodeTypes.Document> {
@@ -765,6 +766,14 @@ export interface LiquidDocParamNode extends ASTNode<NodeTypes.LiquidDocParamNode
   /** Optional type annotation for the parameter (e.g. "{string}", "{number}") */
   paramType: TextNode | null;
 }
+
+/** Represents a `@example` node in a LiquidDoc comment - `@example @exampleContent` */
+export interface LiquidDocExampleNode extends ASTNode<NodeTypes.LiquidDocExampleNode> {
+  name: 'example';
+  /** The contents of the example (e.g. "{{ product }}"). Can be multiline. */
+  exampleContent: TextNode;
+}
+
 export interface ASTNode<T> {
   /**
    * The type of the node, as a string.
@@ -1293,6 +1302,26 @@ function buildAst(
           },
           paramDescription: toNullableTextNode(node.paramDescription),
           paramType: toNullableTextNode(node.paramType),
+        });
+        break;
+      }
+
+      case ConcreteNodeTypes.LiquidDocExampleNode: {
+        builder.push({
+          type: NodeTypes.LiquidDocExampleNode,
+          name: node.name,
+          position: position(node),
+          source: node.source,
+          exampleContent: {
+            type: NodeTypes.TextNode,
+            value: node.exampleContent.value
+              .split('\n')
+              .map((line) => line.trim())
+              .filter(Boolean)
+              .join('\n'),
+            position: position(node.exampleContent),
+            source: node.exampleContent.source,
+          },
         });
         break;
       }

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -1314,11 +1314,7 @@ function buildAst(
           source: node.source,
           exampleContent: {
             type: NodeTypes.TextNode,
-            value: node.exampleContent.value
-              .split('\n')
-              .map((line) => line.trim())
-              .filter(Boolean)
-              .join('\n'),
+            value: node.exampleContent.value,
             position: position(node.exampleContent),
             source: node.exampleContent.source,
           },

--- a/packages/liquid-html-parser/src/types.ts
+++ b/packages/liquid-html-parser/src/types.ts
@@ -45,6 +45,7 @@ export enum NodeTypes {
   RenderMarkup = 'RenderMarkup',
   RenderVariableExpression = 'RenderVariableExpression',
   LiquidDocParamNode = 'LiquidDocParamNode',
+  LiquidDocExampleNode = 'LiquidDocExampleNode',
 }
 
 // These are officially supported with special node types

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -129,6 +129,7 @@ function getCssDisplay(node: AugmentedNode<WithSiblings>, options: LiquidParserO
     case NodeTypes.LogicalExpression:
     case NodeTypes.Comparison:
     case NodeTypes.LiquidDocParamNode:
+    case NodeTypes.LiquidDocExampleNode:
       return 'should not be relevant';
 
     default:
@@ -235,6 +236,7 @@ function getNodeCssStyleWhiteSpace(
     case NodeTypes.LogicalExpression:
     case NodeTypes.Comparison:
     case NodeTypes.LiquidDocParamNode:
+    case NodeTypes.LiquidDocExampleNode:
       return 'should not be relevant';
 
     default:

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -547,14 +547,46 @@ export function printLiquidDocExample(
   const parts: Doc[] = ['@example'];
 
   if (node.exampleContent?.value) {
-    const content = node.exampleContent.value.trim();
+    const content = node.exampleContent.value;
     if (content) {
+      // Count leading newlines before content (\n\nmy content)
+      const leadingNewlines = content.match(/^\n*/)?.[0]?.length ?? 0;
+      const trimmedContent = content.trim();
+
+      // Push inline content to new line
       parts.push(hardline);
-      const lines = content
-        .split('\n')
-        .map((line) => line.trim())
-        .filter(Boolean);
-      parts.push(join(hardline, lines));
+
+      // If there were two or more leading newlines, push another new line
+      if (leadingNewlines > 1) {
+        parts.push(hardline);
+      }
+
+      // If content doesn't have newlines in it, make sure it's on a new line (not inline)
+      if (!trimmedContent.includes('\n')) {
+        parts.push(trimmedContent);
+        return parts;
+      }
+
+      // For multi-line content
+      const lines = trimmedContent.split('\n');
+      const processedLines: string[] = [];
+      let emptyLineCount = 0;
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i].trim();
+
+        if (line === '') {
+          emptyLineCount++;
+          if (emptyLineCount <= 2) {
+            processedLines.push('');
+          }
+        } else {
+          emptyLineCount = 0;
+          processedLines.push(line);
+        }
+      }
+
+      parts.push(join(hardline, processedLines));
     }
   }
 

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -4,6 +4,7 @@ import {
   isBranchedTag,
   RawMarkup,
   LiquidDocParamNode,
+  LiquidDocExampleNode,
 } from '@shopify/liquid-html-parser';
 import { Doc, doc } from 'prettier';
 
@@ -530,6 +531,30 @@ export function printLiquidDocParam(
       parts.push(' - ', normalizedDescription);
     } else {
       parts.push(' ', normalizedDescription);
+    }
+  }
+
+  return parts;
+}
+
+export function printLiquidDocExample(
+  path: AstPath<LiquidDocExampleNode>,
+  options: LiquidParserOptions,
+  _print: LiquidPrinter,
+  _args: LiquidPrinterArgs,
+): Doc {
+  const node = path.getValue();
+  const parts: Doc[] = ['@example'];
+
+  if (node.exampleContent?.value) {
+    const content = node.exampleContent.value.trim();
+    if (content) {
+      parts.push(hardline);
+      const lines = content
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+      parts.push(join(hardline, lines));
     }
   }
 

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -1,5 +1,6 @@
 import {
   getConditionalComment,
+  LiquidDocExampleNode,
   LiquidDocParamNode,
   NodeTypes,
   Position,
@@ -47,6 +48,7 @@ import {
   printLiquidTag,
   printLiquidVariableOutput,
   printLiquidDocParam,
+  printLiquidDocExample,
 } from './print/liquid';
 import { printClosingTagSuffix, printOpeningTagPrefix } from './print/tag';
 import { bodyLines, hasLineBreakInRange, isEmpty, isTextLikeNode, reindent } from './utils';
@@ -557,6 +559,10 @@ function printNode(
 
     case NodeTypes.LiquidDocParamNode: {
       return printLiquidDocParam(path as AstPath<LiquidDocParamNode>, options, print, args);
+    }
+
+    case NodeTypes.LiquidDocExampleNode: {
+      return printLiquidDocExample(path as AstPath<LiquidDocExampleNode>, options, print, args);
     }
 
     default: {

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
@@ -27,3 +27,9 @@ It should normalize the param description
 {% doc %}
   @param paramName - param with description
 {% enddoc %}
+
+It should push example content to the next line
+{% doc %}
+  @example
+  This is a valid example
+{% enddoc %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
@@ -33,3 +33,40 @@ It should push example content to the next line
   @example
   This is a valid example
 {% enddoc %}
+
+It should allow single empty lines between content
+{% doc %}
+  @example
+
+  This is a valid example
+
+  So is this without a newline
+  See?
+{% enddoc %}
+
+It should allow multiple empty lines between content
+{% doc %}
+  @example
+
+  This is a valid example
+
+
+  Here is another example
+
+  with a single empty line
+{% enddoc %}
+
+It should remove empty lines at the end of the content
+{% doc %}
+  @example
+
+  Here is my content and a newline
+{% enddoc %}
+
+It should respect example content with param and description
+{% doc %}
+  @param paramName - param with description
+  @example
+
+  This is a valid example
+{% enddoc %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
@@ -27,3 +27,8 @@ It should normalize the param description
 {% doc %}
   @param paramName - param           with                    description
 {% enddoc %}
+
+It should push example content to the next line
+{% doc %}
+  @example This is a valid example
+{% enddoc %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
@@ -32,3 +32,41 @@ It should push example content to the next line
 {% doc %}
   @example This is a valid example
 {% enddoc %}
+
+It should allow single empty lines between content
+{% doc %}
+  @example
+
+  This is a valid example
+
+  So is this without a newline
+  See?
+{% enddoc %}
+
+It should allow multiple empty lines between content
+{% doc %}
+  @example
+
+  This is a valid example
+
+
+  Here is another example
+
+  with a single empty line
+{% enddoc %}
+
+It should remove empty lines at the end of the content
+{% doc %}
+  @example
+
+  Here is my content and a newline
+
+{% enddoc %}
+
+It should respect example content with param and description
+{% doc %}
+@param paramName - param with description
+@example
+
+This is a valid example
+{% enddoc %}

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -406,6 +406,9 @@ function findCurrentNode(
       case NodeTypes.LiquidDocParamNode: {
         break;
       }
+      case NodeTypes.LiquidDocExampleNode: {
+        break;
+      }
 
       default: {
         return assertNever(current);


### PR DESCRIPTION
## What are you adding in this PR?

References: https://github.com/Shopify/develop-advanced-edits/issues/471

Added support for parsing and formatting `@example` tags within `LiquidDoc` blocks.

## Feedback
Right now, we aren't controlling whitespace for example tags. If someone wants to write `check   out.     my great    example`, it would stay in that format. Should trim whitespace or allow people writing examples to have full control?

## What's next? Any followup issues?

I want to add prettier support to automatically move `@example` tags and content below `@param` as it is the proper flow.

## What did you learn?

AST's and CST's are quite puzzle to figure out.

## Test
https://github.com/user-attachments/assets/70c8452b-820d-4091-acbb-dd6a720821cc


## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible
