### PR TITLE
add dev.yml with tooling versions

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,8 @@
+name: theme-tools
+
+dev.edition: 2024
+
+up:
+  - node:
+      version: v22.14.0
+      yarn: v1.22.22

--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
     "webpack": "^5.94.0",
     "webpack-cli": "^5.0.0",
     "webpack-dev-server": "^4.11.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## What are you adding in this PR?

When @albchu was onboarding me to the project last week, we had trouble getting things running because of missing tooling associations. Other folks who have been around longer might have a default Node and Yarn installed via Homebrew or elsewhere that does the job, but I didn't. What's more, it seems like `dev` or some other piece of internal tooling regularly wipes all `nvm` associations/installs — so adding a `.nvmrc` file fixed the problem in the moment, but stopped working when I came back to the project a few days later.

Looks like there's precedent for having `dev.yml` in other public repos, eg. [`Shopify/cli`](https://github.com/Shopify/cli/). (In fact, they have both `dev.yml` and `.nvmrc` which they [manually keep in sync](https://github.com/Shopify/cli/commit/44483598aac897b2a7eecdd6c9b0a5f4ff4b6dba) — I guess to ease outside contributions.)
