### PR TITLE
Support Liquid doc param type completion

### DIFF
--- a/.changeset/kind-grapes-burn.md
+++ b/.changeset/kind-grapes-burn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+[internal] Adding list of supported doc tag types

--- a/.changeset/two-numbers-hunt.md
+++ b/.changeset/two-numbers-hunt.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Adding liquid doc param type completion
+
+- render param completion supports default values based on param type

--- a/packages/theme-check-common/src/liquid-doc/utils.ts
+++ b/packages/theme-check-common/src/liquid-doc/utils.ts
@@ -1,0 +1,30 @@
+export enum SupportedParamTypes {
+  String = 'string',
+  Number = 'number',
+  Boolean = 'boolean',
+  Object = 'object',
+}
+
+export enum SupportedDocTagTypes {
+  Param = 'param',
+  Example = 'example',
+  Description = 'description',
+}
+
+/**
+ * Provides a default completion value for an argument / parameter of a given type.
+ */
+export function getDefaultValueForType(type: string | null) {
+  switch (type?.toLowerCase()) {
+    case SupportedParamTypes.String:
+      return "''";
+    case SupportedParamTypes.Number:
+      return '0';
+    case SupportedParamTypes.Boolean:
+      return 'false';
+    case SupportedParamTypes.Object:
+      return '';
+    default:
+      return "''";
+  }
+}

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -29,6 +29,7 @@ import {
 import { GetSnippetNamesForURI } from './providers/RenderSnippetCompletionProvider';
 import { RenderSnippetParameterCompletionProvider } from './providers/RenderSnippetParameterCompletionProvider';
 import { LiquidDocTagCompletionProvider } from './providers/LiquidDocTagCompletionProvider';
+import { LiquidDocParamTypeCompletionProvider } from './providers/LiquidDocParamTypeCompletionProvider';
 
 export interface CompletionProviderDependencies {
   documentManager: DocumentManager;
@@ -86,6 +87,7 @@ export class CompletionsProvider {
       new RenderSnippetParameterCompletionProvider(getSnippetDefinitionForURI),
       new FilterNamedParameterCompletionProvider(themeDocset),
       new LiquidDocTagCompletionProvider(),
+      new LiquidDocParamTypeCompletionProvider(),
     ];
   }
 

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.spec.ts
@@ -1,0 +1,43 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { CompletionsProvider } from '../CompletionsProvider';
+import { DocumentManager } from '../../documents';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
+import { SupportedParamTypes } from '@shopify/theme-check-common/src/liquid-doc/utils';
+
+describe('Module: LiquidDocParamTypeCompletionProvider', async () => {
+  let provider: CompletionsProvider;
+
+  beforeEach(async () => {
+    provider = new CompletionsProvider({
+      documentManager: new DocumentManager(),
+      themeDocset: {
+        filters: async () => [],
+        objects: async () => [],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    });
+  });
+
+  it("offers type completions within liquid doc's param type tag", async () => {
+    const sources = [`{% doc %} @param {█`, `{% doc %} @param  {  █`];
+
+    for (const source of sources) {
+      await expect(provider).to.complete(source, Object.values(SupportedParamTypes));
+    }
+  });
+
+  it("does not offer completion if it's not within liquid doc's param type tag", async () => {
+    const sources = [
+      `{% doc %} @param {}█`,
+      `{% doc %} @example {}█`,
+      `{% doc %} @param {string} - █`,
+      `@param {█`,
+    ];
+
+    for (const source of sources) {
+      await expect(provider).to.complete(source, []);
+    }
+  });
+});

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.ts
@@ -1,0 +1,50 @@
+import { NodeTypes } from '@shopify/liquid-html-parser';
+import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
+import { LiquidCompletionParams } from '../params';
+import { Provider } from './common';
+import {
+  SupportedDocTagTypes,
+  SupportedParamTypes,
+} from '@shopify/theme-check-common/src/liquid-doc/utils';
+
+export class LiquidDocParamTypeCompletionProvider implements Provider {
+  constructor() {}
+
+  async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
+    if (!params.completionContext) return [];
+
+    const { node, ancestors } = params.completionContext;
+    const parentNode = ancestors.at(-1);
+
+    if (
+      !node ||
+      !parentNode ||
+      node.type !== NodeTypes.TextNode ||
+      parentNode.type !== NodeTypes.LiquidRawTag ||
+      parentNode.name !== 'doc'
+    ) {
+      return [];
+    }
+
+    /**
+     * We need to make sure we're trying to code complete after
+     * the param tag's `{` character.
+     *
+     * We will be removing any spaces in case there are any formatting issues.
+     */
+    const fragments = node.value.split(' ').filter(Boolean);
+    if (
+      fragments.length > 2 ||
+      fragments[0] !== `@${SupportedDocTagTypes.Param}` ||
+      !/^\{[a-zA-Z]*$/.test(fragments[1])
+    ) {
+      return [];
+    }
+
+    return Object.values(SupportedParamTypes).map((label) => ({
+      label,
+      kind: CompletionItemKind.EnumMember,
+      insertText: label,
+    }));
+  }
+}

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.ts
@@ -11,6 +11,7 @@ import { CURSOR, LiquidCompletionParams } from '../params';
 import { Provider } from './common';
 import { formatLiquidDocParameter } from '../../utils/liquidDoc';
 import { GetSnippetDefinitionForURI } from '@shopify/theme-check-common';
+import { getDefaultValueForType } from '@shopify/theme-check-common/src/liquid-doc/utils';
 
 export type GetSnippetNamesForURI = (uri: string) => Promise<string[]>;
 
@@ -58,15 +59,24 @@ export class RenderSnippetParameterCompletionProvider implements Provider {
     return liquidDocParams
       .filter((liquidDocParam) => !existingRenderParams.includes(liquidDocParam.name))
       .filter((liquidDocParam) => liquidDocParam.name.startsWith(userInputStr))
-      .map((liquidDocParam) => ({
-        label: liquidDocParam.name,
-        kind: CompletionItemKind.Property,
-        documentation: {
-          kind: MarkupKind.Markdown,
-          value: formatLiquidDocParameter(liquidDocParam, true),
-        },
-        textEdit: TextEdit.replace(Range.create(start, end), `${liquidDocParam.name}: $0`),
-        insertTextFormat: InsertTextFormat.Snippet,
-      }));
+      .map((liquidDocParam) => {
+        const paramDefaultValue = getDefaultValueForType(liquidDocParam.type);
+        const paramValueTemplate =
+          paramDefaultValue === "''" ? `'$1'$0` : `\${1:${paramDefaultValue}}$0`;
+
+        return {
+          label: liquidDocParam.name,
+          kind: CompletionItemKind.Property,
+          documentation: {
+            kind: MarkupKind.Markdown,
+            value: formatLiquidDocParameter(liquidDocParam, true),
+          },
+          textEdit: TextEdit.replace(
+            Range.create(start, end),
+            `${liquidDocParam.name}: ${paramValueTemplate}`,
+          ),
+          insertTextFormat: InsertTextFormat.Snippet,
+        };
+      });
   }
 }

--- a/packages/theme-language-server-common/src/utils/liquidDoc.ts
+++ b/packages/theme-language-server-common/src/utils/liquidDoc.ts
@@ -1,4 +1,8 @@
 import { LiquidDocParameter } from '@shopify/theme-check-common';
+import {
+  SupportedDocTagTypes,
+  SupportedParamTypes,
+} from '@shopify/theme-check-common/src/liquid-doc/utils';
 
 export function formatLiquidDocParameter(
   { name, type, description, required }: LiquidDocParameter,
@@ -21,12 +25,14 @@ export function formatLiquidDocTagHandle(label: string, description: string, exa
 }
 
 export const SUPPORTED_LIQUID_DOC_TAG_HANDLES = {
-  param: {
+  [SupportedDocTagTypes.Param]: {
     description:
       'Provides information about a parameter for the snippet.\n' +
-      '- The type of parameter is optional and can be `string`, `number`, or `Object`.\n' +
-      '- An optional parameter is denoted by square brackets around the parameter name.\n' +
-      '- The description is optional Markdown text.',
+      `- The type of parameter is optional and can be ${Object.values(SupportedParamTypes)
+        .map((type) => `\`${type}\``)
+        .join(', ')}\n` +
+      '- An optional parameter is denoted by square brackets around the parameter name\n' +
+      '- The description is optional Markdown text',
     example:
       '{% doc %}\n' +
       "  @param {string} name - The person's name\n" +
@@ -34,13 +40,13 @@ export const SUPPORTED_LIQUID_DOC_TAG_HANDLES = {
       '{% enddoc %}\n',
     template: `param {$1} $2 - $0`,
   },
-  example: {
+  [SupportedDocTagTypes.Example]: {
     description: 'Provides an example on how to use the snippet.',
     example:
       '{% doc %}\n' + '  @example {% render "snippet-name", arg1: "value" %}\n' + '{% enddoc %}\n',
     template: `example\n$0`,
   },
-  description: {
+  [SupportedDocTagTypes.Description]: {
     description: 'Provides information on what the snippet does.',
     example:
       '{% doc %}\n' + '  @description This snippet renders a product image.\n' + '{% enddoc %}\n',


### PR DESCRIPTION
## What are you adding in this PR?

https://github.com/Shopify/developer-tools-team/issues/508

- Adds type completion for liquid docs
- NOTE: packages/theme-check-common/src/liquid-doc/utils.ts is actually from @jamesmengo [PR](https://github.com/Shopify/theme-tools/pull/791) that isn't merged yet

## Tophat 1

- Tophat
- Create a doc tag
- When you type `@param {` and trigger code-completion, it should provide you with types

## Tophat 2

- Render a snippet with liquid doc params
- If the param is `string` or unknown, the completion will place surrounding quotes and put your cursor in the middle of it
- If the param is `boolean`, `object`, or `number`, it will place a default value
  - Press tab to keep the default value
  - Start typing to override the default value

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
