### PR TITLE
Remove `brand` from list of metafield owner types being fetched

### DIFF
--- a/.changeset/tall-toes-sin.md
+++ b/.changeset/tall-toes-sin.md
@@ -1,0 +1,9 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+Remove `brand` from list of metafield owner types being fetched
+
+- Brand is removed from ownerType
+- https://shopify.dev/docs/api/admin-graphql/latest/queries/metafieldDefinitions

--- a/packages/theme-check-common/src/context-utils.spec.ts
+++ b/packages/theme-check-common/src/context-utils.spec.ts
@@ -77,7 +77,6 @@ describe('Unit: getDefaultLocale', () => {
       expect(definitions).deep.equals({
         article: [],
         blog: [],
-        brand: [],
         collection: [],
         company: [],
         company_location: [],

--- a/packages/theme-check-common/src/context-utils.ts
+++ b/packages/theme-check-common/src/context-utils.ts
@@ -152,7 +152,6 @@ function isIgnored([uri, type]: FileTuple) {
 export const FETCHED_METAFIELD_CATEGORIES: MetafieldCategory[] = [
   'article',
   'blog',
-  'brand',
   'collection',
   'company',
   'company_location',
@@ -170,7 +169,6 @@ export const makeGetMetafieldDefinitions = (fs: AbstractFileSystem) =>
     const definitions = {
       article: [],
       blog: [],
-      brand: [],
       collection: [],
       company: [],
       company_location: [],

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -273,7 +273,6 @@ type CheckLifecycleMethods<T extends SourceCodeType> = {
 export type MetafieldCategory =
   | 'article'
   | 'blog'
-  | 'brand'
   | 'collection'
   | 'company'
   | 'company_location'

--- a/packages/theme-language-server-common/src/TypeSystem.spec.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.spec.ts
@@ -137,7 +137,6 @@ describe('Module: TypeSystem', () => {
         return {
           article: [],
           blog: [],
-          brand: [],
           collection: [],
           company: [],
           company_location: [],

--- a/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectCompletionProvider.spec.ts
@@ -82,7 +82,6 @@ describe('Module: ObjectCompletionProvider', async () => {
         return {
           article: [],
           blog: [],
-          brand: [],
           collection: [],
           company: [],
           company_location: [],

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectHoverProvider.spec.ts
@@ -100,7 +100,6 @@ describe('Module: LiquidObjectHoverProvider', async () => {
         return {
           article: [],
           blog: [],
-          brand: [],
           collection: [],
           company: [],
           company_location: [],


### PR DESCRIPTION
## What are you adding in this PR?

We removed it from CLI as well in https://github.com/Shopify/cli/pull/5492


## Before you deploy

- [x] I included a patch bump `changeset`
