### PR TITLE
[LiquidDoc] Modify paramDescription to be null if empty

### DIFF
--- a/.changeset/thirty-walls-grow.md
+++ b/.changeset/thirty-walls-grow.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/liquid-html-parser': patch
+---
+
+[Internal] Modify paramDescription to be null when empty

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1231,19 +1231,22 @@ describe('Unit: Stage 2 (AST)', () => {
 
       ast = toLiquidAST(`
         {% doc -%}
-        @param asdf
+        @param paramWithNoType
         @param {String} paramWithDescription - param with description and \`punctation\`. This is still a valid param description.
+        @param {String} paramWithNoDescription
         @unsupported this node falls back to a text node
         {%- enddoc %}
       `);
       expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
       expectPath(ast, 'children.0.name').to.eql('doc');
+
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocParamNode');
       expectPath(ast, 'children.0.body.nodes.0.name').to.eql('param');
       expectPath(ast, 'children.0.body.nodes.0.paramName.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.0.paramName.value').to.eql('asdf');
-      expectPath(ast, 'children.0.body.nodes.0.paramDescription.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.0.paramDescription.value').to.eql('');
+      expectPath(ast, 'children.0.body.nodes.0.paramName.value').to.eql('paramWithNoType');
+      expectPath(ast, 'children.0.body.nodes.0.paramType').to.be.null;
+      expectPath(ast, 'children.0.body.nodes.0.paramDescription').to.be.null;
+
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocParamNode');
       expectPath(ast, 'children.0.body.nodes.1.name').to.eql('param');
       expectPath(ast, 'children.0.body.nodes.1.paramName.type').to.eql('TextNode');
@@ -1254,8 +1257,17 @@ describe('Unit: Stage 2 (AST)', () => {
       );
       expectPath(ast, 'children.0.body.nodes.1.paramType.type').to.eql('TextNode');
       expectPath(ast, 'children.0.body.nodes.1.paramType.value').to.eql('String');
-      expectPath(ast, 'children.0.body.nodes.2.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.2.value').to.eql(
+
+      expectPath(ast, 'children.0.body.nodes.2.type').to.eql('LiquidDocParamNode');
+      expectPath(ast, 'children.0.body.nodes.2.name').to.eql('param');
+      expectPath(ast, 'children.0.body.nodes.2.paramName.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.2.paramName.value').to.eql('paramWithNoDescription');
+      expectPath(ast, 'children.0.body.nodes.2.paramDescription').to.be.null;
+      expectPath(ast, 'children.0.body.nodes.2.paramType.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.2.paramType.value').to.eql('String');
+
+      expectPath(ast, 'children.0.body.nodes.3.type').to.eql('TextNode');
+      expectPath(ast, 'children.0.body.nodes.3.value').to.eql(
         '@unsupported this node falls back to a text node',
       );
     });

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -1974,7 +1974,8 @@ function toHtmlSelfClosingElement(
 }
 
 function toNullableTextNode(node: ConcreteTextNode | null): TextNode | null {
-  if (!node) return null;
+  if (!node || node.value === '') return null;
+
   return toTextNode(node);
 }
 

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -3,6 +3,7 @@ import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
 import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
 import { GetSnippetDefinitionForURI, SnippetDefinition } from '../../liquidDoc';
+import '../../../../theme-check-common/src/test/test-setup';
 
 describe('Module: RenderSnippetHoverProvider', async () => {
   let provider: HoverProvider;
@@ -20,6 +21,21 @@ describe('Module: RenderSnippetHoverProvider', async () => {
           name: 'border-radius',
           description: 'The border radius in px',
           type: 'number',
+        },
+        {
+          name: 'no-type',
+          description: 'This parameter has no type',
+          type: null,
+        },
+        {
+          name: 'no-description',
+          description: null,
+          type: 'string',
+        },
+        {
+          name: 'no-type-or-description',
+          description: null,
+          type: null,
         },
       ],
     },
@@ -50,7 +66,7 @@ describe('Module: RenderSnippetHoverProvider', async () => {
     it('should return snippet definition with all parameters', async () => {
       await expect(provider).to.hover(
         `{% render 'product-car█d' %}`,
-        '### product-card\n\n**Parameters:**\n- `title`: string - The title of the product\n- `border-radius`: number - The border radius in px',
+        '### product-card\n\n**Parameters:**\n- `title`: string - The title of the product\n- `border-radius`: number - The border radius in px\n- `no-type` - This parameter has no type\n- `no-description`: string\n- `no-type-or-description`',
       );
     });
 

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -49,7 +49,7 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
       const parameters = liquidDoc.parameters
         ?.map(
           ({ name, type, description }: LiquidDocParameter) =>
-            `- \`${name}\`${type ? `: ${type}` : ''} ${description ? `- ${description}` : ''}`,
+            `- \`${name}\`${type ? `: ${type}` : ''}${description ? ` - ${description}` : ''}`,
         )
         .join('\n');
 

--- a/packages/theme-language-server-common/src/liquidDoc.spec.ts
+++ b/packages/theme-language-server-common/src/liquidDoc.spec.ts
@@ -33,6 +33,7 @@ describe('Unit: makeGetLiquidDocDefinitions', () => {
           @param {Number} secondParam - The second param
           @param paramWithNoType - param with no type
           @param paramWithOnlyName
+          @param {Number} paramWithNoDescription
         {% enddoc %}
       `);
 
@@ -58,8 +59,13 @@ describe('Unit: makeGetLiquidDocDefinitions', () => {
           },
           {
             name: 'paramWithOnlyName',
-            description: '',
+            description: null,
             type: null,
+          },
+          {
+            name: 'paramWithNoDescription',
+            description: null,
+            type: 'Number',
           },
         ],
       },


### PR DESCRIPTION
## What are you adding in this PR?

Returns `null` in the `liquid-html-parser` if `paramDescription` value is `''`. 

Also added some test coverage in the language server for this case.

- [paramDescription](https://github.com/Shopify/theme-tools/blob/main/packages/liquid-html-parser/grammar/liquid-html.ohm#L403) is always matched in the grammar. I experimented with changing that matching logic but ultimately felt it was simpler this logic in instead `stage-2`, though we could revisit this


<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
