### PR TITLE
[LiquidDoc] Parsing support for optional parameters and default values

### DIFF
--- a/.changeset/chatty-scissors-relax.md
+++ b/.changeset/chatty-scissors-relax.md
@@ -1,0 +1,6 @@
+---
+'@shopify/liquid-html-parser': minor
+'theme-check-vscode': minor
+---
+
+Add support for parsing optional parameters in LiquidDoc. Optional parameters are designated by wrapping the name in square brackets, and can accept a default value (e.g. `@param [parameter_name=default]`).

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -398,14 +398,28 @@ LiquidDoc <: Helpers {
   strictSpace = " " | "\t"
   // We use this as an escape hatch to stop matching TextNode and try again when one of these characters is encountered 
   openControl:= "@" | end
+  // We use this to map text values into a textNodes via mappings in stage-1-cst.ts
+  textValue = identifierCharacter+
 
   fallbackNode = "@" anyExceptStar<endOfParam>
-  paramNode = "@param" strictSpace* paramType? strictSpace* paramName (strictSpace* "-")? strictSpace* paramDescription
+  paramNode = "@param" strictSpace* paramType? strictSpace* (paramName | optionalParamName) (strictSpace* "-")? strictSpace* paramDescription
+
   paramType = "{" strictSpace* paramTypeContent strictSpace* "}"
   paramTypeContent = anyExceptStar<("}"| strictSpace)>
-  paramName = identifierCharacter+
-  paramDescription = anyExceptStar<endOfParam>
+
+  paramDescription = (~"]" anyExceptStar<endOfParam>)
   endOfParam = strictSpace* (newline | end)
+
+  // Required parameter name - e.g. "paramName"
+  paramName = textValue
+  // Optional parameter name - e.g. "[paramName]"
+  optionalParamName = "[" strictSpace* optionalParamNameContent strictSpace* "]"
+  // Content of an optional parameter name - e.g. "paramName=defaultValue"
+  optionalParamNameContent = strictSpace* textValue strictSpace* optionalParamNameDefaultValue?
+  // Default value of an optional parameter name - e.g. "=defaultValue"
+  optionalParamNameDefaultValue = "=" strictSpace* optionalParamNameDefaultContent
+  optionalParamNameDefaultContent = anyExceptPlus<endOfOptionalParamNameDefaultValue>
+  endOfOptionalParamNameDefaultValue = strictSpace* "]"
 }
 
 LiquidHTML <: Liquid {

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1011,21 +1011,340 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.children.0.value').to.equal('@param');
         });
 
-        it('should parse @param with name', () => {
-          const testStr = `{% doc %} @param paramWithNoDescription {% enddoc %}`;
+        it('should parse required @param', () => {
+          const testStr = `{% doc %}
+            @param paramWithNameOnly
+            @param paramWithNoType - this has no type
+            @param {String} paramWithNoDescription
+            @param {String} paramWithDescriptionAndType - param with description and type
+          {% enddoc %}`;
           cst = toCST(testStr);
 
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocParamNode');
-          expectPath(cst, '0.children.0.paramName.type').to.equal('TextNode');
-          expectPath(cst, '0.children.0.paramName.value').to.equal('paramWithNoDescription');
+          expectPath(cst, '0.children.0.paramName.type').to.equal('LiquidDocParamNameNode');
+          expectPath(cst, '0.children.0.paramName.paramNameContent.value').to.equal(
+            'paramWithNameOnly',
+          );
+          expectPath(cst, '0.children.0.paramName.required').to.equal(true);
           expectPath(cst, '0.children.0.paramName.locStart').to.equal(
-            testStr.indexOf('paramWithNoDescription'),
+            testStr.indexOf('paramWithNameOnly'),
           );
           expectPath(cst, '0.children.0.paramName.locEnd').to.equal(
-            testStr.indexOf('paramWithNoDescription') + 'paramWithNoDescription'.length,
+            testStr.indexOf('paramWithNameOnly') + 'paramWithNameOnly'.length,
           );
-          expectPath(cst, '0.children.0.paramDescription.type').to.equal('TextNode');
+
+          expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.1.paramName.paramNameContent.value').to.equal(
+            'paramWithNoType',
+          );
+          expectPath(cst, '0.children.1.paramName.required').to.equal(true);
+          expectPath(cst, '0.children.1.paramType').to.be.null;
+          expectPath(cst, '0.children.1.paramDescription.value').to.equal('this has no type');
+
+          expectPath(cst, '0.children.2.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.2.paramName.paramNameContent.value').to.equal(
+            'paramWithNoDescription',
+          );
+          expectPath(cst, '0.children.2.paramName.required').to.equal(true);
+          expectPath(cst, '0.children.2.paramType.value').to.equal('String');
+          expectPath(cst, '0.children.2.paramDescription.value').to.equal('');
+
+          expectPath(cst, '0.children.3.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.3.paramName.paramNameContent.value').to.equal(
+            'paramWithDescriptionAndType',
+          );
+          expectPath(cst, '0.children.3.paramName.required').to.equal(true);
+          expectPath(cst, '0.children.3.paramType.value').to.equal('String');
+          expectPath(cst, '0.children.3.paramDescription.value').to.equal(
+            'param with description and type',
+          );
+        });
+
+        it('should parse optional @param', () => {
+          const testStr = `{% doc %}
+          @param [paramWithNameOnly]
+          @param [paramWithNoType] - this has a description
+          @param {String} [paramWithNoDescription]
+          @param {String} [paramWithDescriptionAndType] - this has a description and type
+          {% enddoc %}`;
+          cst = toCST(testStr);
+
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.0.paramName.type').to.equal('LiquidDocParamNameNode');
+          expectPath(cst, '0.children.0.paramName.paramNameContent.value').to.equal(
+            'paramWithNameOnly',
+          );
+          expectPath(cst, '0.children.0.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.0.paramName.locStart').to.equal(
+            testStr.indexOf('paramWithNameOnly'),
+          );
+          expectPath(cst, '0.children.0.paramName.locEnd').to.equal(
+            testStr.indexOf('paramWithNameOnly') + 'paramWithNameOnly'.length,
+          );
+
+          expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.1.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.1.paramName.paramNameContent.value').to.equal(
+            'paramWithNoType',
+          );
+          expectPath(cst, '0.children.1.paramDescription.value').to.equal('this has a description');
+          expectPath(cst, '0.children.1.paramType').to.be.null;
+
+          expectPath(cst, '0.children.2.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.2.paramName.paramNameContent.value').to.equal(
+            'paramWithNoDescription',
+          );
+          expectPath(cst, '0.children.2.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.2.paramType.value').to.equal('String');
+          expectPath(cst, '0.children.2.paramDescription.value').to.equal('');
+
+          expectPath(cst, '0.children.3.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.3.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.3.paramName.paramNameContent.value').to.equal(
+            'paramWithDescriptionAndType',
+          );
+          expectPath(cst, '0.children.3.paramType.value').to.equal('String');
+          expectPath(cst, '0.children.3.paramDescription.value').to.equal(
+            'this has a description and type',
+          );
+        });
+
+        it('should parse optional @param with default value', () => {
+          const testStr = `{% doc %}
+          @param [paramWithNameOnly=defaultValue1]
+          @param [paramWithNoType=defaultValue2] - this has a description
+          @param {String} [paramWithNoDescription=defaultValue3]
+          @param {String} [paramWithDescriptionAndType=defaultValue4] - this has a description and type
+          {% enddoc %}`;
+          cst = toCST(testStr);
+
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.0.paramName.paramNameContent.value').to.equal(
+            'paramWithNameOnly',
+          );
+          expectPath(cst, '0.children.0.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.0.paramName.defaultValue.value').to.equal('defaultValue1');
+          expectPath(cst, '0.children.0.paramName.defaultValue.locStart').to.equal(
+            testStr.indexOf('defaultValue1'),
+          );
+          expectPath(cst, '0.children.0.paramName.defaultValue.locEnd').to.equal(
+            testStr.indexOf('defaultValue1') + 'defaultValue1'.length,
+          );
+          expectPath(cst, '0.children.0.paramType').to.be.null;
           expectPath(cst, '0.children.0.paramDescription.value').to.equal('');
+
+          expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.1.paramName.paramNameContent.value').to.equal(
+            'paramWithNoType',
+          );
+          expectPath(cst, '0.children.1.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.1.paramName.defaultValue.value').to.equal('defaultValue2');
+          expectPath(cst, '0.children.1.paramType').to.be.null;
+          expectPath(cst, '0.children.1.paramDescription.value').to.equal('this has a description');
+
+          expectPath(cst, '0.children.2.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.2.paramName.paramNameContent.value').to.equal(
+            'paramWithNoDescription',
+          );
+          expectPath(cst, '0.children.2.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.2.paramName.defaultValue.value').to.equal('defaultValue3');
+          expectPath(cst, '0.children.2.paramType.value').to.equal('String');
+          expectPath(cst, '0.children.2.paramDescription.value').to.equal('');
+
+          expectPath(cst, '0.children.3.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.3.paramName.paramNameContent.value').to.equal(
+            'paramWithDescriptionAndType',
+          );
+          expectPath(cst, '0.children.3.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.3.paramName.defaultValue.value').to.equal('defaultValue4');
+          expectPath(cst, '0.children.3.paramType.value').to.equal('String');
+          expectPath(cst, '0.children.3.paramDescription.value').to.equal(
+            'this has a description and type',
+          );
+        });
+
+        it('should strip whitespace in from optional @param name values', () => {
+          const testStr = `{% doc %}
+          @param [    paramWithWhitespace       ]
+          @param [  optionalParamWithDefaultAndWhiteSpace=secondDefaultValue    ]
+          @param [  paramWithDefaultWhiteSpace    =    12px]
+          {% enddoc %}`;
+          cst = toCST(testStr);
+
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.0.paramName.type').to.equal('LiquidDocParamNameNode');
+          expectPath(cst, '0.children.0.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.0.paramName.locStart').to.equal(
+            testStr.indexOf('paramWithWhitespace'),
+          );
+          expectPath(cst, '0.children.0.paramName.locEnd').to.equal(
+            testStr.indexOf('paramWithWhitespace') + 'paramWithWhitespace       '.length,
+          );
+          expectPath(cst, '0.children.0.paramName.paramNameContent.value').to.equal(
+            'paramWithWhitespace',
+          );
+          expectPath(cst, '0.children.0.paramName.paramNameContent.locStart').to.equal(
+            testStr.indexOf('paramWithWhitespace'),
+          );
+          expectPath(cst, '0.children.0.paramName.paramNameContent.locEnd').to.equal(
+            testStr.indexOf('paramWithWhitespace') + 'paramWithWhitespace'.length,
+          );
+
+          expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.1.paramName.paramNameContent.value').to.equal(
+            'optionalParamWithDefaultAndWhiteSpace',
+          );
+          expectPath(cst, '0.children.1.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.1.paramName.defaultValue.type').to.equal('TextNode');
+          expectPath(cst, '0.children.1.paramName.defaultValue.value').to.equal(
+            'secondDefaultValue',
+          );
+          expectPath(cst, '0.children.1.paramName.defaultValue.locStart').to.equal(
+            testStr.indexOf('secondDefaultValue'),
+          );
+          expectPath(cst, '0.children.1.paramName.defaultValue.locEnd').to.equal(
+            testStr.indexOf('secondDefaultValue') + 'secondDefaultValue'.length,
+          );
+
+          expectPath(cst, '0.children.2.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.2.paramName.paramNameContent.value').to.equal(
+            'paramWithDefaultWhiteSpace',
+          );
+          expectPath(cst, '0.children.2.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.2.paramName.defaultValue.value').to.equal('12px');
+          expectPath(cst, '0.children.2.paramName.defaultValue.locStart').to.equal(
+            testStr.indexOf('12px'),
+          );
+          expectPath(cst, '0.children.2.paramName.defaultValue.locEnd').to.equal(
+            testStr.indexOf('12px') + '12px'.length,
+          );
+        });
+
+        it('should parse optional params with default values', () => {
+          const testStr = `{% doc %} 
+          @param {Number} [border_radius =    12 ]
+          @param {String} [border_color =red ]
+          @param {String} [punctuated_value = hello-world! ]
+          @param {String} [default_with_space = John Doe]
+          {% enddoc %}`;
+          cst = toCST(testStr);
+
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.0.paramName.paramNameContent.value').to.equal(
+            'border_radius',
+          );
+          expectPath(cst, '0.children.0.paramName.required').to.equal(false);
+
+          expectPath(cst, '0.children.0.paramName.defaultValue.type').to.equal('TextNode');
+          expectPath(cst, '0.children.0.paramName.defaultValue.value').to.equal('12');
+          expectPath(cst, '0.children.0.paramName.defaultValue.locStart').to.equal(
+            testStr.indexOf('12'),
+          );
+          expectPath(cst, '0.children.0.paramName.defaultValue.locEnd').to.equal(
+            testStr.indexOf('12') + '12'.length,
+          );
+
+          expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.1.paramName.paramNameContent.value').to.equal('border_color');
+          expectPath(cst, '0.children.1.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.1.paramName.defaultValue.type').to.equal('TextNode');
+          expectPath(cst, '0.children.1.paramName.defaultValue.value').to.equal('red');
+          expectPath(cst, '0.children.1.paramName.defaultValue.locStart').to.equal(
+            testStr.indexOf('red'),
+          );
+          expectPath(cst, '0.children.1.paramName.defaultValue.locEnd').to.equal(
+            testStr.indexOf('red') + 'red'.length,
+          );
+
+          expectPath(cst, '0.children.2.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.2.paramName.paramNameContent.value').to.equal(
+            'punctuated_value',
+          );
+          expectPath(cst, '0.children.2.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.2.paramName.defaultValue.type').to.equal('TextNode');
+          expectPath(cst, '0.children.2.paramName.defaultValue.value').to.equal('hello-world!');
+          expectPath(cst, '0.children.2.paramName.defaultValue.locStart').to.equal(
+            testStr.indexOf('hello-world'),
+          );
+
+          expectPath(cst, '0.children.3.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.3.paramName.paramNameContent.value').to.equal(
+            'default_with_space',
+          );
+          expectPath(cst, '0.children.3.paramName.required').to.equal(false);
+          expectPath(cst, '0.children.3.paramName.defaultValue.type').to.equal('TextNode');
+          expectPath(cst, '0.children.3.paramName.defaultValue.value').to.equal('John Doe');
+          expectPath(cst, '0.children.3.paramName.defaultValue.locStart').to.equal(
+            testStr.indexOf('John Doe'),
+          );
+          expectPath(cst, '0.children.3.paramName.defaultValue.locEnd').to.equal(
+            testStr.indexOf('John Doe') + 'John Doe'.length,
+          );
+        });
+
+        it('should parse @param with missing optional fallback Text Nodes', () => {
+          const testStr = `{% doc %} 
+            @param paramWithMissingHeadDelim] 
+            @param [paramWithMissingTailDelim
+            @param missingHeadWithDescription] - description value
+            @param [missingTailWithDescription - description value
+            @param [too many words] description
+          {% enddoc %}`;
+          cst = toCST(testStr);
+
+          expectPath(cst, '0.children.0.type').to.equal('TextNode');
+          expectPath(cst, '0.children.0.value').to.equal('@param paramWithMissingHeadDelim]');
+          expectPath(cst, '0.children.0.locStart').to.equal(
+            testStr.indexOf('@param paramWithMissingHeadDelim]'),
+          );
+          expectPath(cst, '0.children.0.locEnd').to.equal(
+            testStr.indexOf('@param paramWithMissingHeadDelim]') +
+              '@param paramWithMissingHeadDelim]'.length,
+          );
+
+          expectPath(cst, '0.children.1.type').to.equal('TextNode');
+          expectPath(cst, '0.children.1.value').to.equal('@param [paramWithMissingTailDelim');
+          expectPath(cst, '0.children.1.locStart').to.equal(
+            testStr.indexOf('@param [paramWithMissingTailDelim'),
+          );
+          expectPath(cst, '0.children.1.locEnd').to.equal(
+            testStr.indexOf('@param [paramWithMissingTailDelim') +
+              '@param [paramWithMissingTailDelim'.length,
+          );
+
+          expectPath(cst, '0.children.2.type').to.equal('TextNode');
+          expectPath(cst, '0.children.2.value').to.equal(
+            '@param missingHeadWithDescription] - description value',
+          );
+          expectPath(cst, '0.children.2.locStart').to.equal(
+            testStr.indexOf('@param missingHeadWithDescription] - description value'),
+          );
+          expectPath(cst, '0.children.2.locEnd').to.equal(
+            testStr.indexOf('@param missingHeadWithDescription] - description value') +
+              '@param missingHeadWithDescription] - description value'.length,
+          );
+
+          expectPath(cst, '0.children.3.type').to.equal('TextNode');
+          expectPath(cst, '0.children.3.value').to.equal(
+            '@param [missingTailWithDescription - description value',
+          );
+          expectPath(cst, '0.children.3.locStart').to.equal(
+            testStr.indexOf('@param [missingTailWithDescription - description value'),
+          );
+          expectPath(cst, '0.children.3.locEnd').to.equal(
+            testStr.indexOf('@param [missingTailWithDescription - description value') +
+              '@param [missingTailWithDescription - description value'.length,
+          );
+
+          expectPath(cst, '0.children.4.type').to.equal('TextNode');
+          expectPath(cst, '0.children.4.value').to.equal('@param [too many words] description');
+          expectPath(cst, '0.children.4.locStart').to.equal(
+            testStr.indexOf('@param [too many words] description'),
+          );
+          expectPath(cst, '0.children.4.locEnd').to.equal(
+            testStr.indexOf('@param [too many words] description') +
+              '@param [too many words] description'.length,
+          );
         });
 
         it('should parse @param with name and description', () => {
@@ -1033,8 +1352,11 @@ describe('Unit: Stage 1 (CST)', () => {
           cst = toCST(testStr);
 
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocParamNode');
-          expectPath(cst, '0.children.0.paramName.type').to.equal('TextNode');
-          expectPath(cst, '0.children.0.paramName.value').to.equal('paramWithDescription');
+          expectPath(cst, '0.children.0.paramName.type').to.equal('LiquidDocParamNameNode');
+          expectPath(cst, '0.children.0.paramName.paramNameContent.value').to.equal(
+            'paramWithDescription',
+          );
+          expectPath(cst, '0.children.0.paramName.required').to.equal(true);
           expectPath(cst, '0.children.0.paramDescription.type').to.equal('TextNode');
           expectPath(cst, '0.children.0.paramDescription.value').to.equal('param with description');
         });
@@ -1044,7 +1366,11 @@ describe('Unit: Stage 1 (CST)', () => {
           cst = toCST(testStr);
 
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocParamNode');
-          expectPath(cst, '0.children.0.paramName.value').to.equal('paramWithType');
+          expectPath(cst, '0.children.0.paramName.type').to.equal('LiquidDocParamNameNode');
+          expectPath(cst, '0.children.0.paramName.paramNameContent.value').to.equal(
+            'paramWithType',
+          );
+          expectPath(cst, '0.children.0.paramName.required').to.equal(true);
 
           expectPath(cst, '0.children.0.paramType.type').to.equal('TextNode');
           expectPath(cst, '0.children.0.paramType.value').to.equal('String');
@@ -1059,7 +1385,9 @@ describe('Unit: Stage 1 (CST)', () => {
           cst = toCST(testStr);
 
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocParamNode');
-          expectPath(cst, '0.children.0.paramName.value').to.equal('paramWithType');
+          expectPath(cst, '0.children.0.paramName.paramNameContent.value').to.equal(
+            'paramWithType',
+          );
 
           expectPath(cst, '0.children.0.paramType.type').to.equal('TextNode');
           expectPath(cst, '0.children.0.paramType.value').to.equal('String');
@@ -1098,11 +1426,11 @@ describe('Unit: Stage 1 (CST)', () => {
           cst = toCST(testStr);
 
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocParamNode');
-          expectPath(cst, '0.children.0.paramName.value').to.equal('param1');
+          expectPath(cst, '0.children.0.paramName.paramNameContent.value').to.equal('param1');
           expectPath(cst, '0.children.0.paramDescription.value').to.equal('first parameter');
 
           expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
-          expectPath(cst, '0.children.1.paramName.value').to.equal('param2');
+          expectPath(cst, '0.children.1.paramName.paramNameContent.value').to.equal('param2');
           expectPath(cst, '0.children.1.paramDescription.value').to.equal('second parameter');
 
           expectPath(cst, '0.children.2.type').to.equal('TextNode');
@@ -1304,8 +1632,8 @@ describe('Unit: Stage 1 (CST)', () => {
           { type: 'AttrSingleQuoted', name: 'single', quote: '‘' },
           { type: 'AttrSingleQuoted', name: 'single', quote: '’' },
           { type: 'AttrDoubleQuoted', name: 'double', quote: '"' },
-          { type: 'AttrDoubleQuoted', name: 'double', quote: '“' },
-          { type: 'AttrDoubleQuoted', name: 'double', quote: '”' },
+          { type: 'AttrDoubleQuoted', name: 'double', quote: '"' },
+          { type: 'AttrDoubleQuoted', name: 'double', quote: '"' },
           { type: 'AttrUnquoted', name: 'unquoted', quote: '' },
         ].forEach((testConfig) => {
           [

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -85,6 +85,7 @@ export enum ConcreteNodeTypes {
   ContentForNamedArgument = 'ContentForNamedArgument',
 
   LiquidDocParamNode = 'LiquidDocParamNode',
+  LiquidDocParamNameNode = 'LiquidDocParamNameNode',
 }
 
 export const LiquidLiteralValues = {
@@ -110,9 +111,16 @@ export interface ConcreteBasicNode<T> {
 export interface ConcreteLiquidDocParamNode
   extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocParamNode> {
   name: 'param';
-  paramName: ConcreteTextNode;
+  paramName: ConcreteLiquidDocParamNameNode;
   paramDescription: ConcreteTextNode | null;
   paramType: ConcreteTextNode | null;
+}
+
+export interface ConcreteLiquidDocParamNameNode
+  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocParamNameNode> {
+  required: boolean;
+  defaultValue: ConcreteTextNode | null;
+  paramNameContent: ConcreteTextNode;
 }
 
 export interface ConcreteHtmlNodeBase<T> extends ConcreteBasicNode<T> {
@@ -1344,7 +1352,28 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
     },
     paramType: 2,
     paramTypeContent: textNode,
-    paramName: textNode,
+    paramName: {
+      type: ConcreteNodeTypes.LiquidDocParamNameNode,
+      paramNameContent: 0,
+      locStart,
+      locEnd,
+      source,
+      required: true,
+      defaultValue: null,
+    },
+    optionalParamName: 2,
+    optionalParamNameContent: {
+      type: ConcreteNodeTypes.LiquidDocParamNameNode,
+      paramNameContent: 1,
+      required: false,
+      defaultValue: 3,
+      locStart,
+      locEnd,
+      source,
+    },
+    optionalParamNameDefaultValue: 2,
+    optionalParamNameDefaultContent: textNode,
+    textValue: textNode,
     paramDescription: textNode,
     fallbackNode: textNode,
   };

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1220,56 +1220,72 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.markup.1.children.0.children.1.markup.name').to.eql('var3');
     });
 
-    it(`should parse doc tags`, () => {
-      ast = toLiquidAST(`{% doc %}{% enddoc %}`);
-      expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
-      expectPath(ast, 'children.0.name').to.eql('doc');
-      expectPath(ast, 'children.0.markup').toEqual('');
-      expectPath(ast, 'children.0.body.value').to.eql('');
-      expectPath(ast, 'children.0.body.type').toEqual('RawMarkup');
-      expectPath(ast, 'children.0.body.nodes').toEqual([]);
+    describe('LiquidDoc', () => {
+      it(`should parse liquid doc tags`, () => {
+        ast = toLiquidAST(`{% doc %}{% enddoc %}`);
+        expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
+        expectPath(ast, 'children.0.name').to.eql('doc');
+        expectPath(ast, 'children.0.markup').toEqual('');
+        expectPath(ast, 'children.0.body.value').to.eql('');
+        expectPath(ast, 'children.0.body.type').toEqual('RawMarkup');
+        expectPath(ast, 'children.0.body.nodes').toEqual([]);
 
-      ast = toLiquidAST(`
+        ast = toLiquidAST(`
         {% doc -%}
-        @param paramWithNoType
+        @param requiredParamWithNoType
+        @param [optionalParameter] - optional parameter description
         @param {String} paramWithDescription - param with description and \`punctation\`. This is still a valid param description.
         @param {String} paramWithNoDescription
         @unsupported this node falls back to a text node
+        @param [optionalParameterWithDefault=defaultValue] - optional parameter description with default
+        @param {String} [optionalParameterWithDefaultAndType=defaultValue]
         {%- enddoc %}
       `);
-      expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
-      expectPath(ast, 'children.0.name').to.eql('doc');
+        expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
+        expectPath(ast, 'children.0.name').to.eql('doc');
 
-      expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocParamNode');
-      expectPath(ast, 'children.0.body.nodes.0.name').to.eql('param');
-      expectPath(ast, 'children.0.body.nodes.0.paramName.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.0.paramName.value').to.eql('paramWithNoType');
-      expectPath(ast, 'children.0.body.nodes.0.paramType').to.be.null;
-      expectPath(ast, 'children.0.body.nodes.0.paramDescription').to.be.null;
+        expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocParamNode');
+        expectPath(ast, 'children.0.body.nodes.0.name').to.eql('param');
+        expectPath(ast, 'children.0.body.nodes.0.required').to.eql(true);
+        expectPath(ast, 'children.0.body.nodes.0.paramName.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.body.nodes.0.paramName.value').to.eql(
+          'requiredParamWithNoType',
+        );
+        expectPath(ast, 'children.0.body.nodes.0.paramType').to.be.null;
+        expectPath(ast, 'children.0.body.nodes.0.paramDescription').to.be.null;
 
-      expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocParamNode');
-      expectPath(ast, 'children.0.body.nodes.1.name').to.eql('param');
-      expectPath(ast, 'children.0.body.nodes.1.paramName.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.1.paramName.value').to.eql('paramWithDescription');
-      expectPath(ast, 'children.0.body.nodes.1.paramDescription.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.1.paramDescription.value').to.eql(
-        'param with description and `punctation`. This is still a valid param description.',
-      );
-      expectPath(ast, 'children.0.body.nodes.1.paramType.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.1.paramType.value').to.eql('String');
+        expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocParamNode');
+        expectPath(ast, 'children.0.body.nodes.1.name').to.eql('param');
+        expectPath(ast, 'children.0.body.nodes.1.required').to.eql(false);
+        expectPath(ast, 'children.0.body.nodes.1.paramName.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.body.nodes.1.paramName.value').to.eql('optionalParameter');
+        expectPath(ast, 'children.0.body.nodes.1.paramDescription.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.body.nodes.1.paramDescription.value').to.eql(
+          'optional parameter description',
+        );
+        expectPath(ast, 'children.0.body.nodes.1.paramType').to.be.null;
+        expectPath(ast, 'children.0.body.nodes.1.paramType').to.be.null;
 
-      expectPath(ast, 'children.0.body.nodes.2.type').to.eql('LiquidDocParamNode');
-      expectPath(ast, 'children.0.body.nodes.2.name').to.eql('param');
-      expectPath(ast, 'children.0.body.nodes.2.paramName.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.2.paramName.value').to.eql('paramWithNoDescription');
-      expectPath(ast, 'children.0.body.nodes.2.paramDescription').to.be.null;
-      expectPath(ast, 'children.0.body.nodes.2.paramType.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.2.paramType.value').to.eql('String');
+        expectPath(ast, 'children.0.body.nodes.2.type').to.eql('LiquidDocParamNode');
+        expectPath(ast, 'children.0.body.nodes.2.name').to.eql('param');
+        expectPath(ast, 'children.0.body.nodes.2.required').to.eql(true);
+        expectPath(ast, 'children.0.body.nodes.2.paramName.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.body.nodes.2.paramName.value').to.eql('paramWithDescription');
+        expectPath(ast, 'children.0.body.nodes.2.paramDescription.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.body.nodes.2.paramDescription.value').to.eql(
+          'param with description and `punctation`. This is still a valid param description.',
+        );
+        expectPath(ast, 'children.0.body.nodes.2.paramType.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.body.nodes.2.paramType.value').to.eql('String');
 
-      expectPath(ast, 'children.0.body.nodes.3.type').to.eql('TextNode');
-      expectPath(ast, 'children.0.body.nodes.3.value').to.eql(
-        '@unsupported this node falls back to a text node',
-      );
+        expectPath(ast, 'children.0.body.nodes.3.type').to.eql('LiquidDocParamNode');
+        expectPath(ast, 'children.0.body.nodes.3.name').to.eql('param');
+        expectPath(ast, 'children.0.body.nodes.2.paramName.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.body.nodes.3.paramName.value').to.eql('paramWithNoDescription');
+        expectPath(ast, 'children.0.body.nodes.3.paramDescription').to.be.null;
+        expectPath(ast, 'children.0.body.nodes.3.paramType.type').to.eql('TextNode');
+        expectPath(ast, 'children.0.body.nodes.3.paramType.value').to.eql('String');
+      });
     });
 
     it('should parse unclosed tables with assignments', () => {

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -755,7 +755,7 @@ export interface TextNode extends ASTNode<NodeTypes.TextNode> {
   value: string;
 }
 
-/** Represents a `@param` node in a LiquidDoc comment - `@param paramName {paramType} - paramDescription` */
+/** Represents a `@param` node in a LiquidDoc comment - `@param {paramType} [paramName=defaultValue]  - paramDescription` */
 export interface LiquidDocParamNode extends ASTNode<NodeTypes.LiquidDocParamNode> {
   name: 'param';
   /** The name of the parameter (e.g. "product") */
@@ -764,6 +764,10 @@ export interface LiquidDocParamNode extends ASTNode<NodeTypes.LiquidDocParamNode
   paramDescription: TextNode | null;
   /** Optional type annotation for the parameter (e.g. "{string}", "{number}") */
   paramType: TextNode | null;
+  /** Whether this parameter must be passed when using the snippet */
+  required: boolean;
+  /** The default value of the parameter (e.g. "10") - null if the parameter is required or has no default value */
+  defaultValue: TextNode | null;
 }
 export interface ASTNode<T> {
   /**
@@ -1285,14 +1289,11 @@ function buildAst(
           name: node.name,
           position: position(node),
           source: node.source,
-          paramName: {
-            type: NodeTypes.TextNode,
-            value: node.paramName.value,
-            position: position(node.paramName),
-            source: node.paramName.source,
-          },
+          paramName: toTextNode(node.paramName.paramNameContent),
           paramDescription: toNullableTextNode(node.paramDescription),
           paramType: toNullableTextNode(node.paramType),
+          required: node.paramName.required,
+          defaultValue: toNullableTextNode(node.paramName.defaultValue),
         });
         break;
       }


### PR DESCRIPTION
## What are you adding in this PR?

Closes [533](https://github.com/Shopify/developer-tools-team/issues/533)
Closes [534](https://github.com/Shopify/developer-tools-team/issues/534)

Adds `LiquidDoc` parsing support to allow users to define optional parameters and default values.

**Optional Parameters**
- By default, parameters are now required unless they have `[]` around the name
- Parameters with incomplete delimiters `e.g. ([missingTail)` will map to a `TextNode`

**Default Values**
- Default values are supported for optional parameters - `[param=default]`
- Default values will match anything between `=` and `]`. Leading and Trailing spaces are trimmed.

## What's next? Any followup issues?

https://github.com/Shopify/theme-tools/pull/734

## Before you deploy

- [x] I included a minor bump `changeset`
- [ ] My feature is backward compatible