### PR TITLE
Add hover support for the description tag

### DIFF
--- a/.changeset/popular-geese-flow.md
+++ b/.changeset/popular-geese-flow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Add hover support for the `@description` tag

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1082,8 +1082,8 @@ describe('Unit: Stage 1 (CST)', () => {
         });
 
         it('should parse @param with malformed optional delimiters as Text Nodes', () => {
-          const testStr = `{% doc %} 
-            @param paramWithMissingHeadDelim] 
+          const testStr = `{% doc %}
+            @param paramWithMissingHeadDelim]
             @param [paramWithMissingTailDelim
             @param missingHeadWithDescription] - description value
             @param [missingTailWithDescription - description value
@@ -1330,10 +1330,10 @@ describe('Unit: Stage 1 (CST)', () => {
           {% enddoc %}`;
           cst = toCST(testStr);
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
-          expectPath(cst, '0.children.0.content.value').to.equal('This is a description\n');
+          expectPath(cst, '0.children.0.content.value').to.equal('This is a description');
 
           expectPath(cst, '0.children.1.type').to.equal('LiquidDocDescriptionNode');
-          expectPath(cst, '0.children.1.content.value').to.equal('This is a second description\n');
+          expectPath(cst, '0.children.1.content.value').to.equal('This is a second description');
         });
 
         it('should parse and strip whitespace from description tag with content that has leading whitespace', () => {
@@ -1362,7 +1362,7 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
           expectPath(cst, '0.children.0.name').to.equal('description');
           expectPath(cst, '0.children.0.content.value').to.equal(
-            'hello      there        my    friend\n          This is a description\n          It supports multiple lines\n',
+            'hello      there        my    friend\n          This is a description\n          It supports multiple lines',
           );
         });
 
@@ -1373,9 +1373,9 @@ describe('Unit: Stage 1 (CST)', () => {
         {% enddoc %}`;
           cst = toCST(testStr);
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
-          expectPath(cst, '0.children.0.content.value').to.equal('hello there\n');
+          expectPath(cst, '0.children.0.content.value').to.equal('hello there');
           expectPath(cst, '0.children.1.type').to.equal('LiquidDocDescriptionNode');
-          expectPath(cst, '0.children.1.content.value').to.equal('second description\n');
+          expectPath(cst, '0.children.1.content.value').to.equal('second description');
         });
       }
     });

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -1400,7 +1400,15 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
       source,
       content: 2,
     },
-    descriptionContent: textNode(),
+    descriptionContent: {
+      type: ConcreteNodeTypes.TextNode,
+      value: function (this: Node) {
+        return this.sourceString.trim();
+      },
+      locStart,
+      locEnd,
+      source,
+    },
     paramType: 2,
     paramTypeContent: textNode(),
     paramName: {

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1385,10 +1385,10 @@ describe('Unit: Stage 2 (AST)', () => {
         {% enddoc %}
       `);
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocDescriptionNode');
-      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description\n');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description');
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocDescriptionNode');
       expectPath(ast, 'children.0.body.nodes.1.content.value').to.eql(
-        'This is another description\n        it can have multiple lines\n',
+        'This is another description\n        it can have multiple lines',
       );
 
       ast = toLiquidAST(`
@@ -1399,7 +1399,7 @@ describe('Unit: Stage 2 (AST)', () => {
         {% enddoc %}
       `);
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocDescriptionNode');
-      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description\n');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description');
 
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.1.name').to.eql('example');
@@ -1572,7 +1572,7 @@ describe('Unit: Stage 2 (AST)', () => {
         @p█
       `);
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocDescriptionNode');
-      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description\n');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description');
 
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.1.name').to.eql('example');

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -584,7 +584,7 @@ export function printLiquidDocDescription(
   const parts: Doc[] = ['@description'];
 
   if (node.content?.value) {
-    parts.push(' ', node.content.value.trim());
+    parts.push(' ', node.content.value);
   }
 
   return parts;

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
@@ -102,12 +102,12 @@ It should add a space between a description tag and content
 
 It should handle param, example, and description nodes
 {% doc %}
+  @description This is a description
+
   @param {String} paramName - param with description
 
   @example
   This is a valid example
-
-  @description This is a description
 {% enddoc %}
 
 It should add padding between dissimilar nodes

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
@@ -101,10 +101,10 @@ It should add a space between a description tag and content
 
 It should handle param, example, and description nodes
 {% doc %}
+  @description This is a description
   @param {String} paramName - param with description
   @example
   This is a valid example
-  @description This is a description
 {% enddoc %}
 
 It should add padding between dissimilar nodes

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
@@ -192,6 +192,45 @@ describe('Unit: getSnippetDefinition', () => {
     });
   });
 
+  it('should extract description from @description annotations', async () => {
+    const ast = toAST(`
+        {% doc %}
+          @description This is a description
+        {% enddoc %}
+      `);
+
+    const result = getSnippetDefinition(ast, 'product-card');
+    expect(result).to.deep.equal({
+      name: 'product-card',
+      liquidDoc: {
+        description: {
+          content: 'This is a description\n',
+          nodeType: 'description',
+        },
+      },
+    });
+  });
+
+  it('should extract only the first @description annotation', async () => {
+    const ast = toAST(`
+        {% doc %}
+          @description This is a description
+          @description This is another description
+        {% enddoc %}
+      `);
+
+    const result = getSnippetDefinition(ast, 'product-card');
+    expect(result).to.deep.equal({
+      name: 'product-card',
+      liquidDoc: {
+        description: {
+          content: 'This is a description\n',
+          nodeType: 'description',
+        },
+      },
+    });
+  });
+
   it('should return snippetDefinition without liquidDoc property if doc header is not present', async () => {
     const ast = toAST(`
       <div>No doc header here</div>

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
@@ -204,7 +204,7 @@ describe('Unit: getSnippetDefinition', () => {
       name: 'product-card',
       liquidDoc: {
         description: {
-          content: 'This is a description\n',
+          content: 'This is a description',
           nodeType: 'description',
         },
       },
@@ -224,7 +224,7 @@ describe('Unit: getSnippetDefinition', () => {
       name: 'product-card',
       liquidDoc: {
         description: {
-          content: 'This is a description\n',
+          content: 'This is a description',
           nodeType: 'description',
         },
       },

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -70,7 +70,7 @@ describe('Module: RenderSnippetHoverProvider', async () => {
       provider = createProvider(async () => mockSnippetDefinition);
       await expect(provider).to.hover(
         `{% render 'product-car█d' %}`,
-        '### product-card\n\n**Description:**\nThis is a description\n\n**Parameters:**\n- `title`: string - The title of the product\n- `border-radius` (Optional): number - The border radius in px\n- `no-type` - This parameter has no type\n- `no-description`: string\n- `no-type-or-description`\n\n**Examples:**\n```liquid{{ product }}```\n```liquid{{ product.title }}```',
+        '### product-card\n\n**Description:**\n\n\nThis is a description\n\n**Parameters:**\n- `title`: string - The title of the product\n- `border-radius` (Optional): number - The border radius in px\n- `no-type` - This parameter has no type\n- `no-description`: string\n- `no-type-or-description`\n\n**Examples:**\n```liquid{{ product }}```\n```liquid{{ product.title }}```',
       );
     });
 

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -49,7 +49,7 @@ describe('Module: RenderSnippetHoverProvider', async () => {
         },
       ],
       description: {
-        content: 'This is a description\n',
+        content: 'This is a description',
         nodeType: 'description',
       },
       examples: [
@@ -70,7 +70,7 @@ describe('Module: RenderSnippetHoverProvider', async () => {
       provider = createProvider(async () => mockSnippetDefinition);
       await expect(provider).to.hover(
         `{% render 'product-car█d' %}`,
-        '### product-card\n\n**Parameters:**\n- `title`: string - The title of the product\n- `border-radius` (Optional): number - The border radius in px\n- `no-type` - This parameter has no type\n- `no-description`: string\n- `no-type-or-description`\n\n**Description:**\nThis is a description\n\n**Examples:**\n```liquid{{ product }}```\n```liquid{{ product.title }}```',
+        '### product-card\n\n**Description:**\nThis is a description\n\n**Parameters:**\n- `title`: string - The title of the product\n- `border-radius` (Optional): number - The border radius in px\n- `no-type` - This parameter has no type\n- `no-description`: string\n- `no-type-or-description`\n\n**Examples:**\n```liquid{{ product }}```\n```liquid{{ product.title }}```',
       );
     });
 

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -48,6 +48,10 @@ describe('Module: RenderSnippetHoverProvider', async () => {
           nodeType: 'param',
         },
       ],
+      description: {
+        content: 'This is a description\n',
+        nodeType: 'description',
+      },
       examples: [
         {
           content: '{{ product }}',
@@ -66,7 +70,7 @@ describe('Module: RenderSnippetHoverProvider', async () => {
       provider = createProvider(async () => mockSnippetDefinition);
       await expect(provider).to.hover(
         `{% render 'product-car█d' %}`,
-        '### product-card\n\n**Parameters:**\n- `title`: string - The title of the product\n- `border-radius` (Optional): number - The border radius in px\n- `no-type` - This parameter has no type\n- `no-description`: string\n- `no-type-or-description`\n\n**Examples:**\n```liquid{{ product }}```\n```liquid{{ product.title }}```',
+        '### product-card\n\n**Parameters:**\n- `title`: string - The title of the product\n- `border-radius` (Optional): number - The border radius in px\n- `no-type` - This parameter has no type\n- `no-description`: string\n- `no-type-or-description`\n\n**Description:**\nThis is a description\n\n**Examples:**\n```liquid{{ product }}```\n```liquid{{ product.title }}```',
       );
     });
 

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -54,6 +54,11 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
       parts.push('', '**Parameters:**', parameters);
     }
 
+    if (liquidDoc.description) {
+      const description = liquidDoc.description.content.trim();
+      parts.push('', '**Description:**', description);
+    }
+
     if (liquidDoc.examples?.length) {
       const examples = liquidDoc.examples
         ?.map(({ content }) => `\`\`\`liquid${content}\`\`\``)

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -51,7 +51,7 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
 
     if (liquidDoc.description) {
       const description = liquidDoc.description.content;
-      parts.push('', '**Description:**', description);
+      parts.push('', '**Description:**', '\n', description);
     }
 
     if (liquidDoc.parameters?.length) {

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -49,14 +49,14 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
 
     const parts = [`### ${snippetDefinition.name}`];
 
+    if (liquidDoc.description) {
+      const description = liquidDoc.description.content;
+      parts.push('', '**Description:**', description);
+    }
+
     if (liquidDoc.parameters?.length) {
       const parameters = this.buildParameters(liquidDoc.parameters);
       parts.push('', '**Parameters:**', parameters);
-    }
-
-    if (liquidDoc.description) {
-      const description = liquidDoc.description.content.trim();
-      parts.push('', '**Description:**', description);
     }
 
     if (liquidDoc.examples?.length) {


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/505

Add hover support for the `@description` tag when hovering over a snippet & supporting tests.

Example Output:
![image](https://github.com/user-attachments/assets/9a79fb9b-971d-43bf-88d4-d8096a17dd6f)

## Before you deploy

<!-- Public API changes, new features -->
- [X] I included a minor bump `changeset`
- [X] My feature is backward compatible
