### PR TITLE
Update repository URL definition to be case sensitive

### DIFF
--- a/.changeset/honest-apricots-pay.md
+++ b/.changeset/honest-apricots-pay.md
@@ -1,0 +1,16 @@
+---
+'@shopify/theme-language-server-browser': patch
+'@shopify/theme-language-server-common': patch
+'@shopify/codemirror-language-client': patch
+'@shopify/theme-language-server-node': patch
+'@shopify/theme-check-docs-updater': patch
+'@shopify/prettier-plugin-liquid': patch
+'@shopify/theme-check-browser': patch
+'@shopify/liquid-html-parser': patch
+'@shopify/theme-check-common': patch
+'@shopify/theme-check-node': patch
+'theme-check-vscode': patch
+'@shopify/lang-jsonc': patch
+---
+
+Update repository URL for all packages to be case sensitive

--- a/packages/codemirror-language-client/package.json
+++ b/packages/codemirror-language-client/package.json
@@ -6,11 +6,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/codemirror-language-client#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/codemirror-language-client"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "license": "MIT",
   "main": "./dist/umd/index.js",

--- a/packages/lang-jsonc/package.json
+++ b/packages/lang-jsonc/package.json
@@ -10,11 +10,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/lang-jsonc#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/lang-jsonc"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "main": "./dist/umd/index.js",
   "typings": "./dist/umd/index.js",

--- a/packages/liquid-html-parser/package.json
+++ b/packages/liquid-html-parser/package.json
@@ -6,11 +6,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/liquid-html-parser#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/liquid-html-parser"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/prettier-plugin-liquid/package.json
+++ b/packages/prettier-plugin-liquid/package.json
@@ -6,11 +6,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/prettier-plugin-liquid#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/prettier-plugin-liquid"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/theme-check-browser/package.json
+++ b/packages/theme-check-browser/package.json
@@ -8,11 +8,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/theme-check-browser#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/theme-check-browser"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -8,11 +8,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/theme-check-common#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/theme-check-common"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -8,11 +8,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/theme-check-docs-updater#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/theme-check-docs-updater"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/theme-check-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/theme-check-node"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/theme-language-server-browser/package.json
+++ b/packages/theme-language-server-browser/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/theme-language-server-browser#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/theme-language-server-browser"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/theme-language-server-common/package.json
+++ b/packages/theme-language-server-common/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/theme-language-server-common#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/theme-language-server-common"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/theme-language-server-node/package.json
+++ b/packages/theme-language-server-node/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/theme-language-server-node#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/theme-language-server-node"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -4,11 +4,11 @@
   "homepage": "https://github.com/Shopify/theme-tools/tree/main/packages/vscode-extension#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shopify/theme-tools.git",
+    "url": "https://github.com/Shopify/theme-tools.git",
     "directory": "packages/vscode-extension"
   },
   "bugs": {
-    "url": "https://github.com/shopify/theme-tools/issues"
+    "url": "https://github.com/Shopify/theme-tools/issues"
   },
   "version": "3.5.2",
   "publisher": "Shopify",


### PR DESCRIPTION
Without this we'll fail to publish to NPM due to a provenance failure that looks like this:

```
error an error occurred while publishing
@shopify/theme-language-server-browser: E422 422 Unprocessable Entity -
PUT https://registry.npmjs.org/@shopify%2ftheme-language-server-browser
- Error verifying sigstore provenance bundle: Failed to validate
  repository information: package.json: "repository.url" is
"git+https://github.com/shopify/theme-tools.git", expected to match
"https://github.com/Shopify/theme-tools" from provenance
```
