### PR TITLE
[LiquidDoc] Show annotation completion suggestions when `@` is typed

### DIFF
--- a/.changeset/funny-experts-vanish.md
+++ b/.changeset/funny-experts-vanish.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Display completion suggestions while typing for liquiddoc annotations

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -320,7 +320,7 @@ export function startServer(
           codeActionKinds: [...CodeActionKinds],
         },
         completionProvider: {
-          triggerCharacters: ['.', '{{ ', '{% ', '<', '/', '[', '"', "'", ':'],
+          triggerCharacters: ['.', '{{ ', '{% ', '<', '/', '[', '"', "'", ':', '@'],
         },
         documentOnTypeFormattingProvider: {
           firstTriggerCharacter: ' ',


### PR DESCRIPTION
## What are you adding in this PR?
Closes https://github.com/Shopify/developer-tools-team/issues/613

Renders completion suggestion for `liquidDoc` annotations while typing

[Cursor - [Extension Development Host] mega-menu.liquid — horizon.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/JdHLnhebSbtZTZO01I1e/4c74d4db-5572-40ae-a019-20a9cf37430c.mp4" />](https://app.graphite.dev/media/video/JdHLnhebSbtZTZO01I1e/4c74d4db-5572-40ae-a019-20a9cf37430c.mp4)

## What did you learn?
- Didn't know about trigger characters before this but now I do!

## Before you deploy
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
