### PR TITLE
Support LiquidDoc param code completion within snippet

### DIFF
--- a/.changeset/nasty-files-appear.md
+++ b/.changeset/nasty-files-appear.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Support LiquidDoc param code completion within snippet
+
+- When a param is defined in LiquidDoc, it will appear as code completion suggestion
+when performing a variable lookup in the file

--- a/packages/theme-language-server-common/src/TypeSystem.spec.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.spec.ts
@@ -5,7 +5,11 @@ import {
   NodeTypes,
   toLiquidHtmlAST,
 } from '@shopify/liquid-html-parser';
-import { MetafieldDefinitionMap, path as pathUtils } from '@shopify/theme-check-common';
+import {
+  MetafieldDefinitionMap,
+  path as pathUtils,
+  SupportedParamTypes,
+} from '@shopify/theme-check-common';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { URI } from 'vscode-uri';
 import { SettingsSchemaJSONFile } from './settings';
@@ -418,6 +422,36 @@ describe('Module: TypeSystem', () => {
       );
       expect(inferredType).to.eql('untyped');
     }
+  });
+
+  describe('LiquidDoc inferred type', () => {
+    const liquidDocParamTypeToTypeMap = {
+      [SupportedParamTypes.String]: 'string',
+      [SupportedParamTypes.Number]: 'number',
+      [SupportedParamTypes.Boolean]: 'boolean',
+      [SupportedParamTypes.Object]: 'untyped',
+      invalid: 'untyped',
+    };
+
+    Object.entries(liquidDocParamTypeToTypeMap).forEach(([docParamType, expectedType]) => {
+      it(`should support liquid doc params type: ${docParamType}`, async () => {
+        const sourceCode = `
+          {% doc %}
+            @param {${docParamType}} data - some data
+          {% enddoc %}
+          {{ data }}
+        `;
+        const ast = toLiquidHtmlAST(sourceCode);
+        const variableOutput = ast.children[1];
+        assert(isLiquidVariableOutput(variableOutput));
+        const inferredType = await typeSystem.inferType(
+          variableOutput.markup,
+          ast,
+          'file:///snippets/example.liquid',
+        );
+        expect(inferredType).to.eql(expectedType);
+      });
+    });
   });
 
   describe('metafieldDefinitionsObjectMap', async () => {


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/595

- When you have liquid doc with a param defined, it should appear as a completion option when you try to code complete a variable in the file
- It should convert our liquid doc param into a type we support in liquid
  - `boolean`, `string`, and `number` will be converted 1-to-1, but `object` will be converted to type `unknown` since it could be a `product`, `array`, etc.

<img width="720" alt="image" src="https://github.com/user-attachments/assets/a6198686-e4f9-4619-8a2a-6bd8909e16d7" />


## Tophat

- Create a snippet with the following
```
{% doc %} @param {string} name - your name {% enddoc %}

{% assign fake_name = 'fake name' %}

{{ f█ }} // completes with `fake_name` with type string
{{ n█ }} // completes with `name` with type string
```

- You should be able to test it with `boolean`, `string`, `number`, and `object`

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
