### PR TITLE
Doc tag completion fix and new theme check for doc tag usage

### DIFF
--- a/.changeset/loud-pears-check.md
+++ b/.changeset/loud-pears-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Do not allow liquid doc completion outside snippet files

--- a/.changeset/quiet-queens-sparkle.md
+++ b/.changeset/quiet-queens-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+New theme check to ensure `doc` tag is only used in snippet files

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -35,6 +35,7 @@ import { UndefinedObject } from './undefined-object';
 import { UniqueStaticBlockId } from './unique-static-block-id';
 import { UnknownFilter } from './unknown-filter';
 import { UnusedAssign } from './unused-assign';
+import { UnsupportedDocTag } from './unsupported-doc-tag';
 import { ValidContentForArguments } from './valid-content-for-arguments';
 import { ValidBlockTarget } from './valid-block-target';
 import { ValidHTMLTranslation } from './valid-html-translation';
@@ -87,6 +88,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   UniqueSettingIds,
   UniqueStaticBlockId,
   UnknownFilter,
+  UnsupportedDocTag,
   UnusedAssign,
   ValidBlockTarget,
   ValidHTMLTranslation,

--- a/packages/theme-check-common/src/checks/unsupported-doc-tag/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unsupported-doc-tag/index.spec.ts
@@ -1,0 +1,43 @@
+import { expect, describe, it } from 'vitest';
+import { UnsupportedDocTag } from './index';
+import { runLiquidCheck, applySuggestions } from '../../test';
+
+describe('Module: UnsupportedDocTag', () => {
+  const sourceCode = `{% doc %} @param param1 - Example param {% enddoc %}{{ 'hello' }}`;
+
+  it('should report an error when `doc` tag is used outside snippets', async () => {
+    const offenses = await runLiquidCheck(
+      UnsupportedDocTag,
+      sourceCode,
+      'file://sections/file.liquid',
+    );
+
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal('The `doc` tag can only be used within a snippet.');
+  });
+
+  it('should apply suggestion when `doc` tag is used outside snippets', async () => {
+    const offenses = await runLiquidCheck(
+      UnsupportedDocTag,
+      sourceCode,
+      'file://sections/file.liquid',
+    );
+
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].suggest).to.have.length(1);
+    expect(offenses[0]!.suggest![0].message).to.equal('Remove unsupported `doc` tag');
+    const suggestions = applySuggestions(sourceCode, offenses[0]);
+
+    expect(suggestions).to.include(`{{ 'hello' }}`);
+  });
+
+  it('should not report an error when `doc` tag is used within snippets', async () => {
+    const offenses = await runLiquidCheck(
+      UnsupportedDocTag,
+      sourceCode,
+      'file://snippets/file.liquid',
+    );
+
+    expect(offenses).to.be.empty;
+  });
+});

--- a/packages/theme-check-common/src/checks/unsupported-doc-tag/index.ts
+++ b/packages/theme-check-common/src/checks/unsupported-doc-tag/index.ts
@@ -1,0 +1,45 @@
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { dirname } from '../../path';
+
+export const UnsupportedDocTag: LiquidCheckDefinition = {
+  meta: {
+    code: 'UnsupportedDocTag',
+    name: 'Prevent unsupported doc tag usage',
+    docs: {
+      description: 'This check exists to prevent use of `doc` tag outside of snippet file.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/unsupported-doc-tag',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    const docTagName = 'doc';
+
+    if (dirname(context.file.uri).endsWith('snippets')) {
+      return {};
+    }
+
+    return {
+      async LiquidRawTag(node) {
+        if (node.name !== docTagName) {
+          return;
+        }
+        context.report({
+          message: `The \`${docTagName}\` tag can only be used within a snippet.`,
+          startIndex: node.position.start,
+          endIndex: node.position.end,
+          suggest: [
+            {
+              message: `Remove unsupported \`${docTagName}\` tag`,
+              fix: (corrector) => corrector.remove(node.position.start, node.position.end),
+            },
+          ],
+        });
+      },
+    };
+  },
+};

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -118,6 +118,9 @@ UniqueStaticBlockId:
 UnknownFilter:
   enabled: true
   severity: 0
+UnsupportedDocTag:
+  enabled: true
+  severity: 0
 UnusedAssign:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -96,6 +96,9 @@ UniqueStaticBlockId:
 UnknownFilter:
   enabled: true
   severity: 0
+UnsupportedDocTag:
+  enabled: true
+  severity: 0
 UnusedAssign:
   enabled: true
   severity: 1

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.spec.ts
@@ -24,7 +24,10 @@ describe('Module: LiquidDocParamTypeCompletionProvider', async () => {
     const sources = [`{% doc %} @param {█`, `{% doc %} @param  {  █`];
 
     for (const source of sources) {
-      await expect(provider).to.complete(source, Object.values(SupportedParamTypes));
+      await expect(provider).to.complete(
+        { source, relativePath: 'file://snippets/file.liquid' },
+        Object.values(SupportedParamTypes),
+      );
     }
   });
 
@@ -37,7 +40,17 @@ describe('Module: LiquidDocParamTypeCompletionProvider', async () => {
     ];
 
     for (const source of sources) {
-      await expect(provider).to.complete(source, []);
+      await expect(provider).to.complete(
+        { source, relativePath: 'file://snippets/file.liquid' },
+        [],
+      );
     }
+  });
+
+  it("does not offer completion if it's not within a snippet file", async () => {
+    await expect(provider).to.complete(
+      { source: `{% doc %} @param {█`, relativePath: 'file://sections/file.liquid' },
+      [],
+    );
   });
 });

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.ts
@@ -3,12 +3,14 @@ import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
 import { LiquidCompletionParams } from '../params';
 import { Provider } from './common';
 import { SupportedDocTagTypes, SupportedParamTypes } from '@shopify/theme-check-common';
+import { isSnippet } from '../../utils/uri';
 
 export class LiquidDocParamTypeCompletionProvider implements Provider {
   constructor() {}
 
   async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
     if (!params.completionContext) return [];
+    if (!isSnippet(params.document.uri)) return [];
 
     const { node, ancestors } = params.completionContext;
     const parentNode = ancestors.at(-1);

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.spec.ts
@@ -20,15 +20,34 @@ describe('Module: LiquidDocTagCompletionProvider', async () => {
   });
 
   it('offers completions within liquid doc tag', async () => {
-    await expect(provider).to.complete(`{% doc %} @█`, ['param', 'example', 'description']);
-    await expect(provider).to.complete(`{% doc %} @par█`, ['param']);
+    await expect(provider).to.complete(
+      { source: `{% doc %} @█`, relativePath: 'file://snippets/file.liquid' },
+      ['param', 'example', 'description'],
+    );
+    await expect(provider).to.complete(
+      { source: `{% doc %} @par█`, relativePath: 'file://snippets/file.liquid' },
+      ['param'],
+    );
   });
 
   it("does not offer completion if it doesn't start with @", async () => {
-    await expect(provider).to.complete(`{% doc %} █`, []);
+    await expect(provider).to.complete(
+      { source: `{% doc %} █`, relativePath: 'file://snippets/file.liquid' },
+      [],
+    );
   });
 
   it('does not offer completion if it is not within a doc tag', async () => {
-    await expect(provider).to.complete(`{% notdoc %} @█`, []);
+    await expect(provider).to.complete(
+      { source: `{% notdoc %} @█`, relativePath: 'file://snippets/file.liquid' },
+      [],
+    );
+  });
+
+  it('does not offer completion if it is not a snippet file', async () => {
+    await expect(provider).to.complete(
+      { source: `{% doc %} @█`, relativePath: 'file://sections/file.liquid' },
+      [],
+    );
   });
 });

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.ts
@@ -10,12 +10,14 @@ import {
 import { LiquidCompletionParams } from '../params';
 import { Provider } from './common';
 import { formatLiquidDocTagHandle, SUPPORTED_LIQUID_DOC_TAG_HANDLES } from '../../utils/liquidDoc';
+import { isSnippet } from '../../utils/uri';
 
 export class LiquidDocTagCompletionProvider implements Provider {
   constructor() {}
 
   async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
     if (!params.completionContext) return [];
+    if (!isSnippet(params.document.uri)) return [];
 
     const { node, ancestors } = params.completionContext;
     const parentNode = ancestors.at(-1);


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/572
commit 1: prevents `doc` tag completions outside snippet file
commit 2: theme check to prevent `doc` tag usage outside snippet files

## Tophat
- Add a `doc` tag inside a snippet file
- Make sure code completion still works for `@param` tag and `@param` tag types
- Add a `doc` tag a section/block file
- You will get a theme check error
- Follow the quick suggestion to remove the tag

## Before you deploy
commit 2:
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

commit 1:
- [x] I included a patch bump `changeset`
