### PR TITLE
Fix liquid doc node hover text

### DIFF
--- a/.changeset/rare-dolls-complain.md
+++ b/.changeset/rare-dolls-complain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Fix bug where help text appears when hovering over liquid doc nodes outside param names

--- a/packages/theme-language-server-common/src/hover/HoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/HoverProvider.ts
@@ -57,7 +57,7 @@ export class HoverProvider {
       new TranslationHoverProvider(getTranslationsForURI, documentManager),
       new RenderSnippetHoverProvider(getSnippetDefinitionForURI),
       new RenderSnippetParameterHoverProvider(getSnippetDefinitionForURI),
-      new LiquidDocTagHoverProvider(),
+      new LiquidDocTagHoverProvider(documentManager),
     ];
   }
 

--- a/packages/theme-language-server-common/src/hover/providers/LiquidDocTagHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidDocTagHoverProvider.spec.ts
@@ -48,30 +48,12 @@ describe('Module: RenderSnippetParameterHoverProvider', async () => {
     );
   });
 
-  it('should show the param help doc when hovering over the text', async () => {
+  it('should not show the param help doc when hovering over text outside param name', async () => {
     await expect(provider).to.hover(
       `{% doc %} @param {string} name - █your name {% enddoc %}`,
-      formatLiquidDocTagHandle(
-        'param',
-        SUPPORTED_LIQUID_DOC_TAG_HANDLES['param'].description,
-        SUPPORTED_LIQUID_DOC_TAG_HANDLES['param'].example,
-      ),
+      null,
     );
-    await expect(provider).to.hover(
-      `{% doc %} @example my █example {% enddoc %}`,
-      formatLiquidDocTagHandle(
-        'example',
-        SUPPORTED_LIQUID_DOC_TAG_HANDLES['example'].description,
-        SUPPORTED_LIQUID_DOC_TAG_HANDLES['example'].example,
-      ),
-    );
-    await expect(provider).to.hover(
-      `{% doc %} @description cool text█ is cool {% enddoc %}`,
-      formatLiquidDocTagHandle(
-        'description',
-        SUPPORTED_LIQUID_DOC_TAG_HANDLES['description'].description,
-        SUPPORTED_LIQUID_DOC_TAG_HANDLES['description'].example,
-      ),
-    );
+    await expect(provider).to.hover(`{% doc %} @example my █example {% enddoc %}`, null);
+    await expect(provider).to.hover(`{% doc %} @description cool text█ is cool {% enddoc %}`, null);
   });
 });


### PR DESCRIPTION
## What are you adding in this PR?

- Fix bug where hover text appears when hovering over liquid doc nodes that aren't just node names

NOTE: The hover text won't appear when your cursor is _just_ on `@` symbol. This is just because of our liquid syntax rules.
<img width="923" alt="image" src="https://github.com/user-attachments/assets/3db5e44a-6336-47f0-9600-73dc4e57cbc5" />


## Before you deploy

- [x] I included a patch bump `changeset`
