### PR TITLE
Improve alias parsing in the cst & ast

### DIFF
--- a/.changeset/curvy-eels-smash.md
+++ b/.changeset/curvy-eels-smash.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/prettier-plugin-liquid': patch
+'@shopify/liquid-html-parser': patch
+'@shopify/theme-check-common': patch
+---
+
+Improve parsing logic around aliases

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -492,15 +492,15 @@ describe('Unit: Stage 1 (CST)', () => {
           {
             expression: `"snippet"`,
             snippetType: 'String',
-            aliasExpression: null,
+            alias: null,
             renderVariableExpression: null,
             namedArguments: [],
           },
           {
             expression: `"snippet" as foo`,
             snippetType: 'String',
-            aliasExpression: {
-              alias: 'foo',
+            alias: {
+              value: 'foo',
             },
             renderVariableExpression: null,
             namedArguments: [],
@@ -508,8 +508,8 @@ describe('Unit: Stage 1 (CST)', () => {
           {
             expression: `"snippet" with "string" as foo`,
             snippetType: 'String',
-            aliasExpression: {
-              alias: 'foo',
+            alias: {
+              value: 'foo',
             },
             renderVariableExpression: {
               kind: 'with',
@@ -522,8 +522,8 @@ describe('Unit: Stage 1 (CST)', () => {
           {
             expression: `"snippet" for products as product`,
             snippetType: 'String',
-            aliasExpression: {
-              alias: 'product',
+            alias: {
+              value: 'product',
             },
             renderVariableExpression: {
               kind: 'for',
@@ -536,8 +536,8 @@ describe('Unit: Stage 1 (CST)', () => {
           {
             expression: `variable with "string" as foo, key1: val1, key2: "hi"`,
             snippetType: 'VariableLookup',
-            aliasExpression: {
-              alias: 'foo',
+            alias: {
+              value: 'foo',
             },
             renderVariableExpression: {
               kind: 'with',
@@ -551,13 +551,7 @@ describe('Unit: Stage 1 (CST)', () => {
             ],
           },
         ].forEach(
-          ({
-            expression,
-            snippetType,
-            renderVariableExpression,
-            aliasExpression,
-            namedArguments,
-          }) => {
+          ({ expression, snippetType, renderVariableExpression, alias, namedArguments }) => {
             for (const { toCST, expectPath } of testCases) {
               cst = toCST(`{% render ${expression} -%}`);
               expectPath(cst, '0.type').to.equal('LiquidTag');
@@ -573,7 +567,7 @@ describe('Unit: Stage 1 (CST)', () => {
               } else {
                 expectPath(cst, '0.markup.variable').to.equal(null);
               }
-              expectPath(cst, '0.markup.aliasExpression.alias').to.equal(aliasExpression?.alias);
+              expectPath(cst, '0.markup.alias.value').to.equal(alias?.value);
               expectPath(cst, '0.markup.renderArguments').to.have.lengthOf(namedArguments.length);
               namedArguments.forEach(({ name, valueType }, i) => {
                 expectPath(cst, `0.markup.renderArguments.${i}.type`).to.equal('NamedArgument');

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -492,21 +492,25 @@ describe('Unit: Stage 1 (CST)', () => {
           {
             expression: `"snippet"`,
             snippetType: 'String',
-            alias: null,
+            aliasExpression: null,
             renderVariableExpression: null,
             namedArguments: [],
           },
           {
             expression: `"snippet" as foo`,
             snippetType: 'String',
-            alias: 'foo',
+            aliasExpression: {
+              alias: 'foo',
+            },
             renderVariableExpression: null,
             namedArguments: [],
           },
           {
             expression: `"snippet" with "string" as foo`,
             snippetType: 'String',
-            alias: 'foo',
+            aliasExpression: {
+              alias: 'foo',
+            },
             renderVariableExpression: {
               kind: 'with',
               name: {
@@ -518,7 +522,9 @@ describe('Unit: Stage 1 (CST)', () => {
           {
             expression: `"snippet" for products as product`,
             snippetType: 'String',
-            alias: 'product',
+            aliasExpression: {
+              alias: 'product',
+            },
             renderVariableExpression: {
               kind: 'for',
               name: {
@@ -530,7 +536,9 @@ describe('Unit: Stage 1 (CST)', () => {
           {
             expression: `variable with "string" as foo, key1: val1, key2: "hi"`,
             snippetType: 'VariableLookup',
-            alias: 'foo',
+            aliasExpression: {
+              alias: 'foo',
+            },
             renderVariableExpression: {
               kind: 'with',
               name: {
@@ -543,7 +551,13 @@ describe('Unit: Stage 1 (CST)', () => {
             ],
           },
         ].forEach(
-          ({ expression, snippetType, renderVariableExpression, alias, namedArguments }) => {
+          ({
+            expression,
+            snippetType,
+            renderVariableExpression,
+            aliasExpression,
+            namedArguments,
+          }) => {
             for (const { toCST, expectPath } of testCases) {
               cst = toCST(`{% render ${expression} -%}`);
               expectPath(cst, '0.type').to.equal('LiquidTag');
@@ -559,7 +573,7 @@ describe('Unit: Stage 1 (CST)', () => {
               } else {
                 expectPath(cst, '0.markup.variable').to.equal(null);
               }
-              expectPath(cst, '0.markup.alias').to.equal(alias);
+              expectPath(cst, '0.markup.aliasExpression.alias').to.equal(aliasExpression?.alias);
               expectPath(cst, '0.markup.renderArguments').to.have.lengthOf(namedArguments.length);
               namedArguments.forEach(({ name, valueType }, i) => {
                 expectPath(cst, `0.markup.renderArguments.${i}.type`).to.equal('NamedArgument');

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -379,7 +379,7 @@ export interface ConcreteLiquidTagRenderMarkup
   extends ConcreteBasicNode<ConcreteNodeTypes.RenderMarkup> {
   snippet: ConcreteStringLiteral | ConcreteLiquidVariableLookup;
   variable: ConcreteRenderVariableExpression | null;
-  aliasExpression: ConcreteRenderAliasExpression | null;
+  alias: ConcreteRenderAliasExpression | null;
   renderArguments: ConcreteLiquidNamedArgument[];
 }
 
@@ -391,7 +391,7 @@ export interface ConcreteRenderVariableExpression
 
 export interface ConcreteRenderAliasExpression
   extends ConcreteBasicNode<ConcreteNodeTypes.RenderAliasExpression> {
-  alias: string;
+  value: string;
 }
 
 export interface ConcreteLiquidVariableOutput
@@ -873,7 +873,7 @@ function toCST<T>(
       type: ConcreteNodeTypes.RenderMarkup,
       snippet: 0,
       variable: 1,
-      aliasExpression: 2,
+      alias: 2,
       renderArguments: 3,
       locStart,
       locEnd,
@@ -908,7 +908,7 @@ function toCST<T>(
     },
     renderAliasExpression: {
       type: ConcreteNodeTypes.RenderAliasExpression,
-      alias: 3,
+      value: 3,
       locStart,
       locEnd,
       source,

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -82,6 +82,7 @@ export enum ConcreteNodeTypes {
   RenderMarkup = 'RenderMarkup',
   PaginateMarkup = 'PaginateMarkup',
   RenderVariableExpression = 'RenderVariableExpression',
+  RenderAliasExpression = 'RenderAliasExpression',
   ContentForNamedArgument = 'ContentForNamedArgument',
 
   LiquidDocParamNode = 'LiquidDocParamNode',
@@ -377,8 +378,8 @@ export interface ConcreteLiquidTagContentForMarkup
 export interface ConcreteLiquidTagRenderMarkup
   extends ConcreteBasicNode<ConcreteNodeTypes.RenderMarkup> {
   snippet: ConcreteStringLiteral | ConcreteLiquidVariableLookup;
-  alias: string | null;
   variable: ConcreteRenderVariableExpression | null;
+  aliasExpression: ConcreteRenderAliasExpression | null;
   renderArguments: ConcreteLiquidNamedArgument[];
 }
 
@@ -386,6 +387,11 @@ export interface ConcreteRenderVariableExpression
   extends ConcreteBasicNode<ConcreteNodeTypes.RenderVariableExpression> {
   kind: 'for' | 'with';
   name: ConcreteLiquidExpression;
+}
+
+export interface ConcreteRenderAliasExpression
+  extends ConcreteBasicNode<ConcreteNodeTypes.RenderAliasExpression> {
+  alias: string;
 }
 
 export interface ConcreteLiquidVariableOutput
@@ -867,7 +873,7 @@ function toCST<T>(
       type: ConcreteNodeTypes.RenderMarkup,
       snippet: 0,
       variable: 1,
-      alias: 2,
+      aliasExpression: 2,
       renderArguments: 3,
       locStart,
       locEnd,
@@ -900,7 +906,13 @@ function toCST<T>(
       locEnd,
       source,
     },
-    renderAliasExpression: 3,
+    renderAliasExpression: {
+      type: ConcreteNodeTypes.RenderAliasExpression,
+      alias: 3,
+      locStart,
+      locEnd,
+      source,
+    },
 
     liquidDrop: {
       type: ConcreteNodeTypes.LiquidVariableOutput,

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -402,21 +402,25 @@ describe('Unit: Stage 2 (AST)', () => {
           {
             expression: `"snippet"`,
             snippetType: 'String',
-            alias: null,
+            aliasExpression: null,
             renderVariableExpression: null,
             namedArguments: [],
           },
           {
             expression: `"snippet" as foo`,
             snippetType: 'String',
-            alias: 'foo',
+            aliasExpression: {
+              alias: 'foo',
+            },
             renderVariableExpression: null,
             namedArguments: [],
           },
           {
             expression: `"snippet" with "string" as foo`,
             snippetType: 'String',
-            alias: 'foo',
+            aliasExpression: {
+              alias: 'foo',
+            },
             renderVariableExpression: {
               kind: 'with',
               name: {
@@ -428,7 +432,9 @@ describe('Unit: Stage 2 (AST)', () => {
           {
             expression: `"snippet" for products as product`,
             snippetType: 'String',
-            alias: 'product',
+            aliasExpression: {
+              alias: 'product',
+            },
             renderVariableExpression: {
               kind: 'for',
               name: {
@@ -440,7 +446,9 @@ describe('Unit: Stage 2 (AST)', () => {
           {
             expression: `variable with "string" as foo, key1: val1, key2: "hi"`,
             snippetType: 'VariableLookup',
-            alias: 'foo',
+            aliasExpression: {
+              alias: 'foo',
+            },
             renderVariableExpression: {
               kind: 'with',
               name: {
@@ -453,7 +461,13 @@ describe('Unit: Stage 2 (AST)', () => {
             ],
           },
         ].forEach(
-          ({ expression, snippetType, renderVariableExpression, alias, namedArguments }) => {
+          ({
+            expression,
+            snippetType,
+            renderVariableExpression,
+            aliasExpression,
+            namedArguments,
+          }) => {
             for (const { toAST, expectPath, expectPosition } of testCases) {
               ast = toAST(`{% render ${expression} -%}`);
               expectPath(ast, 'children.0.type').to.equal('LiquidTag');
@@ -475,7 +489,9 @@ describe('Unit: Stage 2 (AST)', () => {
               } else {
                 expectPath(ast, 'children.0.markup.variable').to.equal(null);
               }
-              expectPath(ast, 'children.0.markup.alias').to.equal(alias);
+              expectPath(ast, 'children.0.markup.aliasExpression.alias').to.equal(
+                aliasExpression?.alias,
+              );
               expectPath(ast, 'children.0.markup.args').to.have.lengthOf(namedArguments.length);
               namedArguments.forEach(({ name, valueType }, i) => {
                 expectPath(ast, `children.0.markup.args.${i}.type`).to.equal('NamedArgument');

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -402,15 +402,15 @@ describe('Unit: Stage 2 (AST)', () => {
           {
             expression: `"snippet"`,
             snippetType: 'String',
-            aliasExpression: null,
+            alias: null,
             renderVariableExpression: null,
             namedArguments: [],
           },
           {
             expression: `"snippet" as foo`,
             snippetType: 'String',
-            aliasExpression: {
-              alias: 'foo',
+            alias: {
+              value: 'foo',
             },
             renderVariableExpression: null,
             namedArguments: [],
@@ -418,8 +418,8 @@ describe('Unit: Stage 2 (AST)', () => {
           {
             expression: `"snippet" with "string" as foo`,
             snippetType: 'String',
-            aliasExpression: {
-              alias: 'foo',
+            alias: {
+              value: 'foo',
             },
             renderVariableExpression: {
               kind: 'with',
@@ -432,8 +432,8 @@ describe('Unit: Stage 2 (AST)', () => {
           {
             expression: `"snippet" for products as product`,
             snippetType: 'String',
-            aliasExpression: {
-              alias: 'product',
+            alias: {
+              value: 'product',
             },
             renderVariableExpression: {
               kind: 'for',
@@ -446,8 +446,8 @@ describe('Unit: Stage 2 (AST)', () => {
           {
             expression: `variable with "string" as foo, key1: val1, key2: "hi"`,
             snippetType: 'VariableLookup',
-            aliasExpression: {
-              alias: 'foo',
+            alias: {
+              value: 'foo',
             },
             renderVariableExpression: {
               kind: 'with',
@@ -461,13 +461,7 @@ describe('Unit: Stage 2 (AST)', () => {
             ],
           },
         ].forEach(
-          ({
-            expression,
-            snippetType,
-            renderVariableExpression,
-            aliasExpression,
-            namedArguments,
-          }) => {
+          ({ expression, snippetType, renderVariableExpression, alias, namedArguments }) => {
             for (const { toAST, expectPath, expectPosition } of testCases) {
               ast = toAST(`{% render ${expression} -%}`);
               expectPath(ast, 'children.0.type').to.equal('LiquidTag');
@@ -489,9 +483,7 @@ describe('Unit: Stage 2 (AST)', () => {
               } else {
                 expectPath(ast, 'children.0.markup.variable').to.equal(null);
               }
-              expectPath(ast, 'children.0.markup.aliasExpression.alias').to.equal(
-                aliasExpression?.alias,
-              );
+              expectPath(ast, 'children.0.markup.alias.value').to.equal(alias?.value);
               expectPath(ast, 'children.0.markup.args').to.have.lengthOf(namedArguments.length);
               namedArguments.forEach(({ name, valueType }, i) => {
                 expectPath(ast, `children.0.markup.args.${i}.type`).to.equal('NamedArgument');

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -431,7 +431,7 @@ export interface RenderVariableExpression extends ASTNode<NodeTypes.RenderVariab
 
 /** Represents the `as name` expressions in render nodes */
 export interface RenderAliasExpression extends ASTNode<NodeTypes.RenderAliasExpression> {
-  /** {% render 'snippet' as name %} */
+  /** {% render 'snippet' for array as name %}` or `{% render 'snippet' with object as name %} */
   value: string;
 }
 

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -408,7 +408,7 @@ export interface RenderMarkup extends ASTNode<NodeTypes.RenderMarkup> {
   /** {% render snippet %} */
   snippet: LiquidString | LiquidVariableLookup;
   /** {% render 'snippet' with thing as alias %} */
-  aliasExpression: RenderAliasExpression | null;
+  alias: RenderAliasExpression | null;
   /** {% render 'snippet' [with variable] %} */
   variable: RenderVariableExpression | null;
   /**
@@ -432,7 +432,7 @@ export interface RenderVariableExpression extends ASTNode<NodeTypes.RenderVariab
 /** Represents the `as name` expressions in render nodes */
 export interface RenderAliasExpression extends ASTNode<NodeTypes.RenderAliasExpression> {
   /** {% render 'snippet' as name %} */
-  alias: string;
+  value: string;
 }
 
 /** The union type of the strictly and loosely typed LiquidBranch nodes */
@@ -1824,7 +1824,7 @@ function toRenderMarkup(node: ConcreteLiquidTagRenderMarkup): RenderMarkup {
   return {
     type: NodeTypes.RenderMarkup,
     snippet: toExpression(node.snippet) as LiquidString | LiquidVariableLookup,
-    aliasExpression: toRenderAliasExpression(node.aliasExpression),
+    alias: toRenderAliasExpression(node.alias),
     variable: toRenderVariableExpression(node.variable),
     /**
      * When we're in completion mode we won't necessarily have valid named
@@ -1859,7 +1859,7 @@ function toRenderAliasExpression(
   if (!node) return null;
   return {
     type: NodeTypes.RenderAliasExpression,
-    alias: node.alias,
+    value: node.value,
     position: position(node),
     source: node.source,
   };

--- a/packages/liquid-html-parser/src/types.ts
+++ b/packages/liquid-html-parser/src/types.ts
@@ -44,6 +44,7 @@ export enum NodeTypes {
   RawMarkup = 'RawMarkup',
   RenderMarkup = 'RenderMarkup',
   RenderVariableExpression = 'RenderVariableExpression',
+  RenderAliasExpression = 'RenderAliasExpression',
   LiquidDocDescriptionNode = 'LiquidDocDescriptionNode',
   LiquidDocParamNode = 'LiquidDocParamNode',
   LiquidDocExampleNode = 'LiquidDocExampleNode',

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -126,6 +126,7 @@ function getCssDisplay(node: AugmentedNode<WithSiblings>, options: LiquidParserO
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
     case NodeTypes.RenderVariableExpression:
+    case NodeTypes.RenderAliasExpression:
     case NodeTypes.LogicalExpression:
     case NodeTypes.Comparison:
     case NodeTypes.LiquidDocParamNode:
@@ -234,6 +235,7 @@ function getNodeCssStyleWhiteSpace(
     case NodeTypes.PaginateMarkup:
     case NodeTypes.RenderMarkup:
     case NodeTypes.RenderVariableExpression:
+    case NodeTypes.RenderAliasExpression:
     case NodeTypes.LogicalExpression:
     case NodeTypes.Comparison:
     case NodeTypes.LiquidDocParamNode:

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -183,7 +183,7 @@ function printNamedLiquidBlockStart(
     case NamedTags.render: {
       const markup = node.markup;
       const trailingWhitespace =
-        markup.args.length > 0 || (markup.variable && markup.aliasExpression?.alias) ? line : ' ';
+        markup.args.length > 0 || (markup.variable && markup.alias) ? line : ' ';
       return tag(trailingWhitespace);
     }
 

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -183,7 +183,7 @@ function printNamedLiquidBlockStart(
     case NamedTags.render: {
       const markup = node.markup;
       const trailingWhitespace =
-        markup.args.length > 0 || (markup.variable && markup.alias) ? line : ' ';
+        markup.args.length > 0 || (markup.variable && markup.aliasExpression?.alias) ? line : ' ';
       return tag(trailingWhitespace);
     }
 

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -411,14 +411,14 @@ function printNode(
       const snippet = path.call((p: any) => print(p), 'snippet');
       const doc: Doc = [snippet];
       if (node.variable) {
-        const whitespace = node.alias ? line : ' ';
+        const whitespace = node.aliasExpression?.alias ? line : ' ';
         doc.push(
           whitespace,
           path.call((p: any) => print(p), 'variable'),
         );
       }
-      if (node.alias) {
-        doc.push(' ', 'as', ' ', node.alias);
+      if (node.aliasExpression?.alias) {
+        doc.push(' ', 'as', ' ', node.aliasExpression.alias);
       }
       if (node.args.length > 0) {
         doc.push(
@@ -435,6 +435,10 @@ function printNode(
 
     case NodeTypes.RenderVariableExpression: {
       return [node.kind, ' ', path.call((p: any) => print(p), 'name')];
+    }
+
+    case NodeTypes.RenderAliasExpression: {
+      return node.alias;
     }
 
     case NodeTypes.LogicalExpression: {

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -411,14 +411,14 @@ function printNode(
       const snippet = path.call((p: any) => print(p), 'snippet');
       const doc: Doc = [snippet];
       if (node.variable) {
-        const whitespace = node.aliasExpression?.alias ? line : ' ';
+        const whitespace = node.alias?.value ? line : ' ';
         doc.push(
           whitespace,
           path.call((p: any) => print(p), 'variable'),
         );
       }
-      if (node.aliasExpression?.alias) {
-        doc.push(' ', 'as', ' ', node.aliasExpression.alias);
+      if (node.alias?.value) {
+        doc.push(' ', 'as', ' ', node.alias.value);
       }
       if (node.args.length > 0) {
         doc.push(
@@ -438,7 +438,7 @@ function printNode(
     }
 
     case NodeTypes.RenderAliasExpression: {
-      return node.alias;
+      return node.value;
     }
 
     case NodeTypes.LogicalExpression: {

--- a/packages/theme-check-common/src/checks/duplicate-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/duplicate-render-snippet-params/index.ts
@@ -30,7 +30,7 @@ export const DuplicateRenderSnippetParams: LiquidCheckDefinition = {
         const encounteredParams = new Set<string>();
         for (const param of node.args) {
           const paramName = param.name;
-          if (encounteredParams.has(paramName) || paramName === node.alias) {
+          if (encounteredParams.has(paramName) || paramName === node.aliasExpression?.alias) {
             context.report({
               message: `Duplicate parameter '${paramName}' in render tag for snippet '${snippetName}'.`,
               startIndex: param.position.start,

--- a/packages/theme-check-common/src/checks/duplicate-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/duplicate-render-snippet-params/index.ts
@@ -30,7 +30,7 @@ export const DuplicateRenderSnippetParams: LiquidCheckDefinition = {
         const encounteredParams = new Set<string>();
         for (const param of node.args) {
           const paramName = param.name;
-          if (encounteredParams.has(paramName) || paramName === node.aliasExpression?.alias) {
+          if (encounteredParams.has(paramName) || paramName === node.alias?.value) {
             context.report({
               message: `Duplicate parameter '${paramName}' in render tag for snippet '${snippetName}'.`,
               startIndex: param.position.start,

--- a/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
@@ -82,8 +82,7 @@ export const MissingRenderSnippetParams: LiquidCheckDefinition = {
 
         const providedParams = new Map(node.args.map((arg) => [arg.name, arg]));
         const missingRequiredParams = snippetDef.liquidDoc.parameters.filter(
-          (p) =>
-            p.required && !providedParams.has(p.name) && p.name !== node.aliasExpression?.alias,
+          (p) => p.required && !providedParams.has(p.name) && p.name !== node.alias?.value,
         );
 
         reportMissingParams(missingRequiredParams, node, snippetName);

--- a/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
@@ -82,7 +82,8 @@ export const MissingRenderSnippetParams: LiquidCheckDefinition = {
 
         const providedParams = new Map(node.args.map((arg) => [arg.name, arg]));
         const missingRequiredParams = snippetDef.liquidDoc.parameters.filter(
-          (p) => p.required && !providedParams.has(p.name) && p.name !== node.alias,
+          (p) =>
+            p.required && !providedParams.has(p.name) && p.name !== node.aliasExpression?.alias,
         );
 
         reportMissingParams(missingRequiredParams, node, snippetName);

--- a/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.spec.ts
@@ -224,7 +224,7 @@ describe('Module: UnrecognizedRenderSnippetParams', () => {
           {% doc %}
             @param {string} title - The title of the card
           {% enddoc %}
-          <div>{{ title }}</div>  
+          <div>{{ title }}</div>
         `,
       } as MockTheme;
 
@@ -241,7 +241,7 @@ describe('Module: UnrecognizedRenderSnippetParams', () => {
       expect(offenses[0].message).toBe(
         "Unknown parameter 'unknown_param' in render tag for snippet 'card'",
       );
-      expect(offenses[0].start.index).toBe(sourceCode.indexOf(' with'));
+      expect(offenses[0].start.index).toBe(sourceCode.indexOf('with'));
       expect(offenses[0].end.index).toBe(
         sourceCode.indexOf('unknown_param') + 'unknown_param'.length,
       );
@@ -259,7 +259,7 @@ describe('Module: UnrecognizedRenderSnippetParams', () => {
       expect(offenses[0].message).toBe(
         "Unknown parameter 'unknown_param' in render tag for snippet 'card'",
       );
-      expect(offenses[0].start.index).toBe(sourceCode.indexOf(' for'));
+      expect(offenses[0].start.index).toBe(sourceCode.indexOf('for'));
       expect(offenses[0].end.index).toBe(
         sourceCode.indexOf('unknown_param') + 'unknown_param'.length,
       );
@@ -277,7 +277,7 @@ describe('Module: UnrecognizedRenderSnippetParams', () => {
           {% doc %}
             @param {string} title - The title of the card
           {% enddoc %}
-          <div>{{ title }}</div>  
+          <div>{{ title }}</div>
         `,
         },
       );

--- a/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
@@ -71,29 +71,22 @@ export const UnrecognizedRenderSnippetParams: LiquidCheckDefinition = {
       liquidDocParameters: Map<string, LiquidDocParameter>,
       snippetName: string,
     ) {
-      if (node.alias?.value && !liquidDocParameters.has(node.alias.value) && node.variable) {
-        const source = node.source;
-        let startIndex = node.variable.position.start;
+      const alias = node.alias;
+      const variable = node.variable;
 
-        if (
-          source.slice(startIndex, node.alias.position.start).includes(' with ') ||
-          source.slice(startIndex, node.alias.position.start).includes(' for ')
-        ) {
-          startIndex = node.variable.position.start + 1;
-        } else {
-          startIndex = node.alias.position.start;
-        }
+      if (alias && !liquidDocParameters.has(alias.value) && variable) {
+        const startIndex = variable.position.start + 1;
 
         context.report({
-          message: `Unknown parameter '${node.alias.value}' in render tag for snippet '${snippetName}'`,
+          message: `Unknown parameter '${alias.value}' in render tag for snippet '${snippetName}'`,
           startIndex: startIndex,
-          endIndex: node.alias.position.end,
+          endIndex: alias.position.end,
           suggest: [
             {
-              message: `Remove '${node.alias.value}'`,
+              message: `Remove '${alias.value}'`,
               fix: (fixer: any) => {
-                if (node.variable) {
-                  return fixer.remove(node.variable.position.start, node.alias?.position.end);
+                if (variable) {
+                  return fixer.remove(variable.position.start, alias.position.end);
                 }
               },
             },

--- a/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
@@ -71,36 +71,29 @@ export const UnrecognizedRenderSnippetParams: LiquidCheckDefinition = {
       liquidDocParameters: Map<string, LiquidDocParameter>,
       snippetName: string,
     ) {
-      if (
-        node.aliasExpression?.alias &&
-        !liquidDocParameters.has(node.aliasExpression?.alias) &&
-        node.variable
-      ) {
+      if (node.alias?.value && !liquidDocParameters.has(node.alias.value) && node.variable) {
         const source = node.source;
         let startIndex = node.variable.position.start;
 
         if (
-          source.slice(startIndex, node.aliasExpression.position.start).includes(' with ') ||
-          source.slice(startIndex, node.aliasExpression.position.start).includes(' for ')
+          source.slice(startIndex, node.alias.position.start).includes(' with ') ||
+          source.slice(startIndex, node.alias.position.start).includes(' for ')
         ) {
           startIndex = node.variable.position.start + 1;
         } else {
-          startIndex = node.aliasExpression.position.start;
+          startIndex = node.alias.position.start;
         }
 
         context.report({
-          message: `Unknown parameter '${node.aliasExpression.alias}' in render tag for snippet '${snippetName}'`,
+          message: `Unknown parameter '${node.alias.value}' in render tag for snippet '${snippetName}'`,
           startIndex: startIndex,
-          endIndex: node.aliasExpression.position.end,
+          endIndex: node.alias.position.end,
           suggest: [
             {
-              message: `Remove '${node.aliasExpression.alias}'`,
+              message: `Remove '${node.alias.value}'`,
               fix: (fixer: any) => {
                 if (node.variable) {
-                  return fixer.remove(
-                    node.variable.position.start,
-                    node.aliasExpression?.position.end,
-                  );
+                  return fixer.remove(node.variable.position.start, node.alias?.position.end);
                 }
               },
             },

--- a/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
+++ b/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
@@ -124,11 +124,13 @@ export const ValidRenderSnippetParamTypes: LiquidCheckDefinition = {
       liquidDocParameters: Map<string, LiquidDocParameter>,
     ) {
       if (
-        node.alias &&
+        node.aliasExpression?.alias &&
         node.variable?.name &&
         node.variable.name.type !== NodeTypes.VariableLookup
       ) {
-        const paramIsDefinedWithType = liquidDocParameters.get(node.alias)?.type?.toLowerCase();
+        const paramIsDefinedWithType = liquidDocParameters
+          .get(node.aliasExpression.alias)
+          ?.type?.toLowerCase();
         if (paramIsDefinedWithType) {
           const providedParamType = inferArgumentType(node.variable.name);
           if (!isTypeCompatible(paramIsDefinedWithType, providedParamType)) {
@@ -139,7 +141,7 @@ export const ValidRenderSnippetParamTypes: LiquidCheckDefinition = {
             );
 
             context.report({
-              message: `Type mismatch for parameter '${node.alias}': expected ${paramIsDefinedWithType}, got ${providedParamType}`,
+              message: `Type mismatch for parameter '${node.aliasExpression.alias}': expected ${paramIsDefinedWithType}, got ${providedParamType}`,
               startIndex: node.variable.name.position.start,
               endIndex: node.variable.name.position.end,
               suggest: suggestions,

--- a/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
+++ b/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
@@ -124,7 +124,7 @@ export const ValidRenderSnippetParamTypes: LiquidCheckDefinition = {
       liquidDocParameters: Map<string, LiquidDocParameter>,
     ) {
       if (
-        node.alias?.value &&
+        node.alias &&
         node.variable?.name &&
         node.variable.name.type !== NodeTypes.VariableLookup
       ) {

--- a/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
+++ b/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
@@ -124,12 +124,12 @@ export const ValidRenderSnippetParamTypes: LiquidCheckDefinition = {
       liquidDocParameters: Map<string, LiquidDocParameter>,
     ) {
       if (
-        node.aliasExpression?.alias &&
+        node.alias?.value &&
         node.variable?.name &&
         node.variable.name.type !== NodeTypes.VariableLookup
       ) {
         const paramIsDefinedWithType = liquidDocParameters
-          .get(node.aliasExpression.alias)
+          .get(node.alias.value)
           ?.type?.toLowerCase();
         if (paramIsDefinedWithType) {
           const providedParamType = inferArgumentType(node.variable.name);
@@ -141,7 +141,7 @@ export const ValidRenderSnippetParamTypes: LiquidCheckDefinition = {
             );
 
             context.report({
-              message: `Type mismatch for parameter '${node.aliasExpression.alias}': expected ${paramIsDefinedWithType}, got ${providedParamType}`,
+              message: `Type mismatch for parameter '${node.alias.value}': expected ${paramIsDefinedWithType}, got ${providedParamType}`,
               startIndex: node.variable.name.position.start,
               endIndex: node.variable.name.position.end,
               suggest: suggestions,

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -408,7 +408,8 @@ function findCurrentNode(
       case NodeTypes.Number:
       case NodeTypes.LiquidDocParamNode:
       case NodeTypes.LiquidDocExampleNode:
-      case NodeTypes.LiquidDocDescriptionNode: {
+      case NodeTypes.LiquidDocDescriptionNode:
+      case NodeTypes.RenderAliasExpression: {
         break;
       }
 

--- a/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.ts
+++ b/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.ts
@@ -246,7 +246,7 @@ async function updateRenderTags(
           };
         }
 
-        if (node.alias === oldParamName && node.variable) {
+        if (node.aliasExpression?.alias === oldParamName && node.variable) {
           // `as variable` is not captured in our liquid parser yet,
           // so we have to check it manually and replace it
           const aliasMatch = /as\s+([^\s,]+)/g;

--- a/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.ts
+++ b/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.ts
@@ -246,7 +246,7 @@ async function updateRenderTags(
           };
         }
 
-        if (node.aliasExpression?.alias === oldParamName && node.variable) {
+        if (node.alias?.value === oldParamName && node.variable) {
           // `as variable` is not captured in our liquid parser yet,
           // so we have to check it manually and replace it
           const aliasMatch = /as\s+([^\s,]+)/g;


### PR DESCRIPTION
## What are you adding in this PR?
Closes: https://github.com/Shopify/developer-tools-team/issues/607

- Added proper position tracking for aliases by introducing a `RenderAliasExpression` node type.
- Updated the parser to capture positional information for the `as` and `with` part of render tags
- Modified any consumers of render markup to use the new structure

## Before you deploy
<!-- Bug fixes -->
- [X] I included a patch bump `changeset`
