### PR TITLE
Move whitespace trimming for LiquidDoc description and example nodes from `liquid-html-parser` to `theme-check-common`

### DIFF
--- a/.changeset/clean-ducks-leave.md
+++ b/.changeset/clean-ducks-leave.md
@@ -1,0 +1,8 @@
+---
+'@shopify/prettier-plugin-liquid': minor
+---
+
+Adjust LiquidDoc formatting rules for single-line and multi-line examples and descriptions
+
+- Multi-line content starts on a new line
+- Single-line content is kept on the same line or a new line as it was provided

--- a/.changeset/perfect-bobcats-tickle.md
+++ b/.changeset/perfect-bobcats-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+[Internal] Update getSnippetDefinitions to trim description content. This was previously done in the parsing step.

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -564,12 +564,12 @@ export function printLiquidDocExample(
   const parts: Doc[] = ['@example'];
 
   const content = node.content.value;
-  if (content) {
-    if (content.includes('\n')) {
-      parts.push(hardline);
-    }
-    parts.push(content.trim());
+  if (content.trimEnd().includes('\n') || !node.isInline) {
+    parts.push(hardline);
+  } else {
+    parts.push(' ');
   }
+  parts.push(content.trim());
 
   return parts;
 }
@@ -582,14 +582,20 @@ export function printLiquidDocDescription(
 ): Doc {
   const node = path.getValue();
   const parts: Doc[] = [];
+  const content = node.content.value;
 
-  if (!node.isImplicit) {
-    parts.push('@description ');
+  if (node.isImplicit) {
+    parts.push(content.trim());
+    return parts;
   }
 
-  if (node.content?.value) {
-    parts.push(node.content.value);
+  parts.push('@description');
+  if (content.trimEnd().includes('\n') || !node.isInline) {
+    parts.push(hardline);
+  } else {
+    parts.push(' ');
   }
+  parts.push(content.trim());
 
   return parts;
 }

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/fixed.liquid
@@ -42,30 +42,21 @@ It should not break params with malformed optional delimiters
   @param [too many words] - param with description
 {% enddoc %}
 
-It should push example content to the next line
+It should keep single-line examples on the line it's written on
 {% doc %}
+  @example This is a valid example
   @example
-  This is a valid example
+  This is a valid example on the next line
 {% enddoc %}
 
-It should allow single empty lines between content
+It should push multi-line examples to the next line
 {% doc %}
   @example
   This is a valid example
+
 
   So is this without a newline
   See?
-{% enddoc %}
-
-It should allow multiple empty lines between content
-{% doc %}
-  @example
-  This is a valid example
-
-
-  Here is another example
-
-  with a single empty line
 {% enddoc %}
 
 It should remove empty lines at the end of the example content
@@ -90,9 +81,20 @@ It should allow multiple example nodes
   Second Example
 {% enddoc %}
 
-It should move description content inline
+It should keep single-line description content on the line it's written on
 {% doc %}
   @description This is a description
+  @description
+  This is another description on the next line
+{% enddoc %}
+
+It should push multi-line description content to the next line
+{% doc %}
+  @description
+  This is a description
+
+
+  This is another description on the next line
 {% enddoc %}
 
 It should add a space between a description tag and content
@@ -125,7 +127,7 @@ It should add padding between dissimilar nodes
   @param {String} param3 - param with description
 {% enddoc %}
 
-It should not append an implicit description with an @description annotation
+It should not prepend an implicit description with an @description annotation
 {% doc %}
   This is an implicit description
 

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.liquid
@@ -41,29 +41,20 @@ It should handle params with malformed optional delimiters
   @param [too many words] - param with description
 {% enddoc %}
 
-It should push example content to the next line
+It should keep single-line examples on the line it's written on
 {% doc %}
   @example This is a valid example
+  @example
+  This is a valid example on the next line
 {% enddoc %}
 
-It should allow single empty lines between content
+It should push multi-line examples to the next line
 {% doc %}
-  @example
-  This is a valid example
+  @example This is a valid example
+
 
   So is this without a newline
   See?
-{% enddoc %}
-
-It should allow multiple empty lines between example content
-{% doc %}
-  @example
-  This is a valid example
-
-
-  Here is another example
-
-  with a single empty line
 {% enddoc %}
 
 It should remove empty lines at the end of the example content
@@ -88,10 +79,19 @@ It should allow multiple example nodes
   Second Example
 {% enddoc %}
 
-It should move description content inline
+It should keep single-line description content on the line it's written on
 {% doc %}
+  @description This is a description
   @description
-  This is a description
+  This is another description on the next line
+{% enddoc %}
+
+It should push multi-line description content to the next line
+{% doc %}
+  @description This is a description
+
+
+  This is another description on the next line
 {% enddoc %}
 
 It should add a space between a description tag and content
@@ -119,7 +119,7 @@ It should add padding between dissimilar nodes
   @param {String} param3 - param with description
 {% enddoc %}
 
-It should not append an implicit description with an @description annotation
+It should not prepend an implicit description with an @description annotation
 {% doc %}
 This is an implicit description
 

--- a/packages/prettier-plugin-liquid/src/test/liquid-doc/index.spec.ts
+++ b/packages/prettier-plugin-liquid/src/test/liquid-doc/index.spec.ts
@@ -1,6 +1,5 @@
 import { test } from 'vitest';
 import { assertFormattedEqualsFixed } from '../test-helpers';
-import * as path from 'path';
 
 test('Unit: liquid-doc', async () => {
   await assertFormattedEqualsFixed(__dirname);

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
@@ -106,7 +106,7 @@ describe('Unit: getSnippetDefinition', () => {
       liquidDoc: {
         examples: [
           {
-            content: '\n          {{ product }}\n',
+            content: '{{ product }}',
             nodeType: 'example',
           },
         ],
@@ -129,7 +129,7 @@ describe('Unit: getSnippetDefinition', () => {
       liquidDoc: {
         examples: [
           {
-            content: '\n          {{ product }}\n          {{ product.title }}\n',
+            content: '{{ product }}\n          {{ product.title }}',
             nodeType: 'example',
           },
         ],
@@ -161,7 +161,7 @@ describe('Unit: getSnippetDefinition', () => {
         ],
         examples: [
           {
-            content: '\n          {{ product }} // This is an example\n',
+            content: '{{ product }} // This is an example',
             nodeType: 'example',
           },
         ],
@@ -185,11 +185,11 @@ describe('Unit: getSnippetDefinition', () => {
       liquidDoc: {
         examples: [
           {
-            content: '\n          {{ product }}\n',
+            content: '{{ product }}',
             nodeType: 'example',
           },
           {
-            content: '\n          {{ product.title }}\n',
+            content: '{{ product.title }}',
             nodeType: 'example',
           },
         ],

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.ts
@@ -68,13 +68,13 @@ export function getSnippetDefinition(
     },
     LiquidDocExampleNode(node: LiquidDocExampleNode) {
       return {
-        content: node.content.value,
+        content: node.content.value.trim(),
         nodeType: 'example',
       };
     },
     LiquidDocDescriptionNode(node: LiquidDocDescriptionNode) {
       return {
-        content: node.content.value,
+        content: node.content.value.trim(),
         nodeType: 'description',
       };
     },

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -87,8 +87,12 @@ This is a description
 - \`no-type-or-description\`
 
 **Examples:**
-\`\`\`liquid{{ product }}\`\`\`
-\`\`\`liquid{{ product.title }}\`\`\``;
+\`\`\`liquid
+{{ product }}
+\`\`\`
+\`\`\`liquid
+{{ product.title }}
+\`\`\``;
 
       await expect(provider).to.hover(`{% render 'product-car█d' %}`, expectedHoverContent);
     });

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -61,7 +61,7 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
 
     if (liquidDoc.examples?.length) {
       const examples = liquidDoc.examples
-        ?.map(({ content }) => `\`\`\`liquid${content}\`\`\``)
+        ?.map(({ content }) => `\`\`\`liquid\n${content}\n\`\`\``)
         .join('\n');
 
       parts.push('', '**Examples:**', examples);


### PR DESCRIPTION
## What are you adding in this PR?

<!-- Describe your changes. Provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Remember to use `fixes` or `solves` keywords to close issues automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

## What's next? Any followup issues?

<!-- Outline follow up tasks with links to issues so they're tracked. -->

## What did you learn?

<!-- Totally optional. But... If you learned something interesting, why not share it? -->

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config
  - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (link PR here).

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
