### PR TITLE
Add env var when CLI is run from language-server

### DIFF
--- a/.changeset/orange-experts-work.md
+++ b/.changeset/orange-experts-work.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-node': patch
+---
+
+[internal] Add env var when CLI command is run

--- a/packages/theme-language-server-node/src/metafieldDefinitions.ts
+++ b/packages/theme-language-server-node/src/metafieldDefinitions.ts
@@ -18,6 +18,10 @@ export async function fetchMetafieldDefinitionsForURI(uri: string) {
     await exec(`${path} theme metafields pull`, {
       cwd: new URL(uri),
       timeout: 10_000,
+      env: {
+        ...process.env,
+        SHOPIFY_LANGUAGE_SERVER: '1',
+      },
     });
   } catch (_) {
     // CLI command can break because of incorrect version or not being logged in


### PR DESCRIPTION
## What are you adding in this PR?

- we are adding an env var to determine when CLI is being run by our language server
- helps distinguish logic in CLI

Part of https://github.com/Shopify/theme-tools/issues/724

## What's next? Any followup issues?

- The current implementation in CLI forces fetching metafields when run by non-promptable CLI
- This env var will prevent this but still allow fetching metafields by force if ever ran by non-promptable CLI


## Before you deploy

- [x] I included a patch bump `changeset`
