### PR TITLE
Fix spacing after @example tag in liquid doc

### DIFF
--- a/.changeset/wild-foxes-hear.md
+++ b/.changeset/wild-foxes-hear.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Fix spacing after @example tag in liquid doc

--- a/packages/theme-language-server-common/src/utils/liquidDoc.ts
+++ b/packages/theme-language-server-common/src/utils/liquidDoc.ts
@@ -41,7 +41,7 @@ export const SUPPORTED_LIQUID_DOC_TAG_HANDLES = {
     description: 'Provides an example on how to use the snippet.',
     example:
       '{% doc %}\n' + '  @example {% render "snippet-name", arg1: "value" %}\n' + '{% enddoc %}\n',
-    template: `example\n$0`,
+    template: `example $0`,
   },
   [SupportedDocTagTypes.Description]: {
     description: 'Provides information on what the snippet does.',


### PR DESCRIPTION
## What are you adding in this PR?

During our bug hunt, it was discovered that there is a difference in where we place our cursor after `@description` and `@example`. They both support multi-line and inline content, but should default to the same.

<img width="317" alt="image" src="https://github.com/user-attachments/assets/45993560-17a6-4d4a-ae4f-eb7016c5a78f" />


## Before you deploy
- [x] I included a patch bump `changeset`

