### PR TITLE
Fix file URI handling for Windows platforms

### DIFF
--- a/.changeset/khaki-hornets-care.md
+++ b/.changeset/khaki-hornets-care.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': patch
+---
+
+[Bug fix] Fix file URI handling for Windows platforms

--- a/packages/theme-check-node/src/index.spec.ts
+++ b/packages/theme-check-node/src/index.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, assert, beforeEach, describe, expect, it } from 'vitest';
-import { Config, SourceCodeType, getTheme } from './index';
+import { Config, SourceCodeType, getTheme, getThemeFilesPathPattern } from './index';
 import { Workspace, makeTempWorkspace } from './test/test-helpers';
+import { pathToFileURL } from 'node:url';
 
 describe('Unit: getTheme', () => {
   let workspace: Workspace;
@@ -35,5 +36,16 @@ describe('Unit: getTheme', () => {
 
     // internally we expect the path to be normalized
     expect(jsonFile.uri).to.equal(workspace.uri('locales/en.default.json').replace(/\\/g, '/'));
+  });
+});
+
+describe('Unit: getThemeFilesPathPattern', () => {
+  // This is mostly just to catch edge cases in Windows paths. We want
+  // to ensure that paths do not start with a leading slash on Windows.
+  it('should correctly format the glob pattern', () => {
+    const rootUri = pathToFileURL(__dirname);
+    const normalizedGlob = getThemeFilesPathPattern(rootUri.toString());
+
+    expect(normalizedGlob).to.equal(__dirname.replace(/\\/g, '/') + '/**/*.{liquid,json}');
   });
 });


### PR DESCRIPTION
## What are you adding in this PR?
Part of https://github.com/Shopify/cli/issues/3497

After a long debugging session and some async work with @aswamy, we found where the issue was coming from.

On windows platforms, filepaths look something like this `file:\\\C:\path\to\file`.
- After normalization, it looks like /C:/path/to/file
- When this glob is provided for `asyncGlob` on Windows, it gets confused because of the leading `/`
- We strip that leading `/` if it exists before a path

This implementation checks if the OS is windows before changing the way we change the URI to ensure we don't affect unix based systems. 

## Before you deploy

- [X] I included a patch bump `changeset`
