### PR TITLE
Update the document manager on git operations

### DIFF
--- a/.changeset/orange-emus-bow.md
+++ b/.changeset/orange-emus-bow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Update document manager on git operations

--- a/packages/theme-language-server-common/src/documents/DocumentManager.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.ts
@@ -50,6 +50,11 @@ export class DocumentManager {
     return this.set(uri, source, version);
   }
 
+  public async changeFromDisk(uri: UriString) {
+    if (!this.fs) throw new Error('Cannot call changeFromDisk without a FileSystem');
+    this.change(uri, await this.fs.readFile(uri), undefined);
+  }
+
   public close(uri: UriString) {
     const sourceCode = this.sourceCodes.get(uri);
     if (!sourceCode) return;

--- a/packages/theme-language-server-common/src/documents/DocumentManager.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.ts
@@ -31,6 +31,7 @@ export class DocumentManager {
    * are preloaded have a version of `undefined`.
    */
   private sourceCodes: Map<UriString, AugmentedSourceCode>;
+  private recentlyRenamed: Set<UriString>;
 
   constructor(
     private readonly fs?: AbstractFileSystem,
@@ -40,6 +41,7 @@ export class DocumentManager {
     private readonly isValidSchema?: IsValidSchema,
   ) {
     this.sourceCodes = new Map();
+    this.recentlyRenamed = new Set();
   }
 
   public open(uri: UriString, source: string, version: number | undefined) {
@@ -66,6 +68,8 @@ export class DocumentManager {
   }
 
   public rename(oldUri: UriString, newUri: UriString) {
+    this.recentlyRenamed.add(oldUri);
+    this.recentlyRenamed.add(newUri);
     const sourceCode = this.sourceCodes.get(oldUri);
     if (!sourceCode) return;
     this.sourceCodes.delete(oldUri);
@@ -90,6 +94,14 @@ export class DocumentManager {
 
   public has(uri: UriString) {
     return this.sourceCodes.has(path.normalize(uri));
+  }
+
+  public hasRecentRename(uri: UriString) {
+    return this.recentlyRenamed.has(uri);
+  }
+
+  public clearRecentRename(uri: UriString) {
+    this.recentlyRenamed.delete(uri);
   }
 
   private set(uri: UriString, source: string, version: number | undefined) {


### PR DESCRIPTION
## What are you adding in this PR?

Tricky part was to not invalidate the cache twice for the same change.

Lots of LSP lifecycle messages (onDidCreateFiles, onDidRenameFiles,
onDidDeleteFiles, onDidSaveTextDocument) were fired before the
onDidChangeWatchedFile events.

Had to do a little trick to avoid invalidating the cache twice for
those.

Fixes #692

## Before you deploy

<!-- Delete the checklists you don't need -->
- [x] I included a patch bump `changeset`
