### PR TITLE
add doc tag auto completion

### DIFF
--- a/.changeset/bright-zoos-provide.md
+++ b/.changeset/bright-zoos-provide.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Add doc tag auto completion
+EX: {% do %} will offer `doc` and finish the tags as {% doc %} {% enddoc %}

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
@@ -106,7 +106,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
     await expect(provider).to.complete('{% ren', ['render']);
     await expect(provider).to.complete('{% rend', ['render']);
     await expect(provider).to.complete('{% fo', ['for']);
-    await expect(provider).to.complete('{% do', ['doc'])
+    await expect(provider).to.complete('{% do', ['doc']);
   });
 
   it('should complete end tags with the correct thing', async () => {

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
@@ -76,6 +76,11 @@ export const tags: TagEntry[] = [
     ],
   },
   { name: 'echo' },
+  {
+    name: 'doc',
+    syntax: '{% doc %}doc_body{% enddoc %}',
+    syntax_keywords: [{ keyword: 'doc_body', description: '...' }],
+  },
 ];
 
 describe('Module: LiquidTagsCompletionProvider', async () => {
@@ -101,6 +106,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
     await expect(provider).to.complete('{% ren', ['render']);
     await expect(provider).to.complete('{% rend', ['render']);
     await expect(provider).to.complete('{% fo', ['for']);
+    await expect(provider).to.complete('{% do', ['doc'])
   });
 
   it('should complete end tags with the correct thing', async () => {

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
@@ -40,6 +40,17 @@ export class LiquidTagsCompletionProvider implements Provider {
     const partial = node.name.replace(CURSOR, '');
     const blockParent = findParentNode(partial, ancestors);
     const tags = await this.themeDocset.tags();
+    if (!tags.some((tag) => tag.name === 'doc')) {
+      tags.push({
+        name: 'doc',
+        category: 'theme',
+        description: 'Creates a documentation block in your theme.',
+        syntax: '{% doc %}\n content\n{% enddoc %}',
+        syntax_keywords: [{ keyword: 'content', description: 'The content of the doc' }],
+        deprecated: false,
+        parameters: [],
+      });
+    }
     return tags
       .filter(({ name }) => name.startsWith(partial))
       .sort(sortByName)


### PR DESCRIPTION
## What are you adding in this PR?
References: https://github.com/Shopify/developer-tools-team/issues/530
Add autocompletion for the doc tag.
Ex: If you start typing `{% do` an auto completion option will come up for `doc`
If you accept it, it will look like:
```liquid
{% doc %}

{% enddoc %}
```

## What's next? Any followup issues?

The actual implementation for the doc tag lives [here](https://github.com/Shopify/theme-liquid-docs/blob/main/data/tags.json) in the `theme-liquid-docs` repo. We don't want to ship usage of the tag yet. For now, the tag has been hardcoded and will be subsequently removed when we officially ship it in the `theme-liquid-docs` repo.

## Before you deploy
<!-- Public API changes, new features -->
- [X] I included a minor bump `changeset`
- [X] My feature is backward compatible