### PR TITLE
New `UnusedDocParam` theme-check rule

### DIFF
--- a/.changeset/dull-badgers-sing.md
+++ b/.changeset/dull-badgers-sing.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+New `UnusedDocParam` theme-check rule
+
+- Theme check will verify if variable defined in `@param` tag within a snippet's `doc` is used

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -35,6 +35,7 @@ import { UndefinedObject } from './undefined-object';
 import { UniqueStaticBlockId } from './unique-static-block-id';
 import { UnknownFilter } from './unknown-filter';
 import { UnusedAssign } from './unused-assign';
+import { UnusedDocParam } from './unused-doc-param';
 import { ValidContentForArguments } from './valid-content-for-arguments';
 import { ValidBlockTarget } from './valid-block-target';
 import { ValidHTMLTranslation } from './valid-html-translation';
@@ -88,6 +89,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   UniqueStaticBlockId,
   UnknownFilter,
   UnusedAssign,
+  UnusedDocParam,
   ValidBlockTarget,
   ValidHTMLTranslation,
   ValidContentForArguments,

--- a/packages/theme-check-common/src/checks/unused-doc-param/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unused-doc-param/index.spec.ts
@@ -1,0 +1,89 @@
+import { expect, describe, it } from 'vitest';
+import { UnusedDocParam } from './index';
+import { runLiquidCheck, applySuggestions } from '../../test';
+import { NamedTags } from '@shopify/liquid-html-parser';
+
+describe('Module: UnusedDocParam', () => {
+  it('should not report a warning when a variable is defined and used', async () => {
+    const sourceCode = `
+      {% doc %}
+        @param param1 - Example param
+      {% enddoc %}
+
+      {{ param1 }}
+    `;
+
+    const offenses = await runLiquidCheck(UnusedDocParam, sourceCode);
+
+    expect(offenses).to.be.empty;
+  });
+
+  it('should report a warning with suggestions when a variable is defined but not used', async () => {
+    const sourceCode = `
+      {% doc %}
+        @param param1 - Example param
+        @param param2 - Example param
+      {% enddoc %}
+
+      {{ param1 }}
+    `;
+
+    const offenses = await runLiquidCheck(UnusedDocParam, sourceCode);
+
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal(
+      "The parameter 'param2' is defined but not used in this file.",
+    );
+    expect(offenses[0].suggest).to.have.length(1);
+    expect(offenses[0]!.suggest![0].message).to.equal("Remove the unused doc parameter 'param2'");
+  });
+
+  it('should apply suggestion when a variable is defined but not used', async () => {
+    const sourceCode = `
+      {% doc %}
+        @param param1 - Example param
+        @param param2 - Example param
+      {% enddoc %}
+
+      {{ param1 }}
+    `;
+
+    const offenses = await runLiquidCheck(UnusedDocParam, sourceCode);
+    const suggestions = applySuggestions(sourceCode, offenses[0]);
+
+    expect(suggestions).to.include(`
+      {% doc %}
+        @param param1 - Example param
+        
+      {% enddoc %}
+
+      {{ param1 }}
+    `);
+  });
+
+  [NamedTags.for, NamedTags.tablerow].forEach((tag) => {
+    it(`should report a warning when a variable is defined but not used outside '${tag}' loop context`, async () => {
+      const sourceCode = `
+        {% doc %}
+          @param param1 - Example param
+          @param param2 - Example param
+        {% enddoc %}
+  
+        {{ param1 }}
+        
+        {% ${tag} param2 in array %}
+          {{ param2 }}
+        {% end${tag} %}
+      `;
+
+      const offenses = await runLiquidCheck(UnusedDocParam, sourceCode);
+
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal(
+        "The parameter 'param2' is defined but not used in this file.",
+      );
+      expect(offenses[0].suggest).to.have.length(1);
+      expect(offenses[0]!.suggest![0].message).to.equal("Remove the unused doc parameter 'param2'");
+    });
+  });
+});

--- a/packages/theme-check-common/src/checks/unused-doc-param/index.ts
+++ b/packages/theme-check-common/src/checks/unused-doc-param/index.ts
@@ -1,0 +1,59 @@
+import { LiquidDocParamNode, NodeTypes } from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { isLoopScopedVariable } from '../utils';
+
+export const UnusedDocParam: LiquidCheckDefinition = {
+  meta: {
+    code: 'UnusedDocParam',
+    name: 'Prevent unused doc parameters',
+    docs: {
+      description:
+        'This check exists to ensure any parameters defined in the `doc` tag are used within the snippet.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/unused-doc-param',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    const definedLiquidDocParams: Map<string, LiquidDocParamNode> = new Map();
+    const usedVariables: Set<string> = new Set();
+
+    return {
+      async LiquidDocParamNode(node) {
+        definedLiquidDocParams.set(node.paramName.value, node);
+      },
+
+      async VariableLookup(node, ancestors) {
+        if (
+          node.type === NodeTypes.VariableLookup &&
+          node.name &&
+          !isLoopScopedVariable(node.name, ancestors)
+        ) {
+          usedVariables.add(node.name);
+        }
+      },
+
+      async onCodePathEnd() {
+        for (const [variable, node] of definedLiquidDocParams.entries()) {
+          if (!usedVariables.has(variable)) {
+            context.report({
+              message: `The parameter '${variable}' is defined but not used in this file.`,
+              startIndex: node.position.start,
+              endIndex: node.position.end,
+              suggest: [
+                {
+                  message: `Remove the unused doc parameter '${variable}'`,
+                  fix: (corrector) => corrector.remove(node.position.start, node.position.end),
+                },
+              ],
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/utils.ts
+++ b/packages/theme-check-common/src/checks/utils.ts
@@ -9,6 +9,7 @@ import {
   AttrUnquoted,
   LiquidHtmlNode,
   LiquidBranch,
+  NamedTags,
 } from '@shopify/liquid-html-parser';
 import { LiquidHtmlNodeOfType as NodeOfType } from '../types';
 
@@ -84,4 +85,14 @@ export function hasAttributeValueOf(attr: ValuedHtmlAttribute, value: string) {
 
 export function isLiquidString(node: LiquidHtmlNode): node is NodeOfType<NodeTypes.String> {
   return node.type === NodeTypes.String;
+}
+
+export function isLoopScopedVariable(variableName: string, ancestors: LiquidHtmlNode[]) {
+  return ancestors.some(
+    (ancestor) =>
+      ancestor.type === NodeTypes.LiquidTag &&
+      (ancestor.name === NamedTags.for || ancestor.name === NamedTags.tablerow) &&
+      typeof ancestor.markup !== 'string' &&
+      ancestor.markup.variableName === variableName,
+  );
 }

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -121,6 +121,9 @@ UnknownFilter:
 UnusedAssign:
   enabled: true
   severity: 1
+UnusedDocParam:
+  enabled: true
+  severity: 1
 ValidBlockTarget:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -99,6 +99,9 @@ UnknownFilter:
 UnusedAssign:
   enabled: true
   severity: 1
+UnusedDocParam:
+  enabled: true
+  severity: 1
 ValidBlockTarget:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/theme-tools/issues/803
- Add check to ensure `@param` variable is actually used in the snippet

## Tophat
- Have a snippet with doc
- Ensure the params defined are actually used
- We will consider it "unused" if the variable is actually a for-loop scoped variable
- You can hover over the warning, and press quick fix to remove the param

e.g.
```
{% doc %}
  @param {string} name - This is a name.
  @param {object} opts - options // Unused
  @param {unknown} extra - extra data // Unused
{% enddoc %}

{{ name }}

{% tablerow extra in product.variants %}
  {{ extra }}
{% endtablerow %}

{% for extra in product.variants %}
  {{ extra }}
{% endfor %}
```


## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
