### PR TITLE
Fix local block validations

### DIFF
--- a/.changeset/twenty-maps-drum.md
+++ b/.changeset/twenty-maps-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fixed local blocks validation to not consider preset blocks as containing local blocks when a name is present

--- a/packages/theme-check-common/src/checks/valid-local-blocks/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-local-blocks/index.spec.ts
@@ -25,39 +25,6 @@ describe('ValidLocalBlocks with array-style blocks', () => {
     expect(offenses[0].message).to.equal('Local scoped blocks are not supported in theme blocks.');
   });
 
-  it('should report errors when preset defined local blocks are defined in a block bucket', async () => {
-    const theme: MockTheme = {
-      'blocks/text.liquid': '',
-      'blocks/local-blocks.liquid': `
-        {% schema %}
-        {
-            "name": "Block name",
-            "blocks": [
-            {
-                "type": "text"
-            }
-            ],
-            "presets": [
-            {
-                "name": "Default",
-                "blocks": [
-                {
-                    "type": "local_block",
-                    "name": "Local Block"
-                }
-                ]
-            }
-            ]
-        }
-        {% endschema %}
-        `,
-    };
-
-    const offenses = await check(theme, [ValidLocalBlocks]);
-    expect(offenses).to.have.length(1);
-    expect(offenses[0].message).to.equal('Local scoped blocks are not supported in theme blocks.');
-  });
-
   it('should report errors when sections use theme blocks together with locally scoped blocks in root level', async () => {
     const theme: MockTheme = {
       'blocks/text.liquid': '',
@@ -154,217 +121,6 @@ describe('ValidLocalBlocks with array-style blocks', () => {
     const content = theme['sections/local-blocks.liquid'];
     const errorContent = content.slice(offenses[0].start.index, offenses[0].end.index);
     expect(errorContent).to.equal('"static_block"');
-  });
-
-  it('should report errors when static theme blocks have a name property', async () => {
-    const theme: MockTheme = {
-      'sections/local-blocks.liquid': `
-        {% schema %}
-        {
-            "name": "Section name",
-            "blocks": [
-            {
-                "type": "@theme"
-            }
-            ],
-            "presets": [
-            {
-                "name": "Default",
-                "blocks": [
-                {
-                    "id": "static_block",
-                    "type": "static_block",
-                    "static": true,
-                    "name": "Static Text Block"
-                }
-                ]
-            }
-            ]
-        }
-        {% endschema %}
-        `,
-    };
-    const offenses = await check(theme, [ValidLocalBlocks]);
-    expect(offenses).to.have.length(1);
-    expect(offenses[0].message).to.equal('Static theme blocks cannot have a name property.');
-  });
-
-  it('should report errors when static theme blocks have a name property within nested blocks', async () => {
-    const theme: MockTheme = {
-      'sections/local-blocks.liquid': `
-        {% schema %}
-        {
-            "name": "Section name",
-            "blocks": [
-            {
-                "type": "@theme"
-            }
-            ],
-            "presets": [
-            {
-                "name": "Default",
-                "blocks": [
-                {
-                   "type": "text",
-                   "blocks": [
-                    {
-                        "id": "static_block",
-                        "type": "static_block",
-                        "static": true,
-                        "name": "Static Text Block"
-                    }
-                   ]
-                }
-                ]
-            }
-            ]
-        }
-        {% endschema %}
-        `,
-    };
-    const offenses = await check(theme, [ValidLocalBlocks]);
-    expect(offenses).to.have.length(1);
-    expect(offenses[0].message).to.equal('Static theme blocks cannot have a name property.');
-  });
-});
-
-describe('ValidLocalBlocks with hash-style presets', () => {
-  it('should report errors when preset defined local blocks are defined in a block bucket with hash-style presets', async () => {
-    const theme: MockTheme = {
-      'blocks/text.liquid': '',
-      'blocks/local-blocks.liquid': `
-          {% schema %}
-          {
-            "name": "Block name",
-            "blocks": [
-              {
-                "type": "text"
-              }
-            ],
-            "presets": [
-              {
-                "name": "Default",
-                "blocks": {
-                  "local_block": {
-                    "type": "local_block",
-                    "name": "Local Block"
-                  }
-                },
-                "block_order": ["local_block"]
-              }
-            ]
-          }
-          {% endschema %}
-        `,
-    };
-
-    const offenses = await check(theme, [ValidLocalBlocks]);
-    expect(offenses).to.have.length(1);
-    expect(offenses[0].message).to.equal('Local scoped blocks are not supported in theme blocks.');
-  });
-
-  it('should report errors when sections use static theme blocks together with locally scoped blocks in hash-style presets', async () => {
-    const theme: MockTheme = {
-      'sections/local-blocks.liquid': `
-            {% schema %}
-            {
-              "name": "Section name",
-              "blocks": [
-                {
-                  "type": "local_block",
-                  "name": "Local Block"
-                }
-              ],
-              "presets": [
-                {
-                  "name": "Default",
-                  "blocks": {
-                    "static_block": {
-                      "type": "static_block",
-                      "static": true
-                    }
-                  }
-                }
-              ]
-            }
-            {% endschema %}
-        `,
-    };
-
-    const offenses = await check(theme, [ValidLocalBlocks]);
-    expect(offenses).to.have.length(1);
-    expect(offenses[0].message).to.equal(
-      'Sections cannot use static theme blocks together with locally scoped blocks.',
-    );
-  });
-
-  it('should report errors with correct indices when sections use static theme blocks together with locally scoped blocks in hash-style presets', async () => {
-    const theme: MockTheme = {
-      'sections/local-blocks.liquid': `
-          {% schema %}
-          {
-            "name": "Section name",
-            "blocks": [
-              {
-                "type": "local_block",
-                "name": "Local Block"
-              }
-            ],
-            "presets": [
-              {
-                "name": "Default",
-                "blocks": {
-                  "my_static_block": {
-                    "type": "static_block",
-                    "static": true
-                  }
-                }
-              }
-            ]
-          }
-          {% endschema %}
-        `,
-    };
-
-    const offenses = await check(theme, [ValidLocalBlocks]);
-    expect(offenses).to.have.length(1);
-
-    const content = theme['sections/local-blocks.liquid'];
-    const errorContent = content.slice(offenses[0].start.index, offenses[0].end.index);
-    expect(errorContent).to.equal('"static_block"');
-  });
-
-  it('should report errors when static theme blocks have a name property in hash-style presets', async () => {
-    const theme: MockTheme = {
-      'sections/local-blocks.liquid': `
-          {% schema %}
-          {
-            "name": "Section name",
-            "blocks": [
-              {
-                "type": "@theme"
-              }
-            ],
-            "presets": [
-              {
-                "name": "Default",
-                "blocks": {
-                  "static_block": {
-                    "type": "static_block",
-                    "static": true,
-                    "name": "Static Text Block"
-                  }
-                }
-              }
-            ]
-          }
-          {% endschema %}
-        `,
-    };
-
-    const offenses = await check(theme, [ValidLocalBlocks]);
-    expect(offenses).to.have.length(1);
-    expect(offenses[0].message).to.equal('Static theme blocks cannot have a name property.');
   });
 });
 
@@ -484,6 +240,43 @@ describe('ValidLocalBlocks on edge cases', () => {
           ]
         }
         {% endschema %}
+      `,
+    };
+    const offenses = await check(theme, [ValidLocalBlocks]);
+    expect(offenses).to.be.empty;
+  });
+
+  it('should not report errors when preset blocks have a name property', async () => {
+    const theme: MockTheme = {
+      'blocks/product-grid.liquid': `
+      {% schema %}
+      {
+        "name": "Product grid",
+        "blocks": [{ "type": "product-card" }],
+        "presets": [
+          {
+            "name": "Product grid",
+            "blocks": {
+              "product-grid-card": {
+                "type": "product-card",
+                "static": true,
+                "blocks": {
+                  "card_gallery_eK4Hr7": {
+                    "type": "card-gallery",
+                    "name": "potato",
+                  },
+                  "group_4RMFLV": {
+                    "type": "group"
+                  }
+                },
+                "block_order": ["card_gallery_eK4Hr7", "group_4RMFLV"]
+              }
+            }
+          }
+        ]
+      }
+      {% endschema %}
+
       `,
     };
 

--- a/packages/theme-check-common/src/checks/valid-local-blocks/index.ts
+++ b/packages/theme-check-common/src/checks/valid-local-blocks/index.ts
@@ -45,7 +45,6 @@ export const ValidLocalBlocks: LiquidCheckDefinition = {
         if (!schema) return;
 
         const {
-          staticBlockNameLocations,
           staticBlockLocations,
           localBlockLocations,
           themeBlockLocations,
@@ -53,16 +52,6 @@ export const ValidLocalBlocks: LiquidCheckDefinition = {
         } = getBlocks(validSchema);
 
         if (isSection(context.file.uri)) {
-          staticBlockNameLocations.forEach((blockWithPath: BlockNodeWithPath) => {
-            const astNode = nodeAtPath(ast, blockWithPath.path)! as LiteralNode;
-            reportWarning(
-              'Static theme blocks cannot have a name property.',
-              offset,
-              astNode,
-              context,
-            );
-          });
-
           if (staticBlockLocations.length > 0 && localBlockLocations.length > 0) {
             staticBlockLocations.forEach((blockWithPath: BlockNodeWithPath) => {
               const astNode = nodeAtPath(ast, blockWithPath.path)! as LiteralNode;


### PR DESCRIPTION
## What are you adding in this PR?
We've introduced the ability to add a `name` on the preset blocks.

There exists a theme check that ensures local blocks are valid. It was considering ANY block with a `name` to be a local block (except for static blocks, see below), when it should not be taking preset blocks into account for this.

The bug before the fix:
<img width="806" alt="image" src="https://github.com/user-attachments/assets/e2237682-fd0e-4081-af80-7297d9cf1818" />

It looks like we had some erroneous tests around this erroneous behaviour, so I cleaned those up.

SECONDARILY, this check considered static blocks (which are only in presets) with names to be erroneous, when really we do support static blocks in the preset to support names now, so I've removed the checking around that.

## Follow-up

Update the erroneous theme check docs that show preset blocks with names as being wrong, as well as static blocks with names: https://github.com/Shopify/shopify-dev/pull/53848

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config
  - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (link PR here).

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
