### PR TITLE
Support render param completion using LiquidDocs

### DIFF
--- a/.changeset/small-timers-kick.md
+++ b/.changeset/small-timers-kick.md
@@ -1,0 +1,9 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/liquid-html-parser': minor
+---
+
+Support `render` param completion based on liquid docs
+
+- If you defined liquid doc parameters on a snippet, they will appear as completion options
+for parameters when rendered by a `render` tag.

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -141,7 +141,10 @@ Liquid <: Helpers {
   liquidTagInclude = liquidTagRule<"include", liquidTagRenderMarkup>
   liquidTagRender = liquidTagRule<"render", liquidTagRenderMarkup>
   liquidTagRenderMarkup =
-    snippetExpression renderVariableExpression? renderAliasExpression? (argumentSeparatorOptionalComma tagArguments) (space* ",")? space*
+    snippetExpression renderVariableExpression? renderAliasExpression? renderArguments
+
+  renderArguments = (argumentSeparatorOptionalComma tagArguments) (space* ",")? space*
+  completionModeRenderArguments = (argumentSeparatorOptionalComma tagArguments) (space* ",")? space* (argumentSeparator? liquidVariableLookup<delimTag> space*)?
   snippetExpression = liquidString<delimTag> | variableSegmentAsLookup
   renderVariableExpression = space+ ("for" | "with") space+ liquidExpression<delimTag>
   renderAliasExpression = space+ "as" space+ variableSegment
@@ -554,6 +557,8 @@ WithPlaceholderLiquid <: Liquid {
   liquidFilter<delim> := space* "|" space* identifier (space* ":" space* filterArguments<delim> (space* ",")?)?
   liquidTagContentForMarkup :=
     contentForType (argumentSeparatorOptionalComma completionModeContentForTagArgument) (space* ",")? space*
+  liquidTagRenderMarkup :=
+    snippetExpression renderVariableExpression? renderAliasExpression? completionModeRenderArguments
   liquidTagName := (letter | "█") (alnum | "_")*
   variableSegment := (letter | "_" | "█") (identifierCharacter | "█")*
 }
@@ -562,6 +567,8 @@ WithPlaceholderLiquidStatement <: LiquidStatement {
   liquidFilter<delim> := space* "|" space* identifier (space* ":" space* filterArguments<delim> (space* ",")?)?
   liquidTagContentForMarkup :=
     contentForType (argumentSeparatorOptionalComma completionModeContentForTagArgument) (space* ",")? space*
+  liquidTagRenderMarkup :=
+    snippetExpression renderVariableExpression? renderAliasExpression? completionModeRenderArguments
   liquidTagName := (letter | "█") (alnum | "_")*
   variableSegment := (letter | "_" | "█") (identifierCharacter | "█")*
 }
@@ -570,6 +577,8 @@ WithPlaceholderLiquidHTML <: LiquidHTML {
   liquidFilter<delim> := space* "|" space* identifier (space* ":" space* filterArguments<delim> (space* ",")?)?
   liquidTagContentForMarkup :=
     contentForType (argumentSeparatorOptionalComma completionModeContentForTagArgument) (space* ",")? space*
+  liquidTagRenderMarkup :=
+    snippetExpression renderVariableExpression? renderAliasExpression? completionModeRenderArguments
   liquidTagName := (letter | "█") (alnum | "_")*
   variableSegment := (letter | "_" | "█") (identifierCharacter | "█")*
   leadingTagNameTextNode := (letter | "█") (alnum | "-" | ":" | "█")*

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -6,8 +6,7 @@ import {
   LiquidCST,
   ConcreteLiquidTagLiquid,
 } from './stage-1-cst';
-import { BLOCKS, VOID_ELEMENTS } from './grammar';
-import { NamedTags } from './types';
+import { VOID_ELEMENTS } from './grammar';
 import { deepGet } from './utils';
 
 describe('Unit: Stage 1 (CST)', () => {
@@ -561,11 +560,11 @@ describe('Unit: Stage 1 (CST)', () => {
                 expectPath(cst, '0.markup.variable').to.equal(null);
               }
               expectPath(cst, '0.markup.alias').to.equal(alias);
-              expectPath(cst, '0.markup.args').to.have.lengthOf(namedArguments.length);
+              expectPath(cst, '0.markup.renderArguments').to.have.lengthOf(namedArguments.length);
               namedArguments.forEach(({ name, valueType }, i) => {
-                expectPath(cst, `0.markup.args.${i}.type`).to.equal('NamedArgument');
-                expectPath(cst, `0.markup.args.${i}.name`).to.equal(name);
-                expectPath(cst, `0.markup.args.${i}.value.type`).to.equal(valueType);
+                expectPath(cst, `0.markup.renderArguments.${i}.type`).to.equal('NamedArgument');
+                expectPath(cst, `0.markup.renderArguments.${i}.name`).to.equal(name);
+                expectPath(cst, `0.markup.renderArguments.${i}.value.type`).to.equal(valueType);
               });
               expectPath(cst, '0.whitespaceStart').to.equal(null);
               expectPath(cst, '0.whitespaceEnd').to.equal('-');
@@ -1785,6 +1784,16 @@ describe('Unit: Stage 1 (CST)', () => {
       expectPath(cst, '0.markup.type').to.equal('ContentForMarkup');
       expectPath(cst, '0.markup.args.0.type').to.equal('NamedArgument');
       expectPath(cst, '0.markup.args.1.type').to.equal('VariableLookup');
+    });
+
+    it('should parse incomplete parameters for render tags', () => {
+      const toCST = (source: string) => toLiquidHtmlCST(source, { mode: 'completion' });
+
+      cst = toCST(`{% render "example-snippet", id: 2, foo█ %}`);
+
+      expectPath(cst, '0.markup.type').to.equal('RenderMarkup');
+      expectPath(cst, '0.markup.renderArguments.0.type').to.equal('NamedArgument');
+      expectPath(cst, '0.markup.renderArguments.1.type').to.equal('VariableLookup');
     });
   });
 

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -376,7 +376,7 @@ export interface ConcreteLiquidTagRenderMarkup
   snippet: ConcreteStringLiteral | ConcreteLiquidVariableLookup;
   alias: string | null;
   variable: ConcreteRenderVariableExpression | null;
-  args: ConcreteLiquidNamedArgument[];
+  renderArguments: ConcreteLiquidNamedArgument[];
 }
 
 export interface ConcreteRenderVariableExpression
@@ -865,10 +865,28 @@ function toCST<T>(
       snippet: 0,
       variable: 1,
       alias: 2,
-      args: 4,
+      renderArguments: 3,
       locStart,
       locEnd,
       source,
+    },
+    renderArguments: 1,
+    completionModeRenderArguments: function (
+      _0,
+      namedArguments,
+      _2,
+      _3,
+      _4,
+      _5,
+      variableLookup,
+      _7,
+    ) {
+      const self = this as any;
+
+      // variableLookup.sourceString can be '' when there are no incomplete params
+      return namedArguments
+        .toAST(self.args.mapping)
+        .concat(variableLookup.sourceString === '' ? [] : variableLookup.toAST(self.args.mapping));
     },
     snippetExpression: 0,
     renderVariableExpression: {

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -1,4 +1,9 @@
-import { MetafieldDefinitionMap, SourceCodeType, ThemeDocset } from '@shopify/theme-check-common';
+import {
+  GetSnippetDefinitionForURI,
+  MetafieldDefinitionMap,
+  SourceCodeType,
+  ThemeDocset,
+} from '@shopify/theme-check-common';
 import { CompletionItem, CompletionParams } from 'vscode-languageserver';
 import { TypeSystem } from '../TypeSystem';
 import { DocumentManager } from '../documents';
@@ -22,6 +27,7 @@ import {
   ContentForParameterCompletionProvider,
 } from './providers';
 import { GetSnippetNamesForURI } from './providers/RenderSnippetCompletionProvider';
+import { RenderSnippetParameterCompletionProvider } from './providers/RenderSnippetParameterCompletionProvider';
 
 export interface CompletionProviderDependencies {
   documentManager: DocumentManager;
@@ -30,6 +36,7 @@ export interface CompletionProviderDependencies {
   getSnippetNamesForURI?: GetSnippetNamesForURI;
   getThemeSettingsSchemaForURI?: GetThemeSettingsSchemaForURI;
   getMetafieldDefinitions: (rootUri: string) => Promise<MetafieldDefinitionMap>;
+  getSnippetDefinitionForURI?: GetSnippetDefinitionForURI;
   getThemeBlockNames?: (rootUri: string, includePrivate: boolean) => Promise<string[]>;
   log?: (message: string) => void;
 }
@@ -47,6 +54,9 @@ export class CompletionsProvider {
     getTranslationsForURI = async () => ({}),
     getSnippetNamesForURI = async () => [],
     getThemeSettingsSchemaForURI = async () => [],
+    getSnippetDefinitionForURI = async (_uri, snippetName) => ({
+      name: snippetName,
+    }),
     getThemeBlockNames = async (_rootUri: string, _includePrivate: boolean) => [],
     log = () => {},
   }: CompletionProviderDependencies) {
@@ -72,6 +82,7 @@ export class CompletionsProvider {
       new FilterCompletionProvider(typeSystem),
       new TranslationCompletionProvider(documentManager, getTranslationsForURI),
       new RenderSnippetCompletionProvider(getSnippetNamesForURI),
+      new RenderSnippetParameterCompletionProvider(getSnippetDefinitionForURI),
       new FilterNamedParameterCompletionProvider(themeDocset),
     ];
   }

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.ts
@@ -11,6 +11,8 @@ export class ObjectCompletionProvider implements Provider {
     if (!params.completionContext) return [];
 
     const { partialAst, node, ancestors } = params.completionContext;
+    const parentNode = ancestors.at(-1);
+
     if (!node || node.type !== NodeTypes.VariableLookup) {
       return [];
     }
@@ -20,8 +22,11 @@ export class ObjectCompletionProvider implements Provider {
       return [];
     }
 
-    // ContentFor uses VariableLookup to support completion of NamedParams.
-    if (ancestors.at(-1)?.type === NodeTypes.ContentForMarkup) {
+    // ContentFor and Render uses VariableLookup to support completion of NamedParams.
+    if (
+      parentNode?.type === NodeTypes.ContentForMarkup ||
+      parentNode?.type === NodeTypes.RenderMarkup
+    ) {
       return [];
     }
 

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.spec.ts
@@ -1,0 +1,87 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { CompletionsProvider } from '../CompletionsProvider';
+import { DocumentManager } from '../../documents';
+import { MetafieldDefinitionMap, SnippetDefinition } from '@shopify/theme-check-common';
+
+describe('Module: RenderSnippetParameterCompletionProvider', async () => {
+  let provider: CompletionsProvider;
+  const mockSnippetName = 'product-card';
+  const mockSnippetDefinition: SnippetDefinition = {
+    name: mockSnippetName,
+    liquidDoc: {
+      parameters: [
+        {
+          name: 'title',
+          description: 'The title of the product',
+          type: 'string',
+          required: true,
+          nodeType: 'param',
+        },
+        {
+          name: 'border-radius',
+          description: 'The border radius in px',
+          type: 'number',
+          required: false,
+          nodeType: 'param',
+        },
+        {
+          name: 'no-type',
+          description: 'This parameter has no type',
+          type: null,
+          required: true,
+          nodeType: 'param',
+        },
+        {
+          name: 'no-description',
+          description: null,
+          type: 'string',
+          required: true,
+          nodeType: 'param',
+        },
+        {
+          name: 'no-type-or-description',
+          description: null,
+          type: null,
+          required: true,
+          nodeType: 'param',
+        },
+      ],
+    },
+  };
+
+  beforeEach(async () => {
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getSnippetDefinitionForURI: async (_uri, snippetName) => {
+        if (mockSnippetName === snippetName) {
+          return mockSnippetDefinition;
+        }
+      },
+    });
+  });
+
+  it("provide completion options that doesn't already exist in render tag", async () => {
+    await expect(provider).to.complete(`{% render '${mockSnippetName}', █ %}`, [
+      'title',
+      'border-radius',
+      'no-type',
+      'no-description',
+      'no-type-or-description',
+    ]);
+    await expect(provider).to.complete(
+      `{% render '${mockSnippetName}', title: 'foo', border-radius: 5, █ %}`,
+      ['no-type', 'no-description', 'no-type-or-description'],
+    );
+  });
+
+  it('does not provide completion options if the snippet does not exist', async () => {
+    await expect(provider).to.complete(`{% render 'fake-snippet', █ %}`, []);
+  });
+});

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.ts
@@ -1,0 +1,72 @@
+import { NodeTypes } from '@shopify/liquid-html-parser';
+import {
+  CompletionItem,
+  CompletionItemKind,
+  InsertTextFormat,
+  MarkupKind,
+  Range,
+  TextEdit,
+} from 'vscode-languageserver';
+import { CURSOR, LiquidCompletionParams } from '../params';
+import { Provider } from './common';
+import { formatLiquidDocParameter } from '../../utils/liquidDoc';
+import { GetSnippetDefinitionForURI } from '@shopify/theme-check-common';
+
+export type GetSnippetNamesForURI = (uri: string) => Promise<string[]>;
+
+export class RenderSnippetParameterCompletionProvider implements Provider {
+  constructor(private readonly getSnippetDefinitionForURI: GetSnippetDefinitionForURI) {}
+
+  async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
+    if (!params.completionContext) return [];
+
+    const { node, ancestors } = params.completionContext;
+    const parentNode = ancestors.at(-1);
+
+    if (
+      !node ||
+      !parentNode ||
+      node.type !== NodeTypes.VariableLookup ||
+      parentNode.type !== NodeTypes.RenderMarkup ||
+      parentNode.snippet.type !== 'String'
+    ) {
+      return [];
+    }
+
+    const userInputStr = node.name?.replace(CURSOR, '') || '';
+    const snippetDefinition = await this.getSnippetDefinitionForURI(
+      params.textDocument.uri,
+      parentNode.snippet.value,
+    );
+
+    const liquidDocParams = snippetDefinition?.liquidDoc?.parameters;
+
+    if (!liquidDocParams) {
+      return [];
+    }
+
+    let offset = node.name === CURSOR ? 1 : 0;
+
+    let start = params.document.textDocument.positionAt(node.position.start);
+    let end = params.document.textDocument.positionAt(node.position.end - offset);
+
+    // We need to find out existing params in the render tag so we don't offer it again for completion
+    const existingRenderParams = parentNode.args
+      .filter((arg) => arg.type === NodeTypes.NamedArgument)
+      .map((arg) => arg.name);
+
+    return liquidDocParams
+      .filter((liquidDocParam) => !existingRenderParams.includes(liquidDocParam.name))
+      .filter((liquidDocParam) => liquidDocParam.name.startsWith(userInputStr))
+      .map((liquidDocParam) => ({
+        label: liquidDocParam.name,
+        kind: CompletionItemKind.Property,
+        documentation: {
+          kind: MarkupKind.Markdown,
+          value: formatLiquidDocParameter(liquidDocParam, true),
+        },
+        textEdit: TextEdit.replace(Range.create(start, end), `${liquidDocParam.name}: $0`),
+        insertTextFormat: InsertTextFormat.Snippet,
+      }));
+  }
+}

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -2,6 +2,7 @@ import { NodeTypes } from '@shopify/liquid-html-parser';
 import { LiquidHtmlNode, SnippetDefinition, LiquidDocParameter } from '@shopify/theme-check-common';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import { BaseHoverProvider } from '../BaseHoverProvider';
+import { formatLiquidDocParameter } from '../../utils/liquidDoc';
 
 export class RenderSnippetHoverProvider implements BaseHoverProvider {
   constructor(
@@ -70,13 +71,6 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
   }
 
   private buildParameters(parameters: LiquidDocParameter[]) {
-    return parameters
-      .map(({ name, type, description, required }: LiquidDocParameter) => {
-        const nameStr = required ? `\`${name}\`` : `\`${name}\` (Optional)`;
-        const typeStr = type ? `: ${type}` : '';
-        const descStr = description ? ` - ${description}` : '';
-        return `- ${nameStr}${typeStr}${descStr}`;
-      })
-      .join('\n');
+    return parameters.map((param) => formatLiquidDocParameter(param)).join('\n');
   }
 }

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
@@ -81,28 +81,28 @@ describe('Module: RenderSnippetParameterHoverProvider', async () => {
     it('should return parameter info with type and description', async () => {
       await expect(provider).to.hover(
         `{% render 'product-card' ti█tle: 'My Product' %}`,
-        '`title`: `string`\n- The title of the product',
+        '### `title`: string\n\nThe title of the product',
       );
     });
 
     it('should return parameter info with only type', async () => {
       await expect(provider).to.hover(
         `{% render 'product-card' no-descri█ption: 'value' %}`,
-        '`no-description`: `string`',
+        '### `no-description`: string',
       );
     });
 
     it('should return parameter info with only description', async () => {
       await expect(provider).to.hover(
         `{% render 'product-card' no-ty█pe: 'value' %}`,
-        '`no-type`\n- This parameter has no type',
+        '### `no-type`\n\nThis parameter has no type',
       );
     });
 
     it('should return only parameter name when no type or description', async () => {
       await expect(provider).to.hover(
         `{% render 'product-card' no-type-or-descri█ption: 'value' %}`,
-        '`no-type-or-description`',
+        '### `no-type-or-description`',
       );
     });
   });

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.ts
@@ -1,7 +1,8 @@
 import { NodeTypes } from '@shopify/liquid-html-parser';
-import { LiquidHtmlNode, SnippetDefinition, LiquidDocParameter } from '@shopify/theme-check-common';
+import { LiquidHtmlNode, SnippetDefinition } from '@shopify/theme-check-common';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import { BaseHoverProvider } from '../BaseHoverProvider';
+import { formatLiquidDocParameter } from '../../utils/liquidDoc';
 
 export class RenderSnippetParameterHoverProvider implements BaseHoverProvider {
   constructor(
@@ -45,21 +46,10 @@ export class RenderSnippetParameterHoverProvider implements BaseHoverProvider {
       return null;
     }
 
-    const parts = [];
-    parts.push(
-      hoveredParameter.type
-        ? `\`${hoveredParameter.name}\`: \`${hoveredParameter.type}\``
-        : `\`${hoveredParameter.name}\``,
-    );
-
-    if (hoveredParameter.description) {
-      parts.push(`- ${hoveredParameter.description}`);
-    }
-
     return {
       contents: {
         kind: 'markdown',
-        value: parts.join('\n'),
+        value: formatLiquidDocParameter(hoveredParameter, true),
       },
     };
   }

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -258,6 +258,7 @@ export function startServer(
     log,
     getThemeBlockNames,
     getMetafieldDefinitions,
+    getSnippetDefinitionForURI,
   });
   const hoverProvider = new HoverProvider(
     documentManager,

--- a/packages/theme-language-server-common/src/utils/liquidDoc.ts
+++ b/packages/theme-language-server-common/src/utils/liquidDoc.ts
@@ -1,0 +1,17 @@
+import { LiquidDocParameter } from '@shopify/theme-check-common';
+
+export function formatLiquidDocParameter(
+  { name, type, description, required }: LiquidDocParameter,
+  heading: boolean = false,
+) {
+  const nameStr = required ? `\`${name}\`` : `\`${name}\` (Optional)`;
+  const typeStr = type ? `: ${type}` : '';
+
+  if (heading) {
+    const descStr = description ? `\n\n${description}` : '';
+    return `### ${nameStr}${typeStr}${descStr}`;
+  }
+
+  const descStr = description ? ` - ${description}` : '';
+  return `- ${nameStr}${typeStr}${descStr}`;
+}


### PR DESCRIPTION
## What are you adding in this PR?

Fixes https://github.com/Shopify/developer-tools-team/issues/507
- Adding `render` tag param completion support
- Moving liquid doc display logic into separate file so it can be shared across 3 providers

## What's next? Any followup issues?

- more completion for liquid docs

## Tophatting

1. Clone repo and run `yarn build`
2. F5 to run the code
3. Open a theme repo
4. Create a block under `blocks`
5. Create a Liquid doc with a few params
    - 1 optional param
    - 1 param with type
6. In a section file try to render the snippet and code-complete. Here are all the types of `render` tags

```
  {% assign example = 'sometext' %}
  {% render 'example-snippet' with example as custom, █ %}
  {% render 'example-snippet' with example, █ %}
  {% render 'example-snippet' for section.settings.collection.products as custom, █ %}
  {% render 'example-snippet', █ %}
```

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
