### PR TITLE
[LiquidDoc] Update hover behaviour for the {% render %} tag to render new lines for multi-line descriptions

### DIFF
--- a/.changeset/fresh-pugs-drum.md
+++ b/.changeset/fresh-pugs-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Update hover behaviour for the {% render %} tag to render new lines for multi-line descriptions

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -68,10 +68,29 @@ describe('Module: RenderSnippetHoverProvider', async () => {
   describe('hover', () => {
     it('should return snippet definition with all parameters', async () => {
       provider = createProvider(async () => mockSnippetDefinition);
-      await expect(provider).to.hover(
-        `{% render 'product-car█d' %}`,
-        '### product-card\n\n**Description:**\n\n\nThis is a description\n\n**Parameters:**\n- `title`: string - The title of the product\n- `border-radius` (Optional): number - The border radius in px\n- `no-type` - This parameter has no type\n- `no-description`: string\n- `no-type-or-description`\n\n**Examples:**\n```liquid{{ product }}```\n```liquid{{ product.title }}```',
-      );
+      // prettier-ignore
+      const expectedHoverContent = 
+`### product-card
+
+**Description:**
+
+
+\`\`\`plaintext
+This is a description
+\`\`\`
+
+**Parameters:**
+- \`title\`: string - The title of the product
+- \`border-radius\` (Optional): number - The border radius in px
+- \`no-type\` - This parameter has no type
+- \`no-description\`: string
+- \`no-type-or-description\`
+
+**Examples:**
+\`\`\`liquid{{ product }}\`\`\`
+\`\`\`liquid{{ product.title }}\`\`\``;
+
+      await expect(provider).to.hover(`{% render 'product-car█d' %}`, expectedHoverContent);
     });
 
     it('should return null if no LiquidDocDefinition found', async () => {

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -51,7 +51,7 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
 
     if (liquidDoc.description) {
       const description = liquidDoc.description.content;
-      parts.push('', '**Description:**', '\n', description);
+      parts.push('', '**Description:**', '\n', `\`\`\`plaintext\n${description}\n\`\`\``);
     }
 
     if (liquidDoc.parameters?.length) {


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/590

You should now be able to write descriptions with line-breaks + whitespaces, which should render when hovered.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JdHLnhebSbtZTZO01I1e/802cec90-5939-4829-8f27-984102a3e78c.png)

## Before you deploy
- [x] I included a patch bump `changeset`
