### PR TITLE
[LiquidDoc] Formatting support for optional `@param` delimiters `[]`

### DIFF
--- a/.changeset/olive-cougars-float.md
+++ b/.changeset/olive-cougars-float.md
@@ -1,0 +1,6 @@
+---
+'@shopify/prettier-plugin-liquid': minor
+---
+
+Add formatting support for optional liquidDoc parameters (e.g. `@param [optional-parameter] - paramDescription`).
+Whitespace is now stripped around the parameter name and the optional delimiters.

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -520,8 +520,10 @@ export function printLiquidDocParam(
     parts.push(' ', `{${node.paramType.value}}`);
   }
 
-  if (node.paramName.value) {
+  if (node.required) {
     parts.push(' ', node.paramName.value);
+  } else {
+    parts.push(' ', `[${node.paramName.value}]`);
   }
 
   if (node.paramDescription?.value) {

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
@@ -19,6 +19,7 @@ It should format the param description with a dash separator
 {% enddoc %}
 
 It should respect the liquidDocParamDash option liquidDocParamDash: false
+liquidDocParamDash: false
 {% doc %}
   @param paramName param with description
 {% enddoc %}
@@ -26,6 +27,19 @@ It should respect the liquidDocParamDash option liquidDocParamDash: false
 It should normalize the param description
 {% doc %}
   @param paramName - param with description
+{% enddoc %}
+
+It should strip whitespace between optional param delimiters
+{% doc %}
+  @param [paramName] - param with description
+{% enddoc %}
+
+It should not break params with malformed optional delimiters
+{% doc %}
+  @param [missingTail - param with description
+  @param missingHead - ] - param with description
+  @param [too many words no desc]
+  @param [too many words] - param with description
 {% enddoc %}
 
 It should push example content to the next line

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
@@ -28,6 +28,19 @@ It should normalize the param description
   @param paramName - param           with                    description
 {% enddoc %}
 
+It should strip whitespace between optional param delimiters
+{% doc %}
+  @param [ paramName ] - param with description
+{% enddoc %}
+
+It should handle params with malformed optional delimiters
+{% doc %}
+  @param [missingTail - param with description
+  @param missingHead - ] - param with description
+  @param [too many words no desc]
+  @param [too many words] - param with description
+{% enddoc %}
+
 It should push example content to the next line
 {% doc %}
   @example This is a valid example


### PR DESCRIPTION
## What are you adding in this PR?
Part of https://github.com/Shopify/developer-tools-team/issues/525

Adds prettier support for LiquidDoc parameters with optional params, indicated by wrapping the param name in `[]`

![Cursor -  Extension Development Host  product-variant-picker liquid — jm-theme](https://github.com/user-attachments/assets/f7f4b1bf-7ab7-495b-89d1-c8edeacfeb37)

## What's next? Any followup issues?
https://github.com/Shopify/theme-tools/pull/735

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
