### PR TITLE
Add doc tag auto completion

### DIFF
--- a/.changeset/modern-eyes-visit.md
+++ b/.changeset/modern-eyes-visit.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/liquid-html-parser': patch
+---
+
+Add doc tag auto completion
+EX: Typing `{% do` will offer an autocompletion for `{% doc %} {% enddoc %}`

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -305,6 +305,7 @@ Liquid <: Helpers {
     // Base blocks
     | "capture"
     | "case"
+    | "doc"
     | "for"
     | "ifchanged"
     | "if"
@@ -399,7 +400,6 @@ LiquidDoc <: Helpers {
     | exampleNode
     | descriptionNode
     | fallbackNode
-    
   // By default, space matches new lines as well. We override it here to make writing rules easier.
   strictSpace = " " | "\t"
   // We use this as an escape hatch to stop matching TextNode and try again when one of these characters is encountered

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.spec.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.spec.ts
@@ -86,7 +86,7 @@ describe('Module: LiquidHTMLSyntaxError', () => {
     const offenses = await runLiquidCheck(LiquidHTMLSyntaxError, sourceCode);
     expect(offenses).to.have.length(1);
     expect(offenses[0].message).to.equal(
-      `SyntaxError: expected "#", a letter, "when", "sections", "section", "render", "liquid", "layout", "increment", "include", "elsif", "else", "echo", "decrement", "content_for", "cycle", "continue", "break", "assign", "tablerow", "unless", "if", "ifchanged", "for", "case", "capture", "paginate", "form", "end", "style", "stylesheet", "schema", "javascript", "raw", "comment", or "doc"`,
+      `SyntaxError: expected "#", a letter, "when", "sections", "section", "render", "liquid", "layout", "increment", "include", "elsif", "else", "echo", "decrement", "content_for", "cycle", "continue", "break", "assign", "tablerow", "unless", "if", "ifchanged", "for", "doc", "case", "capture", "paginate", "form", "end", "style", "stylesheet", "schema", "javascript", "raw", or "comment"`,
     );
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
@@ -76,6 +76,11 @@ export const tags: TagEntry[] = [
     ],
   },
   { name: 'echo' },
+  {
+    name: 'doc',
+    syntax: '{% doc %}doc_body{% enddoc %}',
+    syntax_keywords: [{ keyword: 'doc_body', description: '...' }],
+  },
 ];
 
 describe('Module: LiquidTagsCompletionProvider', async () => {
@@ -101,6 +106,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
     await expect(provider).to.complete('{% ren', ['render']);
     await expect(provider).to.complete('{% rend', ['render']);
     await expect(provider).to.complete('{% fo', ['for']);
+    await expect(provider).to.complete('{% do', ['doc']);
   });
 
   it('should complete end tags with the correct thing', async () => {
@@ -111,6 +117,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
       'endjavascript',
     ]);
     await expect(provider).to.complete('{% form "cart", cart %} ... {% end', ['endform']);
+    await expect(provider).to.complete('{% doc %} doc_body {% end', ['enddoc']);
   });
 
   it('should not complete literal `liquid` tag', async () => {
@@ -141,6 +148,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
       'endjavascript',
     ]);
     await expect(provider).to.complete('{% form "cart", cart %} ... {% e', ['echo', 'endform']);
+    await expect(provider).to.complete('{% doc %} my doc {% e', ['echo', 'enddoc']);
   });
 
   it('should not complete anything if the partial end tag does not match', async () => {
@@ -149,6 +157,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
     await expect(provider).to.complete('{% for i in (1..3) %}{% endz', []);
     await expect(provider).to.complete('{% javascript %} console.log("hi") {% endz', []);
     await expect(provider).to.complete('{% form "cart", cart %} ... {% endz', []);
+    await expect(provider).to.complete('{% doc %} my doc {% endz', []);
   });
 
   it('should complete empty statements', async () => {
@@ -171,6 +180,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
       '{% form "cart", cart %} ... {% ',
       allTags.concat('endform'),
     );
+    await expect(provider).to.complete('{% doc %} my doc {% ', allTags.concat('enddoc'));
   });
 
   describe('Snippet completion', () => {

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
@@ -40,6 +40,17 @@ export class LiquidTagsCompletionProvider implements Provider {
     const partial = node.name.replace(CURSOR, '');
     const blockParent = findParentNode(partial, ancestors);
     const tags = await this.themeDocset.tags();
+    if (!tags.some(tag => tag.name === 'doc')) {
+      tags.push({
+        name: 'doc',
+        category: 'theme',
+        description: 'Creates a documentation block in your theme.',
+        syntax: '{% doc %}\n content\n{% enddoc %}',
+        syntax_keywords: [{ keyword: 'content', description: 'The content of the doc' }],
+        deprecated: false,
+        parameters: [],
+      });
+    }
     return tags
       .filter(({ name }) => name.startsWith(partial))
       .sort(sortByName)

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
@@ -40,7 +40,7 @@ export class LiquidTagsCompletionProvider implements Provider {
     const partial = node.name.replace(CURSOR, '');
     const blockParent = findParentNode(partial, ancestors);
     const tags = await this.themeDocset.tags();
-    if (!tags.some(tag => tag.name === 'doc')) {
+    if (!tags.some((tag) => tag.name === 'doc')) {
       tags.push({
         name: 'doc',
         category: 'theme',


### PR DESCRIPTION
## What are you adding in this PR?
References: https://github.com/Shopify/developer-tools-team/issues/530
Add autocompletion for the doc tag.
Ex: If you start typing `{% do` an auto completion option will come up for `doc`
If you accept it, it will look like:
```liquid
{% doc %}

{% enddoc %}
```

## What's next? Any followup issues?

The actual implementation for the doc tag lives [here](https://github.com/Shopify/theme-liquid-docs/blob/main/data/tags.json) in the `theme-liquid-docs` repo. We don't want to ship usage of the tag yet. For now, the tag has been hardcoded and will be subsequently removed when we officially ship it in the `theme-liquid-docs` repo.

## Before you deploy
<!-- Public API changes, new features -->
- [X] I included a minor bump `changeset`
- [X] My feature is backward compatible

