### PR TITLE
Add completion support for content_for parameters

### DIFF
--- a/.changeset/fresh-suns-provide.md
+++ b/.changeset/fresh-suns-provide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': minor
+---
+
+Support parsing incomplete content_for tags for completions

--- a/.changeset/fresh-suns-provide.md
+++ b/.changeset/fresh-suns-provide.md
@@ -1,5 +1,7 @@
 ---
 '@shopify/liquid-html-parser': minor
+'@shopify/theme-language-server-common': minor
 ---
 
-Support parsing incomplete content_for tags for completions
+- Support parsing incomplete content_for tags in completion context
+- Support content_for param completion

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -133,6 +133,7 @@ Liquid <: Helpers {
     contentForType (argumentSeparatorOptionalComma contentForTagArgument) (space* ",")? space*
 
   contentForTagArgument = listOf<contentForNamedArgument<delimTag>, argumentSeparatorOptionalComma>
+  completionModeContentForTagArgument = listOf<contentForNamedArgument<delimTag>, argumentSeparatorOptionalComma> (argumentSeparator? (liquidVariableLookup<delimTag>))?
   contentForNamedArgument<delim> = (variableSegment ("." variableSegment)*) space* ":" space* (liquidExpression<delim>)
 
   contentForType = liquidString<delimTag>
@@ -551,18 +552,24 @@ StrictLiquidHTML <: LiquidHTML {
 
 WithPlaceholderLiquid <: Liquid {
   liquidFilter<delim> := space* "|" space* identifier (space* ":" space* filterArguments<delim> (space* ",")?)?
+  liquidTagContentForMarkup :=
+    contentForType (argumentSeparatorOptionalComma completionModeContentForTagArgument) (space* ",")? space*
   liquidTagName := (letter | "█") (alnum | "_")*
   variableSegment := (letter | "_" | "█") (identifierCharacter | "█")*
 }
 
 WithPlaceholderLiquidStatement <: LiquidStatement {
   liquidFilter<delim> := space* "|" space* identifier (space* ":" space* filterArguments<delim> (space* ",")?)?
+  liquidTagContentForMarkup :=
+    contentForType (argumentSeparatorOptionalComma completionModeContentForTagArgument) (space* ",")? space*
   liquidTagName := (letter | "█") (alnum | "_")*
   variableSegment := (letter | "_" | "█") (identifierCharacter | "█")*
 }
 
 WithPlaceholderLiquidHTML <: LiquidHTML {
   liquidFilter<delim> := space* "|" space* identifier (space* ":" space* filterArguments<delim> (space* ",")?)?
+  liquidTagContentForMarkup :=
+    contentForType (argumentSeparatorOptionalComma completionModeContentForTagArgument) (space* ",")? space*
   liquidTagName := (letter | "█") (alnum | "_")*
   variableSegment := (letter | "_" | "█") (identifierCharacter | "█")*
   leadingTagNameTextNode := (letter | "█") (alnum | "-" | ":" | "█")*

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1776,6 +1776,25 @@ describe('Unit: Stage 1 (CST)', () => {
       expectPath(cst, '0.markup.filters.0.args.1.type').to.equal('NamedArgument');
       expectPath(cst, '0.markup.filters.0.args.2.type').to.equal('VariableLookup');
     });
+
+    it('should parse incomplete parameters for content_for tags', () => {
+      const toCST = (source: string) => toLiquidHtmlCST(source, { mode: 'completion' });
+
+      cst = toCST(`{% content_for "blocks", id: 1, cl█ %}`);
+
+      expectPath(cst, '0.markup.type').to.equal('ContentForMarkup');
+      expectPath(cst, '0.markup.args.0.type').to.equal('NamedArgument');
+      expectPath(cst, '0.markup.args.1.type').to.equal('VariableLookup');
+    });
+
+    it('blah blah', () => {
+      const toCST = (source: string) => toLiquidHtmlCST(source, { mode: 'completion' });
+
+      cst = toCST(`{% content_for "blocks", cl█ %}`);
+
+      expectPath(cst, '0.markup.type').to.equal('ContentForMarkup');
+      expectPath(cst, '0.markup.args.0.type').to.equal('VariableLookup');
+    });
   });
 
   function makeExpectPath(message: string) {

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1786,15 +1786,6 @@ describe('Unit: Stage 1 (CST)', () => {
       expectPath(cst, '0.markup.args.0.type').to.equal('NamedArgument');
       expectPath(cst, '0.markup.args.1.type').to.equal('VariableLookup');
     });
-
-    it('blah blah', () => {
-      const toCST = (source: string) => toLiquidHtmlCST(source, { mode: 'completion' });
-
-      cst = toCST(`{% content_for "blocks", cl█ %}`);
-
-      expectPath(cst, '0.markup.type').to.equal('ContentForMarkup');
-      expectPath(cst, '0.markup.args.0.type').to.equal('VariableLookup');
-    });
   });
 
   function makeExpectPath(message: string) {

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -937,6 +937,13 @@ function toCST<T>(
     simpleArgument: 0,
     tagArguments: 0,
     contentForTagArgument: 0,
+    completionModeContentForTagArgument: function (namedArguments, _separator, variableLookup) {
+      const self = this as any;
+
+      return namedArguments
+        .toAST(self.args.mapping)
+        .concat(variableLookup.sourceString === '' ? [] : variableLookup.toAST(self.args.mapping));
+    },
     positionalArgument: 0,
     namedArgument: {
       type: ConcreteNodeTypes.NamedArgument,

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1546,6 +1546,15 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.name.0.value').to.equal('h█');
     });
 
+    it('should not freak out when parsing incomplete named arguments for content_for tags', () => {
+      ast = toAST(`{% content_for "blocks", id: 1, cl█ %}`);
+
+      expectPath(ast, 'children.0.type').to.equal('LiquidTag');
+      expectPath(ast, 'children.0.markup.args.0.type').to.equal('NamedArgument');
+      expectPath(ast, 'children.0.markup.args.1.type').to.equal('VariableLookup');
+      expectPath(ast, 'children.0.markup.args').to.have.lengthOf(2);
+    });
+
     it('should not freak out when parsing dangling liquid tags', () => {
       ast = toAST(`<h {% if cond %}attr{% end█ %}>`);
       expectPath(ast, 'children.0.type').to.equal('HtmlElement');

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -19,6 +19,7 @@ import {
   RenderSnippetCompletionProvider,
   TranslationCompletionProvider,
   FilterNamedParameterCompletionProvider,
+  ContentForParameterCompletionProvider,
 } from './providers';
 import { GetSnippetNamesForURI } from './providers/RenderSnippetCompletionProvider';
 
@@ -61,6 +62,7 @@ export class CompletionsProvider {
     this.providers = [
       new ContentForCompletionProvider(),
       new ContentForBlockTypeCompletionProvider(getThemeBlockNames),
+      new ContentForParameterCompletionProvider(),
       new HtmlTagCompletionProvider(),
       new HtmlAttributeCompletionProvider(documentManager),
       new HtmlAttributeValueCompletionProvider(),

--- a/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.spec.ts
@@ -1,0 +1,248 @@
+import { describe, afterEach, beforeEach, it, expect, vi } from 'vitest';
+import { CompletionsProvider } from '../CompletionsProvider';
+import { DocumentManager } from '../../documents';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
+import { TextEdit, InsertTextFormat } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { CURSOR } from '../params';
+
+vi.mock('./data/contentForParameterCompletionOptions', async () => {
+  const actual = (await vi.importActual(
+    './data/contentForParameterCompletionOptions',
+  )) as typeof import('./data/contentForParameterCompletionOptions');
+  return {
+    DEFAULT_COMPLETION_OPTIONS: {
+      ...actual.DEFAULT_COMPLETION_OPTIONS,
+      // Add another option here so we can properly test some scenarios that
+      // we wouldn't be able to otherwise.
+      testOption: '',
+    },
+  };
+});
+
+describe('Module: ContentForBlockParameterCompletionProvider', async () => {
+  let provider: CompletionsProvider;
+
+  beforeEach(async () => {
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('offers a full list of completion items', async () => {
+    await expect(provider).to.complete('{% content_for "block", █ %}', [
+      'type',
+      'id',
+      'closest',
+      'testOption',
+    ]);
+  });
+
+  it('uses text edits to insert the completion item', async () => {
+    //                               char 24 ⌄
+    const context = `{% content_for "block", █ %}`;
+
+    const textEdit: TextEdit = {
+      newText: "type: '$1'",
+      range: {
+        end: { line: 0, character: 24 },
+        start: { line: 0, character: 24 },
+      },
+    };
+
+    await expect(provider).to.complete(
+      context,
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'type',
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit,
+        }),
+      ]),
+    );
+
+    const textDocument = TextDocument.create('', 'liquid', 0, context.replace(CURSOR, ''));
+
+    expect(TextDocument.applyEdits(textDocument, [textEdit])).toBe(
+      `{% content_for "block", type: '$1' %}`,
+    );
+  });
+
+  it('provides a different style of completion for "closest"', async () => {
+    //                               char 24 ⌄
+    const context = `{% content_for "block", █ %}`;
+
+    const textEdit: TextEdit = {
+      newText: 'closest.',
+      range: {
+        end: { line: 0, character: 24 },
+        start: { line: 0, character: 24 },
+      },
+    };
+
+    await expect(provider).to.complete(
+      context,
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'closest',
+          insertTextFormat: InsertTextFormat.PlainText,
+          textEdit,
+        }),
+      ]),
+    );
+
+    const textDocument = TextDocument.create('', 'liquid', 0, context.replace(CURSOR, ''));
+
+    expect(TextDocument.applyEdits(textDocument, [textEdit])).toBe(
+      `{% content_for "block", closest. %}`,
+    );
+  });
+
+  describe("when we're completing for blocks we only allow `closest`", () => {
+    it('does something', async () => {
+      await expect(provider).to.complete('{% content_for "blocks", █ %}', ['closest']);
+    });
+  });
+
+  describe('when the user has already started typing the name of the parameter', () => {
+    it('filters the completion options to only include ones that match', async () => {
+      await expect(provider).to.complete('{% content_for "block", t█ %}', ['type', 'testOption']);
+    });
+  });
+
+  describe('when the user has already typed out a parameter name', () => {
+    describe('and the cursor is in the middle of the parameter', () => {
+      it('changes the range depending on the completion item', async () => {
+        //                              char 24 ⌄               ⌄ char 38
+        const context = `{% content_for "block", t█ype: "button" %}`;
+        //                                            ⌃ char 28
+
+        const typeTextEdit: TextEdit = {
+          newText: 'type',
+          range: {
+            end: { line: 0, character: 28 },
+            start: { line: 0, character: 24 },
+          },
+        };
+
+        const testTextEdit: TextEdit = {
+          newText: "testOption: '$1'",
+          range: {
+            end: { line: 0, character: 38 },
+            start: { line: 0, character: 24 },
+          },
+        };
+
+        await expect(provider).to.complete(context, [
+          expect.objectContaining({
+            label: 'type',
+            insertTextFormat: InsertTextFormat.PlainText,
+            textEdit: expect.objectContaining(typeTextEdit),
+          }),
+          expect.objectContaining({
+            label: 'testOption',
+            insertTextFormat: InsertTextFormat.Snippet,
+            textEdit: expect.objectContaining(testTextEdit),
+          }),
+        ]);
+
+        const textDocument = TextDocument.create('', 'liquid', 0, context.replace(CURSOR, ''));
+
+        expect(TextDocument.applyEdits(textDocument, [testTextEdit])).toBe(
+          `{% content_for "block", testOption: '$1' %}`,
+        );
+
+        expect(TextDocument.applyEdits(textDocument, [typeTextEdit])).toBe(
+          `{% content_for "block", type: "button" %}`,
+        );
+      });
+    });
+
+    describe('and the cursor is at the beginning of the parameter', () => {
+      it('offers a full list of completion items', async () => {
+        const context = `{% content_for "block", █type: "button" %}`;
+
+        await expect(provider).to.complete(context, ['type', 'id', 'closest', 'testOption']);
+      });
+
+      it('does not replace the existing text', async () => {
+        //                               char 24 ⌄
+        const context = `{% content_for "block", █type: "button" %}`;
+
+        const textEdit: TextEdit = {
+          newText: "testOption: '$1', ",
+          range: {
+            end: { line: 0, character: 24 },
+            start: { line: 0, character: 24 },
+          },
+        };
+
+        await expect(provider).to.complete(
+          context,
+          expect.arrayContaining([
+            expect.objectContaining({
+              label: 'testOption',
+              insertTextFormat: InsertTextFormat.Snippet,
+              textEdit,
+            }),
+          ]),
+        );
+
+        const textDocument = TextDocument.create('', 'liquid', 0, context.replace(CURSOR, ''));
+
+        expect(TextDocument.applyEdits(textDocument, [textEdit])).toBe(
+          `{% content_for "block", testOption: '$1', type: "button" %}`,
+        );
+      });
+    });
+
+    describe('and the cursor is at the end of the parameter', () => {
+      it('offers only the same completion item', async () => {
+        const context = `{% content_for "block", type█: "button" %}`;
+
+        await expect(provider).to.complete(context, ['type']);
+      });
+
+      it('only replaces the parameter name', async () => {
+        //                              char 24 ⌄     ⌄ char 28
+        const context = `{% content_for "block", type█: "button" %}`;
+
+        const textEdit: TextEdit = {
+          newText: 'type',
+          range: {
+            end: { line: 0, character: 28 },
+            start: { line: 0, character: 24 },
+          },
+        };
+
+        await expect(provider).to.complete(
+          context,
+          expect.arrayContaining([
+            expect.objectContaining({
+              label: 'type',
+              insertTextFormat: InsertTextFormat.PlainText,
+              textEdit,
+            }),
+          ]),
+        );
+
+        const textDocument = TextDocument.create('', 'liquid', 0, context.replace(CURSOR, ''));
+
+        expect(TextDocument.applyEdits(textDocument, [textEdit])).toBe(
+          `{% content_for "block", type: "button" %}`,
+        );
+      });
+    });
+  });
+});

--- a/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.ts
@@ -1,0 +1,127 @@
+import { LiquidVariableLookup, NodeTypes } from '@shopify/liquid-html-parser';
+import {
+  CompletionItem,
+  CompletionItemKind,
+  InsertTextFormat,
+  TextEdit,
+} from 'vscode-languageserver';
+import { CURSOR, LiquidCompletionParams } from '../params';
+import { Provider } from './common';
+import { AugmentedLiquidSourceCode } from '../../documents';
+import { DEFAULT_COMPLETION_OPTIONS } from './data/contentForParameterCompletionOptions';
+
+/**
+ * Offers completions for parameters for the `content_for` tag after a user has
+ * specificied the type.
+ *
+ * @example {% content_for "block", █ %}
+ */
+export class ContentForParameterCompletionProvider implements Provider {
+  constructor() {}
+
+  async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
+    if (!params.completionContext) return [];
+
+    const { node, ancestors } = params.completionContext;
+
+    const parentNode = ancestors.at(-1);
+
+    const parentIsContentFor = parentNode?.type == NodeTypes.ContentForMarkup;
+    const nodeIsVariableLookup = node?.type == NodeTypes.VariableLookup;
+
+    if (!parentIsContentFor || !nodeIsVariableLookup) {
+      return [];
+    }
+
+    if (!node.name || node.lookups.length > 0) {
+      return [];
+    }
+
+    let options = DEFAULT_COMPLETION_OPTIONS;
+
+    const partial = node.name.replace(CURSOR, '');
+
+    if (parentNode.contentForType.value == 'blocks') {
+      options = {
+        closest: DEFAULT_COMPLETION_OPTIONS.closest,
+      };
+    }
+
+    return Object.entries(options)
+      .filter(([keyword, _description]) => keyword.startsWith(partial))
+      .map(([keyword, description]): CompletionItem => {
+        const { textEdit, format } = this.textEdit(node, params.document, keyword);
+
+        return {
+          label: keyword,
+          kind: CompletionItemKind.Keyword,
+          documentation: {
+            kind: 'markdown',
+            value: description,
+          },
+          insertTextFormat: format,
+          // We want to force these options to appear first in the list given
+          // the context that they are being requested in.
+          sortText: `1${keyword}`,
+          textEdit,
+        };
+      });
+  }
+
+  textEdit(
+    node: LiquidVariableLookup,
+    document: AugmentedLiquidSourceCode,
+    name: string,
+  ): {
+    textEdit: TextEdit;
+    format: InsertTextFormat;
+  } {
+    const remainingText = document.source.slice(node.position.end);
+
+    // Match all the way up to the termination of the parameter which could be
+    // another parameter (`,`), filter (`|`), or the end of a liquid statement.
+    const match = remainingText.match(/^(.*?)\s*(?=,|\||-?\}\}|-?\%\})|^(.*)$/);
+    const offset = match ? match[0].trimEnd().length : remainingText.length;
+    const existingParameterOffset = remainingText.match(/[^a-zA-Z]/)?.index ?? remainingText.length;
+
+    let start = document.textDocument.positionAt(node.position.start);
+    let end = document.textDocument.positionAt(node.position.end + offset);
+    let newText = name === 'closest' ? `${name}.` : `${name}: '$1'`;
+    let format = name === 'closest' ? InsertTextFormat.PlainText : InsertTextFormat.Snippet;
+
+    // If the cursor is inside the parameter or at the end and it's the same
+    // value as the one we're offering a completion for then we want to restrict
+    // the insert to just the name of the parameter.
+    // e.g. `{% content_for "block", t█ype: "button" %}` and we're offering `type`
+    if (node.name + remainingText.slice(0, existingParameterOffset) == name) {
+      newText = name;
+      format = InsertTextFormat.PlainText;
+      end = document.textDocument.positionAt(node.position.end + existingParameterOffset);
+    }
+
+    // If the cursor is at the beginning of the string we can consider all
+    // options and should not replace any text.
+    // e.g. `{% content_for "block", █type: "button" %}`
+    // e.g. `{% content_for "block", █ %}`
+    if (node.name === CURSOR) {
+      end = start;
+
+      // If we're inserting text in front of an existing parameter then we need
+      // to add a comma to separate them.
+      if (existingParameterOffset > 0) {
+        newText += ', ';
+      }
+    }
+
+    return {
+      textEdit: TextEdit.replace(
+        {
+          start,
+          end,
+        },
+        newText,
+      ),
+      format,
+    };
+  }
+}

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.ts
@@ -10,13 +10,18 @@ export class ObjectCompletionProvider implements Provider {
   async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
     if (!params.completionContext) return [];
 
-    const { partialAst, node } = params.completionContext;
+    const { partialAst, node, ancestors } = params.completionContext;
     if (!node || node.type !== NodeTypes.VariableLookup) {
       return [];
     }
 
     if (!node.name || node.lookups.length > 0) {
       // We only do top level in this one.
+      return [];
+    }
+
+    // ContentFor uses VariableLookup to support completion of NamedParams.
+    if (ancestors.at(-1)?.type === NodeTypes.ContentForMarkup) {
       return [];
     }
 

--- a/packages/theme-language-server-common/src/completions/providers/data/contentForParameterCompletionOptions.ts
+++ b/packages/theme-language-server-common/src/completions/providers/data/contentForParameterCompletionOptions.ts
@@ -1,0 +1,9 @@
+/**
+ * These definitions are not currently available in the generated Liquid Docs
+ * so we're hardcoding them here in the interim.
+ */
+export const DEFAULT_COMPLETION_OPTIONS: { [key: string]: string } = {
+  type: "The type (name) of an existing theme block in your theme’s /blocks folder. Only applicable when `content_type` is 'block'.",
+  id: "A unique identifier and literal string within the section or block that contains the static blocks. Only applicable when `content_type` is 'block'.",
+  closest: 'A path that provides a way to access the closest resource of a given type.',
+};

--- a/packages/theme-language-server-common/src/completions/providers/index.ts
+++ b/packages/theme-language-server-common/src/completions/providers/index.ts
@@ -1,5 +1,6 @@
 export { ContentForCompletionProvider } from './ContentForCompletionProvider';
 export { ContentForBlockTypeCompletionProvider } from './ContentForBlockTypeCompletionProvider';
+export { ContentForParameterCompletionProvider } from './ContentForParameterCompletionProvider';
 export { HtmlTagCompletionProvider } from './HtmlTagCompletionProvider';
 export { HtmlAttributeCompletionProvider } from './HtmlAttributeCompletionProvider';
 export { HtmlAttributeValueCompletionProvider } from './HtmlAttributeValueCompletionProvider';


### PR DESCRIPTION
## What are you adding in this PR?

Part of https://github.com/Shopify/theme-tools/issues/570

## What's next? Any followup issues?

- Update shopify.dev so that `content_for` tag has `content.*` param

## Tophatting

- Clone code
- Open VSCode and press F5
- Open a Theme in the new window
- Have a block in the `blocks` folder (e.g. `blocks/example.liquid`
- In a section file, create a content_for 'block' tag
  - `{% content_for 'block' %}` - if you used auto-completion, the `id` and `type` should be prepopulated
- Try adding a `context.` param

NOTE: You can always force trigger auto-completion from VSCode using ctrl + space 

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
