### PR TITLE
`check` test helper shouldn't silently swallow errors

### DIFF
--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -39,7 +39,7 @@ export function getTheme(themeDesc: MockTheme): Theme {
 
 export async function check(
   themeDesc: MockTheme,
-  checks: CheckDefinition<SourceCodeType>[] = recommended,
+  checks: CheckDefinition[] = recommended,
   mockDependencies: Partial<Dependencies> = {},
   checkSettings: ChecksSettings = {},
 ): Promise<Offense[]> {
@@ -47,8 +47,11 @@ export async function check(
   const config: Config = {
     context: 'theme',
     settings: { ...checkSettings },
-    checks: checks,
+    checks,
     rootUri,
+    onError: (err) => {
+      throw err;
+    },
   };
 
   const sections = new Map(


### PR DESCRIPTION
## What are you adding in this PR?

Another small one from me. Currently the `check()` test helper (which wraps the main `check()` export) will happily run a broken rule and report no issues. That is, given a check like this:

```ts
export const SomeWonkyCheck: LiquidCheckDefinition = {
  // metadata block excluded...
  create(context) {
    return {
      async LiquidRawTag(node) {
        throw new Error("I tried to do something weird!")
      },
    };
  },
};
```

a test like this will be green:

```ts
it('does not report an error, even if the rule implementation is busted', async () => {
  const theme = {
    'sections/example.liquid': toLiquid(someConfigThatTriggersAnEdgeCase),
  };

  const offenses = await check(theme, [SomeWonkyCheck]);

  expect(offenses).toHaveLength(0);
});
```

This PR overrides the default no-op `onError` so that we properly rethrow errors when running tests, rather than silently squelching all error output. Fortunately, this doesn't seem to unmask any broken test cases. I can't really think of any reason this shouldn't be the default — callers of the `check()` test helper can wrap it in `try...catch` if they genuinely have some reason to expect a check to throw, though my intuition is that checks should never be doing that on purpose.