### PR TITLE
[LiquidDoc] Formatting support for implicit descriptions

### DIFF
--- a/.changeset/proud-chefs-relate.md
+++ b/.changeset/proud-chefs-relate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+---
+
+Prevent prettier from appending `@description` annotation before implicit descriptions

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -581,10 +581,14 @@ export function printLiquidDocDescription(
   _args: LiquidPrinterArgs,
 ): Doc {
   const node = path.getValue();
-  const parts: Doc[] = ['@description'];
+  const parts: Doc[] = [];
+
+  if (!node.isImplicit) {
+    parts.push('@description ');
+  }
 
   if (node.content?.value) {
-    parts.push(' ', node.content.value);
+    parts.push(node.content.value);
   }
 
   return parts;

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
@@ -124,3 +124,10 @@ It should add padding between dissimilar nodes
 
   @param {String} param3 - param with description
 {% enddoc %}
+
+It should not append an implicit description with an @description annotation
+{% doc %}
+  This is an implicit description
+
+  @description This is an explicit description
+{% enddoc %}

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
@@ -118,3 +118,10 @@ It should add padding between dissimilar nodes
   @description This is a description
   @param {String} param3 - param with description
 {% enddoc %}
+
+It should not append an implicit description with an @description annotation
+{% doc %}
+This is an implicit description
+
+  @description This is an explicit description
+{% enddoc %}


### PR DESCRIPTION
## What are you adding in this PR?
Closes https://github.com/Shopify/developer-tools-team/issues/587

Mothing too complicated here. We just need to use the is implicit property to determine if we should append the `@description` annotation or not.

Indenting, etc should behave similarly to a normal description.

## Before you deploy
- [x] I included a patch bump `changeset`

_The ends result of this change is more of a bug fix from introducing a new node,so I chose to go with a patch._
