### PR TITLE
Revert "Add doc tag auto completion"

### DIFF
--- a/.changeset/modern-eyes-visit.md
+++ b/.changeset/modern-eyes-visit.md
@@ -1,7 +1,0 @@
----
-'@shopify/theme-language-server-common': patch
-'@shopify/liquid-html-parser': patch
----
-
-Add doc tag auto completion
-EX: Typing `{% do` will offer an autocompletion for `{% doc %} {% enddoc %}`

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -305,7 +305,6 @@ Liquid <: Helpers {
     // Base blocks
     | "capture"
     | "case"
-    | "doc"
     | "for"
     | "ifchanged"
     | "if"
@@ -400,6 +399,7 @@ LiquidDoc <: Helpers {
     | exampleNode
     | descriptionNode
     | fallbackNode
+    
   // By default, space matches new lines as well. We override it here to make writing rules easier.
   strictSpace = " " | "\t"
   // We use this as an escape hatch to stop matching TextNode and try again when one of these characters is encountered

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.spec.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.spec.ts
@@ -86,7 +86,7 @@ describe('Module: LiquidHTMLSyntaxError', () => {
     const offenses = await runLiquidCheck(LiquidHTMLSyntaxError, sourceCode);
     expect(offenses).to.have.length(1);
     expect(offenses[0].message).to.equal(
-      `SyntaxError: expected "#", a letter, "when", "sections", "section", "render", "liquid", "layout", "increment", "include", "elsif", "else", "echo", "decrement", "content_for", "cycle", "continue", "break", "assign", "tablerow", "unless", "if", "ifchanged", "for", "doc", "case", "capture", "paginate", "form", "end", "style", "stylesheet", "schema", "javascript", "raw", or "comment"`,
+      `SyntaxError: expected "#", a letter, "when", "sections", "section", "render", "liquid", "layout", "increment", "include", "elsif", "else", "echo", "decrement", "content_for", "cycle", "continue", "break", "assign", "tablerow", "unless", "if", "ifchanged", "for", "case", "capture", "paginate", "form", "end", "style", "stylesheet", "schema", "javascript", "raw", "comment", or "doc"`,
     );
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
@@ -76,11 +76,6 @@ export const tags: TagEntry[] = [
     ],
   },
   { name: 'echo' },
-  {
-    name: 'doc',
-    syntax: '{% doc %}doc_body{% enddoc %}',
-    syntax_keywords: [{ keyword: 'doc_body', description: '...' }],
-  },
 ];
 
 describe('Module: LiquidTagsCompletionProvider', async () => {
@@ -106,7 +101,6 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
     await expect(provider).to.complete('{% ren', ['render']);
     await expect(provider).to.complete('{% rend', ['render']);
     await expect(provider).to.complete('{% fo', ['for']);
-    await expect(provider).to.complete('{% do', ['doc']);
   });
 
   it('should complete end tags with the correct thing', async () => {
@@ -117,7 +111,6 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
       'endjavascript',
     ]);
     await expect(provider).to.complete('{% form "cart", cart %} ... {% end', ['endform']);
-    await expect(provider).to.complete('{% doc %} doc_body {% end', ['enddoc']);
   });
 
   it('should not complete literal `liquid` tag', async () => {
@@ -148,7 +141,6 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
       'endjavascript',
     ]);
     await expect(provider).to.complete('{% form "cart", cart %} ... {% e', ['echo', 'endform']);
-    await expect(provider).to.complete('{% doc %} my doc {% e', ['echo', 'enddoc']);
   });
 
   it('should not complete anything if the partial end tag does not match', async () => {
@@ -157,7 +149,6 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
     await expect(provider).to.complete('{% for i in (1..3) %}{% endz', []);
     await expect(provider).to.complete('{% javascript %} console.log("hi") {% endz', []);
     await expect(provider).to.complete('{% form "cart", cart %} ... {% endz', []);
-    await expect(provider).to.complete('{% doc %} my doc {% endz', []);
   });
 
   it('should complete empty statements', async () => {
@@ -180,7 +171,6 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
       '{% form "cart", cart %} ... {% ',
       allTags.concat('endform'),
     );
-    await expect(provider).to.complete('{% doc %} my doc {% ', allTags.concat('enddoc'));
   });
 
   describe('Snippet completion', () => {

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
@@ -40,17 +40,6 @@ export class LiquidTagsCompletionProvider implements Provider {
     const partial = node.name.replace(CURSOR, '');
     const blockParent = findParentNode(partial, ancestors);
     const tags = await this.themeDocset.tags();
-    if (!tags.some((tag) => tag.name === 'doc')) {
-      tags.push({
-        name: 'doc',
-        category: 'theme',
-        description: 'Creates a documentation block in your theme.',
-        syntax: '{% doc %}\n content\n{% enddoc %}',
-        syntax_keywords: [{ keyword: 'content', description: 'The content of the doc' }],
-        deprecated: false,
-        parameters: [],
-      });
-    }
     return tags
       .filter(({ name }) => name.startsWith(partial))
       .sort(sortByName)


### PR DESCRIPTION
Reverts Shopify/theme-tools#794

Reverting due to error on main


### Notes
The liquidohm rules for doc tag are different than the other [rules](https://github.com/Shopify/theme-tools/blob/main/packages/liquid-html-parser/grammar/liquid-html.ohm) like `liquidTagStrict` and `liquidTagOpenStrict`. If the doc tag doesn't follow these rules, it will break. Without a proper end tag, it assumes anything that follows the doc tag will be part of the doc content, and appears as a `TextNode`.