### PR TITLE
[LiquidDoc] Parser support for `@description` annotation

### DIFF
--- a/.changeset/four-snakes-compare.md
+++ b/.changeset/four-snakes-compare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': minor
+---
+
+[LiquidDoc]: Add parser support for @description annotations. These can be placed anywhere within the header, and can span numerous lines.

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -393,12 +393,17 @@ LiquidDoc <: Helpers {
   LiquidDocNode =
     | paramNode
     | exampleNode
+    | descriptionNode
     | fallbackNode
-
+    
   // By default, space matches new lines as well. We override it here to make writing rules easier.
   strictSpace = " " | "\t"
   // We use this as an escape hatch to stop matching TextNode and try again when one of these characters is encountered
   openControl:= "@" | end
+
+  descriptionNode = "@description" strictSpace* descriptionContent
+  descriptionContent = anyExceptStar<endOfDescription>
+  endOfDescription = strictSpace* openControl
 
   paramNode = "@param" strictSpace* paramType? strictSpace* (optionalParamName | paramName) (strictSpace* "-")? strictSpace* paramDescription
   paramType = "{" strictSpace* paramTypeContent strictSpace* "}"

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1316,6 +1316,70 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.children.1.type').to.equal('LiquidDocExampleNode');
           expectPath(cst, '0.children.1.exampleContent.value').to.equal('second example\n');
         });
+
+        it('should parse @description node', () => {
+          const testStr = `{% doc %} @description {%- enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.name').to.equal('doc');
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
+          expectPath(cst, '0.children.0.content.value').to.equal('');
+        });
+
+        it('should parse @description node', () => {
+          const testStr = `{% doc %}
+          @description This is a description
+          @description This is a second description
+          {% enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
+          expectPath(cst, '0.children.0.content.value').to.equal('This is a description\n');
+
+          expectPath(cst, '0.children.1.type').to.equal('LiquidDocDescriptionNode');
+          expectPath(cst, '0.children.1.content.value').to.equal('This is a second description\n');
+        });
+
+        it('should parse and strip whitespace from description tag with content that has leading whitespace', () => {
+          const testStr = `{% doc %} @description         hello there       {%- enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.name').to.equal('doc');
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
+          expectPath(cst, '0.children.0.name').to.equal('description');
+          expectPath(cst, '0.children.0.content.value').to.equal('hello there');
+          expectPath(cst, '0.children.0.content.locStart').to.equal(testStr.indexOf('hello there'));
+          expectPath(cst, '0.children.0.content.locEnd').to.equal(
+            testStr.indexOf('hello there') + 'hello there'.length,
+          );
+        });
+
+        it('should parse description node with whitespace and new lines', () => {
+          const testStr = `{% doc %}
+          @description hello      there        my    friend
+          This is a description
+          It supports multiple lines
+        {% enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.name').to.equal('doc');
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
+          expectPath(cst, '0.children.0.name').to.equal('description');
+          expectPath(cst, '0.children.0.content.value').to.equal(
+            'hello      there        my    friend\n          This is a description\n          It supports multiple lines\n',
+          );
+        });
+
+        it('should parse multiple description nodes', () => {
+          const testStr = `{% doc %}
+          @description hello there
+          @description second description
+        {% enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
+          expectPath(cst, '0.children.0.content.value').to.equal('hello there\n');
+          expectPath(cst, '0.children.1.type').to.equal('LiquidDocDescriptionNode');
+          expectPath(cst, '0.children.1.content.value').to.equal('second description\n');
+        });
       }
     });
   });

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -86,6 +86,7 @@ export enum ConcreteNodeTypes {
 
   LiquidDocParamNode = 'LiquidDocParamNode',
   LiquidDocParamNameNode = 'LiquidDocParamNameNode',
+  LiquidDocDescriptionNode = 'LiquidDocDescriptionNode',
   LiquidDocExampleNode = 'LiquidDocExampleNode',
 }
 
@@ -122,6 +123,12 @@ export interface ConcreteLiquidDocParamNameNode
   name: 'paramName';
   content: ConcreteTextNode;
   required: boolean;
+}
+
+export interface ConcreteLiquidDocDescriptionNode
+  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocDescriptionNode> {
+  name: 'description';
+  content: ConcreteTextNode;
 }
 
 export interface ConcreteLiquidDocExampleNode
@@ -469,7 +476,10 @@ export type LiquidHtmlCST = LiquidHtmlConcreteNode[];
 
 export type LiquidCST = LiquidConcreteNode[];
 
-export type LiquidDocConcreteNode = ConcreteLiquidDocParamNode | ConcreteLiquidDocExampleNode;
+export type LiquidDocConcreteNode =
+  | ConcreteLiquidDocParamNode
+  | ConcreteLiquidDocExampleNode
+  | ConcreteLiquidDocDescriptionNode;
 
 interface Mapping {
   [k: string]: number | TemplateMapping | TopLevelFunctionMapping;
@@ -1357,6 +1367,15 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
       paramName: 4,
       paramDescription: 8,
     },
+    descriptionNode: {
+      type: ConcreteNodeTypes.LiquidDocDescriptionNode,
+      name: 'description',
+      locStart,
+      locEnd,
+      source,
+      content: 2,
+    },
+    descriptionContent: textNode,
     paramType: 2,
     paramTypeContent: textNode,
     paramName: {

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1382,6 +1382,43 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.body.nodes.1.paramDescription.value').to.eql(
         'param with description',
       );
+
+      ast = toLiquidAST(`
+        {% doc -%}
+        @description This is a description
+        @description This is another description
+        it can have multiple lines
+        {% enddoc %}
+      `);
+      expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocDescriptionNode');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description\n');
+      expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocDescriptionNode');
+      expectPath(ast, 'children.0.body.nodes.1.content.value').to.eql(
+        'This is another description\n        it can have multiple lines\n',
+      );
+
+      ast = toLiquidAST(`
+        {% doc -%}
+        @description This is a description
+        @example This is an example
+        @param {String} paramWithDescription - param with description
+        {% enddoc %}
+      `);
+      expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocDescriptionNode');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description\n');
+
+      expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocExampleNode');
+      expectPath(ast, 'children.0.body.nodes.1.name').to.eql('example');
+      expectPath(ast, 'children.0.body.nodes.1.exampleContent.value').to.eql(
+        'This is an example\n',
+      );
+
+      expectPath(ast, 'children.0.body.nodes.2.type').to.eql('LiquidDocParamNode');
+      expectPath(ast, 'children.0.body.nodes.2.name').to.eql('param');
+      expectPath(ast, 'children.0.body.nodes.2.paramName.value').to.eql('paramWithDescription');
+      expectPath(ast, 'children.0.body.nodes.2.paramDescription.value').to.eql(
+        'param with description',
+      );
     });
 
     it('should parse unclosed tables with assignments', () => {

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -109,7 +109,8 @@ export type LiquidHtmlNode =
   | LiquidComparison
   | TextNode
   | LiquidDocParamNode
-  | LiquidDocExampleNode;
+  | LiquidDocExampleNode
+  | LiquidDocDescriptionNode;
 
 /** The root node of all LiquidHTML ASTs. */
 export interface DocumentNode extends ASTNode<NodeTypes.Document> {
@@ -769,6 +770,13 @@ export interface LiquidDocParamNode extends ASTNode<NodeTypes.LiquidDocParamNode
   required: boolean;
 }
 
+/** Represents a `@description` node in a LiquidDoc comment - `@description descriptionContent` */
+export interface LiquidDocDescriptionNode extends ASTNode<NodeTypes.LiquidDocDescriptionNode> {
+  name: 'description';
+  /** The contents of the description (e.g. "This is a description"). Can be multiline. */
+  content: TextNode;
+}
+
 /** Represents a `@example` node in a LiquidDoc comment - `@example exampleContent` */
 export interface LiquidDocExampleNode extends ASTNode<NodeTypes.LiquidDocExampleNode> {
   name: 'example';
@@ -1300,6 +1308,17 @@ function buildAst(
           paramDescription: toNullableTextNode(node.paramDescription),
           paramType: toNullableTextNode(node.paramType),
           required: node.paramName.required,
+        });
+        break;
+      }
+
+      case ConcreteNodeTypes.LiquidDocDescriptionNode: {
+        builder.push({
+          type: NodeTypes.LiquidDocDescriptionNode,
+          name: node.name,
+          position: position(node),
+          source: node.source,
+          content: toTextNode(node.content),
         });
         break;
       }

--- a/packages/liquid-html-parser/src/types.ts
+++ b/packages/liquid-html-parser/src/types.ts
@@ -44,6 +44,7 @@ export enum NodeTypes {
   RawMarkup = 'RawMarkup',
   RenderMarkup = 'RenderMarkup',
   RenderVariableExpression = 'RenderVariableExpression',
+  LiquidDocDescriptionNode = 'LiquidDocDescriptionNode',
   LiquidDocParamNode = 'LiquidDocParamNode',
   LiquidDocExampleNode = 'LiquidDocExampleNode',
 }

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -130,6 +130,7 @@ function getCssDisplay(node: AugmentedNode<WithSiblings>, options: LiquidParserO
     case NodeTypes.Comparison:
     case NodeTypes.LiquidDocParamNode:
     case NodeTypes.LiquidDocExampleNode:
+    case NodeTypes.LiquidDocDescriptionNode:
       return 'should not be relevant';
 
     default:
@@ -237,6 +238,7 @@ function getNodeCssStyleWhiteSpace(
     case NodeTypes.Comparison:
     case NodeTypes.LiquidDocParamNode:
     case NodeTypes.LiquidDocExampleNode:
+    case NodeTypes.LiquidDocDescriptionNode:
       return 'should not be relevant';
 
     default:

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -565,6 +565,10 @@ function printNode(
       return printLiquidDocExample(path as AstPath<LiquidDocExampleNode>, options, print, args);
     }
 
+    case NodeTypes.LiquidDocDescriptionNode: {
+      return '';
+    }
+
     default: {
       return assertNever(node);
     }

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -403,10 +403,9 @@ function findCurrentNode(
       case NodeTypes.LiquidLiteral:
       case NodeTypes.String:
       case NodeTypes.Number:
-      case NodeTypes.LiquidDocParamNode: {
-        break;
-      }
-      case NodeTypes.LiquidDocExampleNode: {
+      case NodeTypes.LiquidDocParamNode:
+      case NodeTypes.LiquidDocExampleNode:
+      case NodeTypes.LiquidDocDescriptionNode: {
         break;
       }
 


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/503

This adds parsing for a `@description` annotation.
- This annotation can span multiple lines, similar to `@example`
- This annotation can be defined anywhere in the `liquiddoc` body. It will match until end of input or until the next `@`
- We are NOT supporting implicit descriptions here - [issue](https://github.com/Shopify/developer-tools-team/issues/558)

## What's next? Any followup issues?
Prettier support https://github.com/Shopify/developer-tools-team/issues/504

## What did you learn?
- Did a little more reading on [Lexical vs Syntactic rules ](https://ohmjs.org/docs/syntax-reference#syntactic-lexical). Still stewing on what this means in practice, though I think this will help us with whitespace handling. It seems like syntactic rules are useful for high-level grammar structure

## Before you deploy
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible