### PR TITLE
Rename doc param or its usage

### DIFF
--- a/.changeset/beige-months-exercise.md
+++ b/.changeset/beige-months-exercise.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Renaming variables inside snippets also renames the LiquidDoc parameters
+
+- You can rename doc params or variable usage in the file

--- a/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.spec.ts
+++ b/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.spec.ts
@@ -12,14 +12,16 @@ describe('LiquidVariableRenameProvider', () => {
     let provider: RenameProvider;
     let textDocument: TextDocument;
 
-    const documentSource = `{% assign animal = 'dog' %}
+    const documentSource = `{% doc %}@param {string} food - favorite food{% enddoc %}
+{% assign animal = 'dog' %}
 {% assign plant = 'cactus' %}
 {% liquid
   echo plant
+  echo food
 %}
 {% assign painting = 'mona lisa' %}
 {% assign paintings = 'starry night, sunday afternoon, the scream' %}
-<p>I have a cool animal and a great plant</p>`;
+<p>I have a cool animal, a great plant, and my favorite food</p>`;
 
     beforeEach(() => {
       documentManager = new DocumentManager();
@@ -32,7 +34,7 @@ describe('LiquidVariableRenameProvider', () => {
     it('returns null when the cursor is not over a liquid variable', async () => {
       const params = {
         textDocument,
-        position: Position.create(0, 3),
+        position: Position.create(1, 3),
         newName: 'pet',
       };
 
@@ -43,7 +45,7 @@ describe('LiquidVariableRenameProvider', () => {
     it('returns new name after liquid variable is renamed from assign tag', async () => {
       const params = {
         textDocument,
-        position: Position.create(0, 11),
+        position: Position.create(1, 11),
         newName: 'pet',
       };
 
@@ -52,21 +54,23 @@ describe('LiquidVariableRenameProvider', () => {
       assert(result.documentChanges);
       expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
         textDocument,
-        `{% assign pet = 'dog' %}
+        `{% doc %}@param {string} food - favorite food{% enddoc %}
+{% assign pet = 'dog' %}
 {% assign plant = 'cactus' %}
 {% liquid
   echo plant
+  echo food
 %}
 {% assign painting = 'mona lisa' %}
 {% assign paintings = 'starry night, sunday afternoon, the scream' %}
-<p>I have a cool animal and a great plant</p>`,
+<p>I have a cool animal, a great plant, and my favorite food</p>`,
       );
     });
 
     it('returns new name after liquid variable is renamed on variable usage', async () => {
       const params = {
         textDocument,
-        position: Position.create(3, 11),
+        position: Position.create(4, 11),
         newName: 'fauna',
       };
 
@@ -75,21 +79,23 @@ describe('LiquidVariableRenameProvider', () => {
       assert(result.documentChanges);
       expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
         textDocument,
-        `{% assign animal = 'dog' %}
+        `{% doc %}@param {string} food - favorite food{% enddoc %}
+{% assign animal = 'dog' %}
 {% assign fauna = 'cactus' %}
 {% liquid
   echo fauna
+  echo food
 %}
 {% assign painting = 'mona lisa' %}
 {% assign paintings = 'starry night, sunday afternoon, the scream' %}
-<p>I have a cool animal and a great plant</p>`,
+<p>I have a cool animal, a great plant, and my favorite food</p>`,
       );
     });
 
     it("doesn't rename variables where the name of the one being changed contains within it", async () => {
       const params = {
         textDocument,
-        position: Position.create(5, 11),
+        position: Position.create(7, 11),
         newName: 'famous_painting',
       };
 
@@ -98,14 +104,66 @@ describe('LiquidVariableRenameProvider', () => {
       assert(result.documentChanges);
       expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
         textDocument,
-        `{% assign animal = 'dog' %}
+        `{% doc %}@param {string} food - favorite food{% enddoc %}
+{% assign animal = 'dog' %}
 {% assign plant = 'cactus' %}
 {% liquid
   echo plant
+  echo food
 %}
 {% assign famous_painting = 'mona lisa' %}
 {% assign paintings = 'starry night, sunday afternoon, the scream' %}
-<p>I have a cool animal and a great plant</p>`,
+<p>I have a cool animal, a great plant, and my favorite food</p>`,
+      );
+    });
+
+    it('returns new name after liquid doc param is renamed in doc', async () => {
+      const params = {
+        textDocument,
+        position: Position.create(0, 26),
+        newName: 'meal',
+      };
+
+      const result = await provider.rename(params);
+      assert(result);
+      assert(result.documentChanges);
+      expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
+        textDocument,
+        `{% doc %}@param {string} meal - favorite food{% enddoc %}
+{% assign animal = 'dog' %}
+{% assign plant = 'cactus' %}
+{% liquid
+  echo plant
+  echo meal
+%}
+{% assign painting = 'mona lisa' %}
+{% assign paintings = 'starry night, sunday afternoon, the scream' %}
+<p>I have a cool animal, a great plant, and my favorite food</p>`,
+      );
+    });
+
+    it('returns new name after liquid doc param is renamed on variable usage', async () => {
+      const params = {
+        textDocument,
+        position: Position.create(5, 9),
+        newName: 'meal',
+      };
+
+      const result = await provider.rename(params);
+      assert(result);
+      assert(result.documentChanges);
+      expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
+        textDocument,
+        `{% doc %}@param {string} meal - favorite food{% enddoc %}
+{% assign animal = 'dog' %}
+{% assign plant = 'cactus' %}
+{% liquid
+  echo plant
+  echo meal
+%}
+{% assign painting = 'mona lisa' %}
+{% assign paintings = 'starry night, sunday afternoon, the scream' %}
+<p>I have a cool animal, a great plant, and my favorite food</p>`,
       );
     });
   });
@@ -163,23 +221,24 @@ describe('LiquidVariableRenameProvider', () => {
       });
     });
 
-    it('returns new name after variable is renamed outside loop', async () => {
-      const source = documentSource.replace(/LOOP/g, 'for');
+    describe('assign tag', () => {
+      it('returns new name after variable is renamed outside loop', async () => {
+        const source = documentSource.replace(/LOOP/g, 'for');
 
-      textDocument = TextDocument.create(textDocumentUri, 'liquid', 1, source);
-      documentManager.open(textDocument.uri, source, 1);
+        textDocument = TextDocument.create(textDocumentUri, 'liquid', 1, source);
+        documentManager.open(textDocument.uri, source, 1);
 
-      const params = {
-        textDocument,
-        position: Position.create(1, 11),
-        newName: 'item',
-      };
-      const result = await provider.rename(params);
-      assert(result);
-      assert(result.documentChanges);
-      expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
-        textDocument,
-        `{% assign counter = 0 %}
+        const params = {
+          textDocument,
+          position: Position.create(1, 11),
+          newName: 'item',
+        };
+        const result = await provider.rename(params);
+        assert(result);
+        assert(result.documentChanges);
+        expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
+          textDocument,
+          `{% assign counter = 0 %}
 {% assign item = 'some product' %}
 {% liquid
   for prod in products
@@ -187,26 +246,26 @@ describe('LiquidVariableRenameProvider', () => {
     increment counter
   endfor
 %}`,
-      );
-    });
+        );
+      });
 
-    it('returns new name after variable is renamed inside loop, but is scoped outside it', async () => {
-      const source = documentSource.replace(/LOOP/g, 'for');
+      it('returns new name after variable is renamed inside loop, but is scoped outside it', async () => {
+        const source = documentSource.replace(/LOOP/g, 'for');
 
-      textDocument = TextDocument.create(textDocumentUri, 'liquid', 1, source);
-      documentManager.open(textDocument.uri, source, 1);
+        textDocument = TextDocument.create(textDocumentUri, 'liquid', 1, source);
+        documentManager.open(textDocument.uri, source, 1);
 
-      const params = {
-        textDocument,
-        position: Position.create(0, 11),
-        newName: 'x',
-      };
-      const result = await provider.rename(params);
-      assert(result);
-      assert(result.documentChanges);
-      expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
-        textDocument,
-        `{% assign x = 0 %}
+        const params = {
+          textDocument,
+          position: Position.create(0, 11),
+          newName: 'x',
+        };
+        const result = await provider.rename(params);
+        assert(result);
+        assert(result.documentChanges);
+        expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
+          textDocument,
+          `{% assign x = 0 %}
 {% assign prod = 'some product' %}
 {% liquid
   for prod in products
@@ -214,7 +273,65 @@ describe('LiquidVariableRenameProvider', () => {
     increment x
   endfor
 %}`,
-      );
+        );
+      });
+    });
+
+    describe('liquid doc param', () => {
+      const documentSource = `{% doc %}@param prod - product{% enddoc %}
+{% liquid
+  for prod in products
+    echo prod.title
+  endfor
+  echo prod
+%}`;
+
+      beforeEach(() => {
+        textDocument = TextDocument.create(textDocumentUri, 'liquid', 1, documentSource);
+        documentManager.open(textDocument.uri, documentSource, 1);
+      });
+
+      it('returns new name after variable is renamed outside loop', async () => {
+        const params = {
+          textDocument,
+          position: Position.create(0, 17),
+          newName: 'ppp',
+        };
+        const result = await provider.rename(params);
+        assert(result);
+        assert(result.documentChanges);
+        expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
+          textDocument,
+          `{% doc %}@param ppp - product{% enddoc %}
+{% liquid
+  for prod in products
+    echo prod.title
+  endfor
+  echo ppp
+%}`,
+        );
+      });
+
+      it('returns new name after variable is renamed inside loop, but is scoped outside it', async () => {
+        const params = {
+          textDocument,
+          position: Position.create(3, 10),
+          newName: 'ppp',
+        };
+        const result = await provider.rename(params);
+        assert(result);
+        assert(result.documentChanges);
+        expect((result.documentChanges[0] as TextDocumentEdit).edits).to.applyEdits(
+          textDocument,
+          `{% doc %}@param prod - product{% enddoc %}
+{% liquid
+  for ppp in products
+    echo ppp.title
+  endfor
+  echo prod
+%}`,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/theme-tools/issues/810
- When you rename a variable usage or a param in doc tag, rename all instances

NOTE: if you have a `assign` (or equivalent) that collides with the `param` tag in doc, assume they are referring to the same variable and rename everything.

## Tophat

- Create a snippet with a doc param
- Use the doc param in different liquid tags (pass in as a param for another snippet, use it in an `echo` tag, etc.)
- Rename the variable from the doc param (place cursor on param name, and press F2)
- Rename the variable usage in the snippet file (place cursor on variable usage, and press F2)

## Before you deploy

- [x] I included a patch bump `changeset`
