### PR TITLE
Fix typo in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           # Put date in the title and commit message
           title: "Theme Tools Release — ${{ steps.date.outputs.date }}"
-          commit: "Theme Rools Release — ${{ steps.date.outputs.date }}"
+          commit: "Theme Tools Release — ${{ steps.date.outputs.date }}"
           # When there are no changesets, this gets called
           publish: yarn changeset publish
           # When there are changesets, this gets called and then a PR is opened/updated


### PR DESCRIPTION
Noticed this when looking up the newest release: https://github.com/Shopify/theme-tools/commit/9173015ccf7f3f81372fa9b5cbcd44567a9b126a