### PR TITLE
Ignore errors if workspace folder isnt a theme

### DIFF
--- a/.changeset/wise-brooms-exercise.md
+++ b/.changeset/wise-brooms-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+[internal] ignore errors if workspace folder isnt a theme

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -286,10 +286,14 @@ export function startServer(
     if (!fetchMetafieldDefinitionsForURI) return;
 
     for (let folder of folders) {
-      const mode = await getModeForURI(folder.uri);
+      try {
+        const mode = await getModeForURI(folder.uri);
 
-      if (mode === 'theme') {
-        fetchMetafieldDefinitionsForURI(folder.uri);
+        if (mode === 'theme') {
+          fetchMetafieldDefinitionsForURI(folder.uri);
+        }
+      } catch (_err) {
+        // ignore if we can't find mode for folder uri
       }
     }
   };


### PR DESCRIPTION
## What are you adding in this PR?

Noticed our logs show errors when non-theme projects are added to the workspace. Since we are in a for-loop this causes all the other folders in workspace to break if one fails to fetch the `mode`.

Part of https://github.com/Shopify/theme-tools/issues/724

## Before you deploy

- [x] I included a patch bump `changeset`
