### PR TITLE
Renaming liquid doc params refactors render tag params

### DIFF
--- a/.changeset/witty-lizards-collect.md
+++ b/.changeset/witty-lizards-collect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Renaming liquid doc params refactors render tag params

--- a/packages/theme-language-server-common/src/rename/RenameProvider.ts
+++ b/packages/theme-language-server-common/src/rename/RenameProvider.ts
@@ -12,6 +12,8 @@ import { findCurrentNode } from '@shopify/theme-check-common';
 import { BaseRenameProvider } from './BaseRenameProvider';
 import { HtmlTagNameRenameProvider } from './providers/HtmlTagNameRenameProvider';
 import { LiquidVariableRenameProvider } from './providers/LiquidVariableRenameProvider';
+import { Connection } from 'vscode-languageserver';
+import { ClientCapabilities } from '../ClientCapabilities';
 
 /**
  * RenameProvider is responsible for providing rename support for the theme language server.
@@ -21,10 +23,20 @@ import { LiquidVariableRenameProvider } from './providers/LiquidVariableRenamePr
 export class RenameProvider {
   private providers: BaseRenameProvider[];
 
-  constructor(private documentManager: DocumentManager) {
+  constructor(
+    connection: Connection,
+    clientCapabilities: ClientCapabilities,
+    private documentManager: DocumentManager,
+    findThemeRootURI: (uri: string) => Promise<string>,
+  ) {
     this.providers = [
       new HtmlTagNameRenameProvider(documentManager),
-      new LiquidVariableRenameProvider(documentManager),
+      new LiquidVariableRenameProvider(
+        connection,
+        clientCapabilities,
+        documentManager,
+        findThemeRootURI,
+      ),
     ];
   }
 

--- a/packages/theme-language-server-common/src/rename/providers/HtmlTagNameRenameProvider.spec.ts
+++ b/packages/theme-language-server-common/src/rename/providers/HtmlTagNameRenameProvider.spec.ts
@@ -2,6 +2,10 @@ import { assert, beforeEach, describe, expect, it } from 'vitest';
 import { Position, TextDocumentEdit } from 'vscode-languageserver-protocol';
 import { DocumentManager } from '../../documents';
 import { RenameProvider } from '../RenameProvider';
+import { ClientCapabilities } from '../../ClientCapabilities';
+import { mockConnection } from '../../test/MockConnection';
+
+const mockRoot = 'file:';
 
 describe('HtmlTagNameRenameProvider', () => {
   let documentManager: DocumentManager;
@@ -9,7 +13,12 @@ describe('HtmlTagNameRenameProvider', () => {
 
   beforeEach(() => {
     documentManager = new DocumentManager();
-    provider = new RenameProvider(documentManager);
+    provider = new RenameProvider(
+      mockConnection(mockRoot),
+      new ClientCapabilities(),
+      documentManager,
+      async () => mockRoot,
+    );
   });
 
   it('returns null when the cursor is not over an HTML tag name', async () => {

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -117,7 +117,12 @@ export function startServer(
   );
   const linkedEditingRangesProvider = new LinkedEditingRangesProvider(documentManager);
   const documentHighlightProvider = new DocumentHighlightsProvider(documentManager);
-  const renameProvider = new RenameProvider(documentManager);
+  const renameProvider = new RenameProvider(
+    connection,
+    clientCapabilities,
+    documentManager,
+    findThemeRootURI,
+  );
   const renameHandler = new RenameHandler(
     connection,
     clientCapabilities,


### PR DESCRIPTION
## What are you adding in this PR?

Part 1 of https://github.com/Shopify/developer-tools-team/issues/616

By renaming liquid doc params, we also refactor the render tag named params
- Next PR will also update alias
  - `with 'literal' as foo`
  - `with variable as foo`
  - `for 'literal' as foo`
  - `for variable as foo`

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
