### PR TITLE
Renaming liquid doc params refactors render tag alias param

### DIFF
--- a/.changeset/thick-suits-float.md
+++ b/.changeset/thick-suits-float.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Renaming liquid doc params refactors render tag alias param

--- a/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.ts
+++ b/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.ts
@@ -245,6 +245,23 @@ async function updateRenderTags(
             ),
           };
         }
+
+        if (node.alias === oldParamName && node.variable) {
+          // `as variable` is not captured in our liquid parser yet,
+          // so we have to check it manually and replace it
+          const aliasMatch = /as\s+([^\s,]+)/g;
+          const match = aliasMatch.exec(node.source.slice(node.position.start, node.position.end));
+
+          if (!match) return;
+
+          return {
+            newText: `as ${newParamName}`,
+            range: Range.create(
+              textDocument.positionAt(node.position.start + match.index),
+              textDocument.positionAt(node.position.start + match.index + match[0].length),
+            ),
+          };
+        }
       },
     });
 


### PR DESCRIPTION
## What are you adding in this PR?

Part 2 of https://github.com/Shopify/developer-tools-team/issues/616
Closes https://github.com/Shopify/developer-tools-team/issues/616

By renaming liquid doc params, we also refactor the render tag alias.

Example:
  - `render 'example-snippet' with 'literal' as foo`
  - `render 'example-snippet' with variable as foo`
  - `render 'example-snippet' for 'literal' as foo`
  - `render 'example-snippet' for variable as foo`

https://github.com/user-attachments/assets/e50b912f-9dd0-4667-8c8c-59c12ceaf859

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
