### PR TITLE
Modify getSnippetDefinition to return undefined when liquidDoc header is not present

### DIFF
--- a/.changeset/stale-planes-knock.md
+++ b/.changeset/stale-planes-knock.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Improve type adherence of `getSnippetDefinition`. The function now returns `undefined` when the corresponding properties are empty.

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
@@ -19,10 +19,7 @@ describe('Unit: getSnippetDefinition', () => {
     const result = getSnippetDefinition(ast, 'product-card');
     expect(result).to.deep.equal({
       name: 'product-card',
-      liquidDoc: {
-        parameters: [],
-        examples: [],
-      },
+      liquidDoc: {},
     });
   });
 
@@ -86,7 +83,6 @@ describe('Unit: getSnippetDefinition', () => {
             nodeType: 'param',
           },
         ],
-        examples: [],
       },
     });
   });
@@ -103,7 +99,6 @@ describe('Unit: getSnippetDefinition', () => {
     expect(result).to.deep.equal({
       name: 'product-card',
       liquidDoc: {
-        parameters: [],
         examples: [
           {
             content: '\n          {{ product }}\n',
@@ -127,7 +122,6 @@ describe('Unit: getSnippetDefinition', () => {
     expect(result).to.deep.equal({
       name: 'product-card',
       liquidDoc: {
-        parameters: [],
         examples: [
           {
             content: '\n          {{ product }}\n          {{ product.title }}\n',
@@ -184,7 +178,6 @@ describe('Unit: getSnippetDefinition', () => {
     expect(result).to.deep.equal({
       name: 'product-card',
       liquidDoc: {
-        parameters: [],
         examples: [
           {
             content: '\n          {{ product }}\n',
@@ -196,6 +189,29 @@ describe('Unit: getSnippetDefinition', () => {
           },
         ],
       },
+    });
+  });
+
+  it('should return snippetDefinition without liquidDoc property if doc header is not present', async () => {
+    const ast = toAST(`
+      <div>No doc header here</div>
+    `);
+
+    const result = getSnippetDefinition(ast, 'product-card');
+    expect(result).to.deep.equal({
+      name: 'product-card',
+    });
+  });
+
+  it('should return an empty liquidDoc definition doc header is present but empty', async () => {
+    const ast = toAST(`
+      {% doc %}{% enddoc %}
+    `);
+
+    const result = getSnippetDefinition(ast, 'product-card');
+    expect(result).to.deep.equal({
+      name: 'product-card',
+      liquidDoc: {},
     });
   });
 });

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.ts
@@ -1,11 +1,7 @@
 import { SourceCodeType } from '../types';
 import { visit } from '../visitor';
 import { LiquidHtmlNode } from '../types';
-import {
-  LiquidDocExampleNode,
-  LiquidDocParamNode,
-  LiquidRawTag,
-} from '@shopify/liquid-html-parser';
+import { LiquidDocExampleNode, LiquidDocParamNode } from '@shopify/liquid-html-parser';
 
 export type GetSnippetDefinitionForURI = (
   uri: string,
@@ -67,12 +63,25 @@ export function getSnippetDefinition(
       };
     },
   });
+  const { parameters, examples } = nodes.reduce(
+    (acc, node) => {
+      if (node.nodeType === 'param') {
+        acc.parameters.push(node as LiquidDocParameter);
+      } else if (node.nodeType === 'example') {
+        acc.examples.push(node as LiquidDocExample);
+      }
+      return acc;
+    },
+    { parameters: [] as LiquidDocParameter[], examples: [] as LiquidDocExample[] },
+  );
 
-  const parameters = nodes.filter((node): node is LiquidDocParameter => node.nodeType === 'param');
-  const examples = nodes.filter((node): node is LiquidDocExample => node.nodeType === 'example');
+  if (!hasDocTag) return { name: snippetName };
 
   return {
     name: snippetName,
-    liquidDoc: hasDocTag ? { parameters, examples } : undefined,
+    liquidDoc: {
+      ...(parameters.length && { parameters }),
+      ...(examples.length && { examples }),
+    },
   };
 }


### PR DESCRIPTION
## What are you adding in this PR?

Before this PR, we weren't actually adhering to the types properly. **We weren't returning undefined when expected**

```
export type SnippetDefinition = {
    name: string;
    liquidDoc?: LiquidDocDefinition;
};
type LiquidDocDefinition = {
    parameters?: LiquidDocParameter[];
    examples?: LiquidDocExample[];
};
```

Now, when:
- `{% doc %}` header **is not present** -> `.liquidDoc` is `undefined`
- `{% doc %}` header is **empty** -> `.liquidDoc` is `{}`
- `@param` or `@example` are not provided -> `liquidDoc.param` or `liquidDoc.example` are `undefined` respectively

This provides more granularity for how we handle hover, checks, etc.

## What's next? Any followup issues?
This enables us to write better theme checks for LiquidDoc

## Before you deploy
- [x] I included a patch bump `changeset`
