### PR TITLE
Move `getSnippetDefinition` to `theme-check-common`

### DIFF
--- a/.changeset/popular-readers-sin.md
+++ b/.changeset/popular-readers-sin.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+---
+
+Move `getSnippetDefinition` to theme-check-common

--- a/packages/theme-check-common/src/index.ts
+++ b/packages/theme-check-common/src/index.ts
@@ -57,6 +57,7 @@ export * from './utils/memo';
 export * from './utils/types';
 export * from './utils/object';
 export * from './visitor';
+export * from './liquid-doc/liquidDoc';
 
 const defaultErrorHandler = (_error: Error): void => {
   // Silently ignores errors by default.

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
@@ -1,7 +1,6 @@
-import { expect, it } from 'vitest';
-import { LiquidHtmlNode } from '@shopify/theme-check-common';
-import { toSourceCode } from '@shopify/theme-check-common';
-import { describe } from 'vitest';
+import { expect, it, describe } from 'vitest';
+import { toSourceCode } from '../to-source-code';
+import { LiquidHtmlNode } from '../types';
 import { getSnippetDefinition } from './liquidDoc';
 
 describe('Unit: getSnippetDefinition', () => {

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.ts
@@ -1,7 +1,6 @@
-import { SourceCodeType, visit } from '@shopify/theme-check-common';
-
-import { LiquidHtmlNode } from '@shopify/theme-check-common';
-
+import { SourceCodeType } from '../types';
+import { visit } from '../visitor';
+import { LiquidHtmlNode } from '../types';
 import { LiquidDocExampleNode, LiquidDocParamNode } from '@shopify/liquid-html-parser';
 
 export type GetSnippetDefinitionForURI = (

--- a/packages/theme-language-server-common/src/documents/DocumentManager.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.ts
@@ -19,7 +19,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { ClientCapabilities } from '../ClientCapabilities';
 import { percent, Progress } from '../progress';
 import { AugmentedSourceCode } from './types';
-import { getSnippetDefinition } from '../liquidDoc';
+import { getSnippetDefinition } from '@shopify/theme-check-common';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/packages/theme-language-server-common/src/documents/types.ts
+++ b/packages/theme-language-server-common/src/documents/types.ts
@@ -6,7 +6,7 @@ import {
   AppBlockSchema,
 } from '@shopify/theme-check-common';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { SnippetDefinition } from '../liquidDoc';
+import { SnippetDefinition } from '@shopify/theme-check-common';
 
 /** Util type to add the common `textDocument` property to the SourceCode. */
 type _AugmentedSourceCode<SCT extends SourceCodeType = SourceCodeType> = SourceCode<SCT> & {

--- a/packages/theme-language-server-common/src/hover/HoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/HoverProvider.ts
@@ -1,4 +1,9 @@
-import { MetafieldDefinitionMap, SourceCodeType, ThemeDocset } from '@shopify/theme-check-common';
+import {
+  GetSnippetDefinitionForURI,
+  MetafieldDefinitionMap,
+  SourceCodeType,
+  ThemeDocset,
+} from '@shopify/theme-check-common';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import { TypeSystem } from '../TypeSystem';
 import { DocumentManager } from '../documents';
@@ -18,7 +23,6 @@ import {
 import { HtmlAttributeValueHoverProvider } from './providers/HtmlAttributeValueHoverProvider';
 import { findCurrentNode } from '@shopify/theme-check-common';
 import { GetThemeSettingsSchemaForURI } from '../settings';
-import { GetSnippetDefinitionForURI } from '../liquidDoc';
 
 export class HoverProvider {
   private providers: BaseHoverProvider[] = [];

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -2,7 +2,7 @@ import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
 import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
-import { GetSnippetDefinitionForURI, SnippetDefinition } from '../../liquidDoc';
+import { GetSnippetDefinitionForURI, SnippetDefinition } from '@shopify/theme-check-common';
 import '../../../../theme-check-common/src/test/test-setup';
 
 describe('Module: RenderSnippetHoverProvider', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -1,8 +1,7 @@
 import { NodeTypes } from '@shopify/liquid-html-parser';
-import { LiquidHtmlNode } from '@shopify/theme-check-common';
+import { LiquidHtmlNode, SnippetDefinition, LiquidDocParameter } from '@shopify/theme-check-common';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import { BaseHoverProvider } from '../BaseHoverProvider';
-import { SnippetDefinition, LiquidDocParameter } from '../../liquidDoc';
 
 export class RenderSnippetHoverProvider implements BaseHoverProvider {
   constructor(

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
@@ -2,7 +2,7 @@ import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
 import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
-import { GetSnippetDefinitionForURI, SnippetDefinition } from '../../liquidDoc';
+import { GetSnippetDefinitionForURI, SnippetDefinition } from '@shopify/theme-check-common';
 import '../../../../theme-check-common/src/test/test-setup';
 
 describe('Module: RenderSnippetParameterHoverProvider', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.ts
@@ -1,8 +1,7 @@
 import { NodeTypes } from '@shopify/liquid-html-parser';
-import { LiquidHtmlNode } from '@shopify/theme-check-common';
+import { LiquidHtmlNode, SnippetDefinition, LiquidDocParameter } from '@shopify/theme-check-common';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import { BaseHoverProvider } from '../BaseHoverProvider';
-import { SnippetDefinition, LiquidDocParameter } from '../../liquidDoc';
 
 export class RenderSnippetParameterHoverProvider implements BaseHoverProvider {
   constructor(

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -12,6 +12,7 @@ import {
   path,
   recursiveReadDirectory,
   SourceCodeType,
+  SnippetDefinition,
 } from '@shopify/theme-check-common';
 import {
   Connection,
@@ -35,7 +36,6 @@ import { OnTypeFormattingProvider } from '../formatting';
 import { HoverProvider } from '../hover';
 import { JSONLanguageService } from '../json/JSONLanguageService';
 import { LinkedEditingRangesProvider } from '../linkedEditingRanges/LinkedEditingRangesProvider';
-import { SnippetDefinition } from '../liquidDoc';
 import { RenameProvider } from '../rename/RenameProvider';
 import { RenameHandler } from '../renamed/RenameHandler';
 import { GetTranslationsForURI } from '../translations';


### PR DESCRIPTION
## What are you adding in this PR?

Moving the `liquidDoc` module from `theme-language-server-common` to `theme-check-common`.

This is where `visit` lives, and allows us to us `getSnippetDefinition` in both `theme-language-server-common` and `theme-check-common`

## What's next? Any followup issues?
Improving type adherence [here](https://app.graphite.dev/github/pr/Shopify/theme-tools/779/Modify-getSnippetDefinition-to-return-undefined-when-liquidDoc-header-is-not-present)

This is all work I'm doing to enable / improve our ability to write theme checks

## Before you deploy
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible