### PR TITLE
Doc param names don't collide with reserved words

### DIFF
--- a/.changeset/eight-dodos-yawn.md
+++ b/.changeset/eight-dodos-yawn.md
@@ -1,0 +1,9 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Theme check to ensure liquid doc param names don't collide with reserved words
+
+- Theme check will report a warning if param name collides with global liquid objects
+- Theme check will report a warning if param name collides with liquid tags

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -42,6 +42,7 @@ import { ValidContentForArguments } from './valid-content-for-arguments';
 import { ValidBlockTarget } from './valid-block-target';
 import { ValidHTMLTranslation } from './valid-html-translation';
 import { ValidJSON } from './valid-json';
+import { ValidDocParamNames } from './valid-doc-param-names';
 import { ValidDocParamTypes } from './valid-doc-param-types';
 import { ValidLocalBlocks } from './valid-local-blocks';
 import { ValidRenderSnippetParams } from './valid-render-snippet-params';
@@ -100,6 +101,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   ValidHTMLTranslation,
   ValidContentForArguments,
   ValidJSON,
+  ValidDocParamNames,
   ValidDocParamTypes,
   ValidLocalBlocks,
   ValidSchema,

--- a/packages/theme-check-common/src/checks/valid-doc-param-names/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-doc-param-names/index.spec.ts
@@ -1,0 +1,49 @@
+import { expect, describe, it } from 'vitest';
+import { ValidDocParamNames } from './index';
+import { runLiquidCheck } from '../../test';
+
+describe('Module: ValidDocParamNames', () => {
+  it(`should not report a warning when no doc params share names with global objects or liquid tags`, async () => {
+    const sourceCode = `
+      {% doc %}
+        @param param1 - Example param
+      {% enddoc %}
+    `;
+
+    const offenses = await runLiquidCheck(ValidDocParamNames, sourceCode);
+
+    expect(offenses).to.be.empty;
+  });
+
+  it('should report a warning when a doc param shares a name with global objects', async () => {
+    const sourceCode = `
+      {% doc %}
+        @param param1 - Example param
+        @param when - Example param
+      {% enddoc %}
+    `;
+
+    const offenses = await runLiquidCheck(ValidDocParamNames, sourceCode);
+
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal(
+      "The parameter 'when' shares the same name with a liquid tag.",
+    );
+  });
+
+  it('should report a warning when a doc param shares a name with a liquid tag', async () => {
+    const sourceCode = `
+      {% doc %}
+        @param param1 - Example param
+        @param product - Example param
+      {% enddoc %}
+    `;
+
+    const offenses = await runLiquidCheck(ValidDocParamNames, sourceCode);
+
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal(
+      "The parameter 'product' shares the same name with a global liquid object.",
+    );
+  });
+});

--- a/packages/theme-check-common/src/checks/valid-doc-param-names/index.ts
+++ b/packages/theme-check-common/src/checks/valid-doc-param-names/index.ts
@@ -1,0 +1,57 @@
+import { TextNode } from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+
+export const ValidDocParamNames: LiquidCheckDefinition = {
+  meta: {
+    code: 'ValidDocParamNames',
+    name: 'Valid doc parameter names',
+    docs: {
+      description:
+        'This check exists to ensure any parameter names defined in LiquidDoc do not collide with reserved words.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-doc-param-names',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    const tagsPromise = context.themeDocset?.tags();
+    const objectsPromise = context.themeDocset?.objects();
+
+    return {
+      async LiquidDocParamNode(node) {
+        const paramName = node.paramName.value;
+
+        const tags = (await tagsPromise)?.map((tag) => tag.name) || [];
+        const objects = (await objectsPromise)?.map((obj) => obj.name) || [];
+
+        if (tags.includes(paramName)) {
+          reportWarning(
+            context,
+            `The parameter '${paramName}' shares the same name with a liquid tag.`,
+            node.paramName,
+          );
+        }
+
+        if (objects.includes(paramName)) {
+          reportWarning(
+            context,
+            `The parameter '${paramName}' shares the same name with a global liquid object.`,
+            node.paramName,
+          );
+        }
+      },
+    };
+  },
+};
+
+function reportWarning(context: any, message: string, node: TextNode) {
+  context.report({
+    message,
+    startIndex: node.position.start,
+    endIndex: node.position.end,
+  });
+}

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -136,6 +136,9 @@ ValidBlockTarget:
 ValidContentForArguments:
   enabled: true
   severity: 0
+ValidDocParamNames:
+  enabled: true
+  severity: 1
 ValidDocParamTypes:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -114,6 +114,9 @@ ValidBlockTarget:
 ValidContentForArguments:
   enabled: true
   severity: 0
+ValidDocParamNames:
+  enabled: true
+  severity: 1
 ValidDocParamTypes:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/538
- Ensure param names don't collide with liquid tags (e.g. `if`, `liquid`, etc.)
- Ensure param names don't collide with global variables (e.g. `product`, `collections`, etc.)

## Tophat

- Create a snippet
- Create a param with name that collides with any liquid tag or global variable
- See warning

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
