### PR TITLE
[Theme Check][LiquidDoc] Validate parameters passed to `render` markup 

### DIFF
--- a/.changeset/fair-colts-deny.md
+++ b/.changeset/fair-colts-deny.md
@@ -7,3 +7,4 @@ Add ValidRenderSnippetParams check which validates args passed to snippets with 
 
 - Checks that required parameters are provided
 - Checks that unknown parameters are not provided
+- Checks that the defined type of a parameter matches the type of the provided value if provided

--- a/packages/theme-check-common/src/liquid-doc/utils.ts
+++ b/packages/theme-check-common/src/liquid-doc/utils.ts
@@ -1,0 +1,47 @@
+import { LiquidNamedArgument, NodeTypes } from '@shopify/liquid-html-parser';
+import { assertNever } from '../utils';
+
+export enum SupportedTypes {
+  String = 'string',
+  Number = 'number',
+  Boolean = 'boolean',
+  Object = 'object',
+}
+
+/**
+ * Casts the value of a LiquidNamedArgument to a string representing the type of the value.
+ */
+export function inferArgumentType(arg: LiquidNamedArgument): SupportedTypes {
+  switch (arg.value.type) {
+    case NodeTypes.String:
+      return SupportedTypes.String;
+    case NodeTypes.Number:
+      return SupportedTypes.Number;
+    case NodeTypes.LiquidLiteral:
+      return SupportedTypes.Boolean;
+    case NodeTypes.Range:
+    case NodeTypes.VariableLookup:
+      return SupportedTypes.Object;
+    default:
+      // This ensures that we have a case for every possible type for arg.value
+      return assertNever(arg.value);
+  }
+}
+
+/**
+ * Provides a default completion value for an argument / parameter of a given type.
+ */
+export function getDefaultValueForType(type: string | null) {
+  switch (type?.toLowerCase()) {
+    case SupportedTypes.String:
+      return "''";
+    case SupportedTypes.Number:
+      return '0';
+    case SupportedTypes.Boolean:
+      return 'false';
+    case SupportedTypes.Object:
+      return '';
+    default:
+      return "''";
+  }
+}


### PR DESCRIPTION
## What are you adding in this PR?

<!-- Describe your changes. Provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Remember to use `fixes` or `solves` keywords to close issues automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

## What's next? Any followup issues?

<!-- Outline follow up tasks with links to issues so they're tracked. -->

## What did you learn?

<!-- Totally optional. But... If you learned something interesting, why not share it? -->

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config
  - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (link PR here).

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
