### PR TITLE
Add description support for prettier

### DIFF
--- a/.changeset/swift-snails-check.md
+++ b/.changeset/swift-snails-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+---
+
+Add prettier support for the `@description` tag

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -5,6 +5,7 @@ import {
   RawMarkup,
   LiquidDocParamNode,
   LiquidDocExampleNode,
+  LiquidDocDescriptionNode,
 } from '@shopify/liquid-html-parser';
 import { Doc, doc } from 'prettier';
 
@@ -554,6 +555,22 @@ export function printLiquidDocExample(
       parts.push(hardline);
     }
     parts.push(content.trim());
+  }
+
+  return parts;
+}
+
+export function printLiquidDocDescription(
+  path: AstPath<LiquidDocDescriptionNode>,
+  options: LiquidParserOptions,
+  _print: LiquidPrinter,
+  _args: LiquidPrinterArgs,
+): Doc {
+  const node = path.getValue();
+  const parts: Doc[] = ['@description'];
+
+  if (node.content?.value) {
+    parts.push(' ', node.content.value.trim());
   }
 
   return parts;

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -1,5 +1,6 @@
 import {
   getConditionalComment,
+  LiquidDocDescriptionNode,
   LiquidDocExampleNode,
   LiquidDocParamNode,
   NodeTypes,
@@ -49,6 +50,7 @@ import {
   printLiquidVariableOutput,
   printLiquidDocParam,
   printLiquidDocExample,
+  printLiquidDocDescription,
 } from './print/liquid';
 import { printClosingTagSuffix, printOpeningTagPrefix } from './print/tag';
 import { bodyLines, hasLineBreakInRange, isEmpty, isTextLikeNode, reindent } from './utils';
@@ -566,7 +568,12 @@ function printNode(
     }
 
     case NodeTypes.LiquidDocDescriptionNode: {
-      return '';
+      return printLiquidDocDescription(
+        path as AstPath<LiquidDocDescriptionNode>,
+        options,
+        print,
+        args,
+      );
     }
 
     default: {

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
@@ -88,3 +88,21 @@ It should allow multiple example nodes
   @example
   Second Example
 {% enddoc %}
+
+It should move description content inline
+{% doc %}
+  @description This is a description
+{% enddoc %}
+
+It should add a space between a description tag and content
+{% doc %}
+  @description This is a description
+{% enddoc %}
+
+It should handle param, example, and description nodes
+{% doc %}
+  @param {String} paramName - param with description
+  @example
+  This is a valid example
+  @description This is a description
+{% enddoc %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
@@ -87,3 +87,23 @@ It should allow multiple example nodes
   @example
   Second Example
 {% enddoc %}
+
+It should move description content inline
+{% doc %}
+  @description
+  This is a description
+{% enddoc %}
+
+It should add a space between a description tag and content
+{% doc %}
+  @descriptionThis is a description
+{% enddoc %}
+
+It should handle param, example, and description nodes
+{% doc %}
+  @param {String} paramName - param with description
+  @example
+  This is a valid example
+  @description This is a description
+{% enddoc %}
+


### PR DESCRIPTION
## What are you adding in this PR?

Closes: https://github.com/Shopify/developer-tools-team/issues/504

Add prettier support for the `@description` tag

## Testing
Add a `@description` tag and some text to see how it formats.

## Before you deploy

<!-- Public API changes, new features -->
- [X] I included a minor bump `changeset`
- [X] My feature is backward compatible
