### PR TITLE
New Liquid Doc param checks

### DIFF
--- a/.changeset/green-seahorses-glow.md
+++ b/.changeset/green-seahorses-glow.md
@@ -1,0 +1,9 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+New theme checks to validate liquid doc params
+
+- `UniqueDocParamNames` will check if param names are unique within the `doc` tag
+- `ValidDocParamTypes` will check if the param types defined in the `doc` tag are supported

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -32,6 +32,7 @@ import { RequiredLayoutThemeObject } from './required-layout-theme-object';
 import { TranslationKeyExists } from './translation-key-exists';
 import { UnclosedHTMLElement } from './unclosed-html-element';
 import { UndefinedObject } from './undefined-object';
+import { UniqueDocParamNames } from './unique-doc-param-names';
 import { UniqueStaticBlockId } from './unique-static-block-id';
 import { UnknownFilter } from './unknown-filter';
 import { UnusedAssign } from './unused-assign';
@@ -41,6 +42,7 @@ import { ValidContentForArguments } from './valid-content-for-arguments';
 import { ValidBlockTarget } from './valid-block-target';
 import { ValidHTMLTranslation } from './valid-html-translation';
 import { ValidJSON } from './valid-json';
+import { ValidDocParamTypes } from './valid-doc-param-types';
 import { ValidLocalBlocks } from './valid-local-blocks';
 import { ValidRenderSnippetParams } from './valid-render-snippet-params';
 import { ValidRenderSnippetParamTypes } from './valid-render-snippet-param-types';
@@ -87,6 +89,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   TranslationKeyExists,
   UnclosedHTMLElement,
   UndefinedObject,
+  UniqueDocParamNames,
   UniqueSettingIds,
   UniqueStaticBlockId,
   UnknownFilter,
@@ -97,6 +100,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   ValidHTMLTranslation,
   ValidContentForArguments,
   ValidJSON,
+  ValidDocParamTypes,
   ValidLocalBlocks,
   ValidSchema,
   ValidSettingsKey,

--- a/packages/theme-check-common/src/checks/unique-doc-param-names/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unique-doc-param-names/index.spec.ts
@@ -1,0 +1,36 @@
+import { expect, describe, it } from 'vitest';
+import { UniqueDocParamNames } from './index';
+import { runLiquidCheck, applySuggestions } from '../../test';
+import { SupportedParamTypes } from '../../liquid-doc/utils';
+
+describe('Module: UniqueDocParamNames', () => {
+  it(`should not report an error when a all doc params have unique names`, async () => {
+    const sourceCode = `
+      {% doc %}
+        @param param1 - Example param
+        @param param2 - Example param
+        @param param3 - Example param
+      {% enddoc %}
+    `;
+
+    const offenses = await runLiquidCheck(UniqueDocParamNames, sourceCode);
+
+    expect(offenses).to.be.empty;
+  });
+
+  it('should report an error when a param name appears more than once', async () => {
+    const sourceCode = `
+      {% doc %}
+        @param param1 - Example param
+        @param param1 - Example param
+        @param param1 - Example param
+      {% enddoc %}
+    `;
+
+    const offenses = await runLiquidCheck(UniqueDocParamNames, sourceCode);
+
+    expect(offenses).to.have.length(2);
+    expect(offenses[0].message).to.equal("The parameter 'param1' is defined more than once.");
+    expect(offenses[1].message).to.equal("The parameter 'param1' is defined more than once.");
+  });
+});

--- a/packages/theme-check-common/src/checks/unique-doc-param-names/index.ts
+++ b/packages/theme-check-common/src/checks/unique-doc-param-names/index.ts
@@ -1,0 +1,39 @@
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+
+export const UniqueDocParamNames: LiquidCheckDefinition = {
+  meta: {
+    code: 'UniqueDocParamNames',
+    name: 'Unique doc parameter names',
+    docs: {
+      description:
+        'This check exists to ensure any parameter names defined in the `doc` tag are unique.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/unique-doc-param-names',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    const definedLiquidDocParamNames: Set<string> = new Set();
+
+    return {
+      async LiquidDocParamNode(node) {
+        const paramName = node.paramName.value;
+
+        if (!definedLiquidDocParamNames.has(paramName)) {
+          definedLiquidDocParamNames.add(paramName);
+          return;
+        }
+
+        context.report({
+          message: `The parameter '${paramName}' is defined more than once.`,
+          startIndex: node.paramName.position.start,
+          endIndex: node.paramName.position.end,
+        });
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/valid-doc-param-types/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-doc-param-types/index.spec.ts
@@ -1,0 +1,51 @@
+import { expect, describe, it } from 'vitest';
+import { ValidDocParamTypes } from './index';
+import { runLiquidCheck, applySuggestions } from '../../test';
+import { SupportedParamTypes } from '../../liquid-doc/utils';
+
+describe('Module: ValidDocParamTypes', () => {
+  Object.values(SupportedParamTypes).forEach((paramType) => {
+    it(`should not report an error when a valid parameter (${paramType}) type is used`, async () => {
+      const sourceCode = `
+        {% doc %}
+          @param {${paramType}} param1 - Example param
+        {% enddoc %}
+      `;
+
+      const offenses = await runLiquidCheck(ValidDocParamTypes, sourceCode);
+
+      expect(offenses).to.be.empty;
+    });
+  });
+
+  it('should report an error with suggestions when an invalid parameter type is used', async () => {
+    const sourceCode = `
+      {% doc %}
+        @param {invalidType} param1 - Example param
+      {% enddoc %}
+    `;
+
+    const offenses = await runLiquidCheck(ValidDocParamTypes, sourceCode);
+
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal("The parameter type 'invalidType' is not supported.");
+    expect(offenses[0].suggest).to.have.length(1);
+    expect(offenses[0]!.suggest![0].message).to.equal('Remove invalid parameter type');
+  });
+
+  it('should apply suggestion when an invalid parameter type is used', async () => {
+    const sources = [
+      `{% doc %} @param {invalidType} param1 - Example param {% enddoc %}`,
+      `{% doc %} @param   {   invalidType   }   param1 - Example param {% enddoc %}`,
+    ];
+
+    for (const source of sources) {
+      const offenses = await runLiquidCheck(ValidDocParamTypes, source);
+
+      expect(offenses).to.have.length(1);
+      const suggestions = applySuggestions(source, offenses[0]);
+
+      expect(suggestions).to.include(`{% doc %} @param param1 - Example param {% enddoc %}`);
+    }
+  });
+});

--- a/packages/theme-check-common/src/checks/valid-doc-param-types/index.ts
+++ b/packages/theme-check-common/src/checks/valid-doc-param-types/index.ts
@@ -1,0 +1,58 @@
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { SupportedParamTypes } from '../../liquid-doc/utils';
+
+export const ValidDocParamTypes: LiquidCheckDefinition = {
+  meta: {
+    code: 'ValidDocParamTypes',
+    name: 'Valid doc parameter types',
+    docs: {
+      description:
+        'This check exists to ensure any parameter types defined in the `doc` tag are valid.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-doc-param-types',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    return {
+      async LiquidDocParamNode(node) {
+        if (!node.paramType) {
+          return;
+        }
+
+        if (Object.values(SupportedParamTypes).includes(node.paramType.value as any)) {
+          return;
+        }
+
+        context.report({
+          message: `The parameter type '${node.paramType.value}' is not supported.`,
+          startIndex: node.paramType.position.start,
+          endIndex: node.paramType.position.end,
+          suggest: [
+            {
+              message: 'Remove invalid parameter type',
+              fix: (corrector) => {
+                if (!node.paramType) return;
+
+                corrector.replace(
+                  node.position.start,
+                  node.position.end,
+                  node.source.slice(node.position.start, node.position.end).replace(
+                    // We could have padded spaces around + inside the param type
+                    // e.g. `{ string }`, `{string}`, or ` { string } `
+                    new RegExp(`\\s*\\{\\s*${node.paramType.value}\\s*\\}\\s*`),
+                    ' ',
+                  ),
+                );
+              },
+            },
+          ],
+        });
+      },
+    };
+  },
+};

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -109,6 +109,9 @@ UnclosedHTMLElement:
 UndefinedObject:
   enabled: true
   severity: 1
+UniqueDocParamNames:
+  enabled: true
+  severity: 0
 UniqueSettingId:
   enabled: true
   severity: 0
@@ -131,6 +134,9 @@ ValidBlockTarget:
   enabled: true
   severity: 0
 ValidContentForArguments:
+  enabled: true
+  severity: 0
+ValidDocParamTypes:
   enabled: true
   severity: 0
 ValidHTMLTranslation:

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -87,6 +87,9 @@ UnclosedHTMLElement:
 UndefinedObject:
   enabled: true
   severity: 1
+UniqueDocParamNames:
+  enabled: true
+  severity: 0
 UniqueSettingId:
   enabled: true
   severity: 0
@@ -109,6 +112,9 @@ ValidBlockTarget:
   enabled: true
   severity: 0
 ValidContentForArguments:
+  enabled: true
+  severity: 0
+ValidDocParamTypes:
   enabled: true
   severity: 0
 ValidHTMLTranslation:


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/592
Closes https://github.com/Shopify/developer-tools-team/issues/593

- Ensure param type exists in doc tag
- Ensure param names are unique within doc tag

## Tophat
- Run the code in VSCode
- Create a snippet with the following content

```
{% doc %}
    @param {string} name - This is a name.
    @param {string} name - This is a name. // Error should show up on the param name
    @param {unknown} data - This is data. // Error should show up on the param type
{% enddoc %}
```

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
