### PR TITLE
[LiquidDoc] Modify LiquidDoc parsing to capture leading whitespace and add inline flag

### DIFF
--- a/.changeset/slow-papayas-worry.md
+++ b/.changeset/slow-papayas-worry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': minor
+---
+
+Modify parsing logic to capture leading whitespace on `description` and `example` nodes and add a `isInline` property to indicate whether content was provided inline or on a new line.

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -409,7 +409,7 @@ LiquidDoc <: Helpers {
   // We use this as an escape hatch to stop matching TextNode and try again when one of these characters is encountered
   openControl:= "@" | end
 
-  descriptionNode = "@description" strictSpace* descriptionContent
+  descriptionNode = "@description" space* descriptionContent
 
   paramNode = "@param" strictSpace* paramType? strictSpace* (optionalParamName | paramName) (strictSpace* "-")? strictSpace* paramDescription
   paramType = "{" strictSpace* paramTypeContent strictSpace* "}"
@@ -422,7 +422,7 @@ LiquidDoc <: Helpers {
   paramDescription = (~"]" anyExceptStar<endOfParam>)
   endOfParam = strictSpace* (newline | end)
 
-  exampleNode = "@example" strictSpace* exampleContent
+  exampleNode = "@example" space* exampleContent
   exampleContent = anyExceptStar<endOfExample>
   endOfExample =  strictSpace* ("@" | end)
 

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1266,7 +1266,7 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocExampleNode');
           expectPath(cst, '0.children.0.name').to.equal('example');
           expectPath(cst, '0.children.0.content.value').to.equal(
-            '\n          This is an example\n          It supports multiple lines\n',
+            'This is an example\n          It supports multiple lines\n',
           );
         });
 
@@ -1279,9 +1279,7 @@ describe('Unit: Stage 1 (CST)', () => {
           cst = toCST(testStr);
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocExampleNode');
           expectPath(cst, '0.children.0.name').to.equal('example');
-          expectPath(cst, '0.children.0.content.value').to.equal(
-            '\n          This is an example\n',
-          );
+          expectPath(cst, '0.children.0.content.value').to.equal('This is an example\n');
           expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
           expectPath(cst, '0.children.1.paramName.content.value').to.equal('param1');
         });
@@ -1330,10 +1328,10 @@ describe('Unit: Stage 1 (CST)', () => {
           {% enddoc %}`;
           cst = toCST(testStr);
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
-          expectPath(cst, '0.children.0.content.value').to.equal('This is a description');
+          expectPath(cst, '0.children.0.content.value').to.equal('This is a description\n');
 
           expectPath(cst, '0.children.1.type').to.equal('LiquidDocDescriptionNode');
-          expectPath(cst, '0.children.1.content.value').to.equal('This is a second description');
+          expectPath(cst, '0.children.1.content.value').to.equal('This is a second description\n');
         });
 
         it('should parse and strip whitespace from description tag with content that has leading whitespace', () => {
@@ -1362,20 +1360,21 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
           expectPath(cst, '0.children.0.name').to.equal('description');
           expectPath(cst, '0.children.0.content.value').to.equal(
-            'hello      there        my    friend\n          This is a description\n          It supports multiple lines',
+            'hello      there        my    friend\n          This is a description\n          It supports multiple lines\n',
           );
         });
 
         it('should parse multiple description nodes', () => {
           const testStr = `{% doc %}
           @description hello there
-          @description second description
+          @description
+          second description
         {% enddoc %}`;
           cst = toCST(testStr);
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
-          expectPath(cst, '0.children.0.content.value').to.equal('hello there');
+          expectPath(cst, '0.children.0.content.value').to.equal('hello there\n');
           expectPath(cst, '0.children.1.type').to.equal('LiquidDocDescriptionNode');
-          expectPath(cst, '0.children.1.content.value').to.equal('second description');
+          expectPath(cst, '0.children.1.content.value').to.equal('second description\n');
         });
 
         it('should parse implicit description', () => {
@@ -1414,7 +1413,7 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.name').to.equal('doc');
           expectPath(cst, '0.children.0.type').to.equal('LiquidDocDescriptionNode');
           expectPath(cst, '0.children.0.isImplicit').to.equal(true);
-          expectPath(cst, '0.children.0.content.value').to.equal('implicit content');
+          expectPath(cst, '0.children.0.content.value').to.equal('implicit content\n');
           expectPath(cst, '0.children.0.content.locStart').to.equal(
             testStr.indexOf('implicit content'),
           );

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -130,12 +130,14 @@ export interface ConcreteLiquidDocDescriptionNode
   name: 'description';
   content: ConcreteTextNode;
   isImplicit: boolean;
+  isInline: boolean;
 }
 
 export interface ConcreteLiquidDocExampleNode
   extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocExampleNode> {
   name: 'example';
   content: ConcreteTextNode;
+  isInline: boolean;
 }
 
 export interface ConcreteHtmlNodeBase<T> extends ConcreteBasicNode<T> {
@@ -1397,6 +1399,7 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
       source,
       content: 0,
       isImplicit: true,
+      isInline: true,
     },
     TextNode: textNode(),
     paramNode: {
@@ -1417,16 +1420,11 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
       source,
       content: 2,
       isImplicit: false,
-    },
-    descriptionContent: {
-      type: ConcreteNodeTypes.TextNode,
-      value: function (this: Node) {
-        return this.sourceString.trim();
+      isInline: function (this: Node) {
+        return !this.children[1].sourceString.includes('\n');
       },
-      locStart,
-      locEnd,
-      source,
     },
+    descriptionContent: textNode(),
     paramType: 2,
     paramTypeContent: textNode(),
     paramName: {
@@ -1453,6 +1451,9 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
       locEnd,
       source,
       content: 2,
+      isInline: function (this: Node) {
+        return !this.children[1].sourceString.includes('\n');
+      },
     },
     exampleContent: textNode(),
     textValue: textNode(),

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1350,10 +1350,10 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.name').to.eql('doc');
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.0.name').to.eql('example');
-      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('\n        First Example\n');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('First Example\n');
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.1.name').to.eql('example');
-      expectPath(ast, 'children.0.body.nodes.1.content.value').to.eql('\n        Second Example\n');
+      expectPath(ast, 'children.0.body.nodes.1.content.value').to.eql('Second Example\n');
 
       ast = toLiquidAST(`
         {% doc -%}
@@ -1368,7 +1368,7 @@ describe('Unit: Stage 2 (AST)', () => {
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.0.name').to.eql('example');
       expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql(
-        '\n        This is a valid example\n        It can have multiple lines\n',
+        'This is a valid example\n        It can have multiple lines\n',
       );
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocParamNode');
       expectPath(ast, 'children.0.body.nodes.1.name').to.eql('param');
@@ -1385,10 +1385,10 @@ describe('Unit: Stage 2 (AST)', () => {
         {% enddoc %}
       `);
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocDescriptionNode');
-      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description\n');
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocDescriptionNode');
       expectPath(ast, 'children.0.body.nodes.1.content.value').to.eql(
-        'This is another description\n        it can have multiple lines',
+        'This is another description\n        it can have multiple lines\n',
       );
 
       ast = toLiquidAST(`
@@ -1399,7 +1399,7 @@ describe('Unit: Stage 2 (AST)', () => {
         {% enddoc %}
       `);
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocDescriptionNode');
-      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description\n');
 
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.1.name').to.eql('example');
@@ -1416,19 +1416,19 @@ describe('Unit: Stage 2 (AST)', () => {
         {% doc -%}
         this is an implicit description
         in a header
-        
+
         @description with a description annotation
         {% enddoc %}
       `);
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocDescriptionNode');
       expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql(
-        'this is an implicit description\n        in a header',
+        'this is an implicit description\n        in a header\n\n',
       );
       expectPath(ast, 'children.0.body.nodes.0.isImplicit').to.eql(true);
 
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocDescriptionNode');
       expectPath(ast, 'children.0.body.nodes.1.content.value').to.eql(
-        'with a description annotation',
+        'with a description annotation\n',
       );
       expectPath(ast, 'children.0.body.nodes.1.isImplicit').to.eql(false);
     });
@@ -1592,7 +1592,7 @@ describe('Unit: Stage 2 (AST)', () => {
         @p█
       `);
       expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocDescriptionNode');
-      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is a description\n');
 
       expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocExampleNode');
       expectPath(ast, 'children.0.body.nodes.1.name').to.eql('example');

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -789,6 +789,8 @@ export interface LiquidDocDescriptionNode extends ASTNode<NodeTypes.LiquidDocDes
   content: TextNode;
   /** Whether this description is implicit (e.g. not appended by a @description annotation) */
   isImplicit: boolean;
+  /** Whether this description starts on the same line as the @description annotation. This is false for implicit descriptions. */
+  isInline: boolean;
 }
 
 /** Represents a `@example` node in a LiquidDoc comment - `@example exampleContent` */
@@ -796,6 +798,8 @@ export interface LiquidDocExampleNode extends ASTNode<NodeTypes.LiquidDocExample
   name: 'example';
   /** The contents of the example (e.g. "{{ product }}"). Can be multiline. */
   content: TextNode;
+  /** Whether this example starts on the same line as the @example annotation.  */
+  isInline: boolean;
 }
 
 export interface ASTNode<T> {
@@ -1334,6 +1338,7 @@ function buildAst(
           source: node.source,
           content: toTextNode(node.content),
           isImplicit: node.isImplicit,
+          isInline: node.isInline,
         });
         break;
       }
@@ -1345,6 +1350,7 @@ function buildAst(
           position: position(node),
           source: node.source,
           content: toTextNode(node.content),
+          isInline: node.isInline,
         });
         break;
       }


### PR DESCRIPTION
## What are you adding in this PR?
Part of https://github.com/Shopify/developer-tools-team/issues/573

**[‼️] The tests on this branch are broken, but I fix them in the [PR above](https://app.graphite.dev/github/pr/Shopify/theme-tools/824/%5BLiquidDoc%5D-Update-Prettier-%2B-Formatting-behaviour-for-descriptions-and-examples). I'm splitting these up for the sake of review, but I will ship them together in a stack.**

Before this change, examples and description nodes had similar types of content, but were being treated differently in stage 1.

This change makes the parsing consistent between examples and descriptions by:
-  **removing the trimming we do for the description content** in `stage-1`.
- assigning an `isInline` property to examples and descriptions. I consume this in the next PR in the stack.

```
@description inline means it's on the same line
@description 
otherwise it can be like this
```

## What's next? Any followup issues?
- Update hover, prettier to work with this new parsing behaviour

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible