### PR TITLE
[LiquidDoc][Theme Check] Check for duplicated params passed to `{% render %}` tag

### DIFF
--- a/.changeset/sour-walls-perform.md
+++ b/.changeset/sour-walls-perform.md
@@ -1,0 +1,11 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Add DuplicateRenderSnippetParams theme check
+
+Introduces a new theme check to detect and report duplicate parameters in Liquid render tags. The check:
+- Identifies duplicate parameter names in render snippets
+- Provides suggestions to remove redundant parameters
+

--- a/packages/theme-check-common/src/checks/duplicate-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/duplicate-render-snippet-params/index.ts
@@ -1,0 +1,87 @@
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { LiquidNamedArgument, RenderMarkup } from '@shopify/liquid-html-parser';
+import { isLiquidString } from '../utils';
+
+export const DuplicateRenderSnippetParams: LiquidCheckDefinition = {
+  meta: {
+    code: 'DuplicateRenderSnippetParams',
+    name: 'Duplicate Render Snippet Parameters',
+    docs: {
+      description:
+        'This check ensures that no duplicate parameter names are provided when rendering a snippet.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/duplicate-render-snippet-params',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    return {
+      async RenderMarkup(node: RenderMarkup) {
+        if (!isLiquidString(node.snippet)) {
+          return;
+        }
+
+        const snippetName = node.snippet.value;
+
+        const encounteredParams = new Set<string>();
+        for (const param of node.args) {
+          const paramName = param.name;
+          if (encounteredParams.has(paramName) || paramName === node.alias) {
+            context.report({
+              message: `Duplicate parameter '${paramName}' in render tag for snippet '${snippetName}'.`,
+              startIndex: param.position.start,
+              endIndex: param.position.end,
+              suggest: [
+                {
+                  message: `Remove duplicate parameter '${paramName}'`,
+                  fix: (fixer) => {
+                    // This parameter removal logic is duplicated in UnrecognizedRenderSnippetParams
+                    // Consider extracting to a shared utility or simplifying the removal approach in the parsing steps.
+                    // I chose not to do so here as I would like more examples to see how this should be done.
+                    const sourceBeforeArg = node.source.slice(0, param.position.start);
+                    const matches = sourceBeforeArg.match(/,\s*/g);
+                    const lastWhitespaceMatch = matches ? matches[matches.length - 1] : null;
+                    let startPos = lastWhitespaceMatch
+                      ? param.position.start - (lastWhitespaceMatch.length - 1)
+                      : param.position.start;
+
+                    if (isLastParam(param)) {
+                      startPos -= 1;
+                    }
+
+                    const sourceAfterArg = node.source.substring(
+                      param.position.end,
+                      node.position.end,
+                    );
+                    const trailingCommaMatch = sourceAfterArg.match(/\s*,/);
+                    if (trailingCommaMatch) {
+                      return fixer.remove(
+                        startPos,
+                        param.position.end + trailingCommaMatch[0].length,
+                      );
+                    }
+                    return fixer.remove(startPos, param.position.end);
+
+                    function isLastParam(param: LiquidNamedArgument): boolean {
+                      return (
+                        node.args.length == 1 ||
+                        param.position.start == node.args[node.args.length - 1].position.start
+                      );
+                    }
+                  },
+                },
+              ],
+            });
+            continue;
+          } else {
+            encounteredParams.add(param.name);
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/duplicate-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/duplicate-render-snippet-params/index.ts
@@ -42,14 +42,18 @@ export const DuplicateRenderSnippetParams: LiquidCheckDefinition = {
                     // This parameter removal logic is duplicated in UnrecognizedRenderSnippetParams
                     // Consider extracting to a shared utility or simplifying the removal approach in the parsing steps.
                     // I chose not to do so here as I would like more examples to see how this should be done.
-                    const sourceBeforeArg = node.source.slice(0, param.position.start);
+                    const sourceBeforeArg = node.source.slice(
+                      node.position.start,
+                      param.position.start,
+                    );
                     const matches = sourceBeforeArg.match(/,\s*/g);
-                    const lastWhitespaceMatch = matches ? matches[matches.length - 1] : null;
-                    let startPos = lastWhitespaceMatch
-                      ? param.position.start - (lastWhitespaceMatch.length - 1)
+                    const lastCommaMatch = matches?.[matches.length - 1];
+                    let startPos = lastCommaMatch
+                      ? param.position.start - (lastCommaMatch.length - 1)
                       : param.position.start;
 
-                    if (isLastParam(param)) {
+                    if (isLastParam(node, param)) {
+                      // Remove the leading comma if it's the last parameter
                       startPos -= 1;
                     }
 
@@ -65,13 +69,6 @@ export const DuplicateRenderSnippetParams: LiquidCheckDefinition = {
                       );
                     }
                     return fixer.remove(startPos, param.position.end);
-
-                    function isLastParam(param: LiquidNamedArgument): boolean {
-                      return (
-                        node.args.length == 1 ||
-                        param.position.start == node.args[node.args.length - 1].position.start
-                      );
-                    }
                   },
                 },
               ],
@@ -85,3 +82,9 @@ export const DuplicateRenderSnippetParams: LiquidCheckDefinition = {
     };
   },
 };
+
+export function isLastParam(node: RenderMarkup, param: LiquidNamedArgument): boolean {
+  return (
+    node.args.length == 1 || param.position.start == node.args[node.args.length - 1].position.start
+  );
+}

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -56,6 +56,7 @@ import { ValidVisibleIf, ValidVisibleIfSettingsSchema } from './valid-visible-if
 import { VariableName } from './variable-name';
 import { AppBlockMissingSchema } from './app-block-missing-schema';
 import { UniqueSettingIds } from './unique-settings-id';
+import { DuplicateRenderSnippetParams } from './duplicate-render-snippet-params';
 
 export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   AppBlockValidTags,
@@ -72,6 +73,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   DeprecatedFilter,
   DeprecatedTag,
   DeprecateLazysizes,
+  DuplicateRenderSnippetParams,
   EmptyBlockContent,
   ImgWidthAndHeight,
   JSONMissingBlock,

--- a/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
@@ -36,7 +36,9 @@ export const UnrecognizedRenderSnippetParams: LiquidCheckDefinition = {
             {
               message: `Remove '${param.name}'`,
               fix: (fixer) => {
-                // This is a bit messy, but it allows us to strip leading and trailing whitespaces and commas
+                // This parameter removal logic is duplicated in DuplicateRenderSnippetParams
+                // Consider extracting to a shared utility or simplifying the removal approach in the parsing steps.
+                // I chose not to do so here as I would like more examples to see how this should be done.
                 const sourceBeforeArg = node.source.slice(0, param.position.start);
                 const matches = sourceBeforeArg.match(/,\s*/g);
                 const lastWhitespaceMatch = matches ? matches[matches.length - 1] : null;

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -52,6 +52,9 @@ DeprecatedFilter:
 DeprecatedTag:
   enabled: true
   severity: 1
+DuplicateRenderSnippetParams:
+  enabled: true
+  severity: 1
 EmptyBlockContent:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -30,6 +30,9 @@ DeprecatedFilter:
 DeprecatedTag:
   enabled: true
   severity: 1
+DuplicateRenderSnippetParams:
+  enabled: true
+  severity: 1
 EmptyBlockContent:
   enabled: true
   severity: 1


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/539

Add a theme check to check for duplicated param passed into a `{% render %}` tag

**Includes:**
- **Reporting** duplicated params
- **Suggesting** fixes to remove -> We will always keep the first occurrence and suggest removal for subsequent occurrences
- Support for **aliases** `{% render 'snippet-name' with 'test' as param, param: 'test' %}`

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config
  - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (link PR here).
