### PR TITLE
[LiquidDoc] Improve hover behaviour for multi-line descriptions and examples

### DIFF
--- a/.changeset/cool-flowers-listen.md
+++ b/.changeset/cool-flowers-listen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fix indentation for multi-line examples and descriptions

--- a/.changeset/few-planes-argue.md
+++ b/.changeset/few-planes-argue.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Improve rendering of multi-line descriptions

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
@@ -129,7 +129,7 @@ describe('Unit: getSnippetDefinition', () => {
       liquidDoc: {
         examples: [
           {
-            content: '{{ product }}\n          {{ product.title }}',
+            content: '{{ product }}\n{{ product.title }}',
             nodeType: 'example',
           },
         ],
@@ -276,7 +276,7 @@ describe('Unit: getSnippetDefinition', () => {
       name: 'product-card',
       liquidDoc: {
         description: {
-          content: 'this is an implicit description\n        in a header',
+          content: 'this is an implicit description\nin a header',
           nodeType: 'description',
         },
         parameters: [

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.ts
@@ -68,13 +68,13 @@ export function getSnippetDefinition(
     },
     LiquidDocExampleNode(node: LiquidDocExampleNode) {
       return {
-        content: node.content.value.trim(),
+        content: handleMultilineIndentation(node.content.value.trim()),
         nodeType: 'example',
       };
     },
     LiquidDocDescriptionNode(node: LiquidDocDescriptionNode) {
       return {
-        content: node.content.value.trim(),
+        content: handleMultilineIndentation(node.content.value.trim()),
         nodeType: 'description',
       };
     },
@@ -107,4 +107,28 @@ export function getSnippetDefinition(
       ...(description && { description }),
     },
   };
+}
+
+function handleMultilineIndentation(text: string): string {
+  const lines = text.split('\n');
+
+  if (lines.length <= 1) return text;
+
+  const nonEmptyLines = lines.slice(1).filter((line) => line.trim().length > 0);
+  const indentLengths = nonEmptyLines.map((line) => {
+    const match = line.match(/^\s*/);
+    return match ? match[0].length : 0;
+  });
+
+  if (indentLengths.length === 0) return text;
+
+  const minIndent = Math.min(...indentLengths);
+
+  return [
+    lines[0],
+    ...lines.slice(1).map((line) => {
+      if (line.trim().length === 0) return line; // Skip empty lines
+      return line.slice(minIndent);
+    }),
+  ].join('\n');
 }

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -75,9 +75,7 @@ describe('Module: RenderSnippetHoverProvider', async () => {
 **Description:**
 
 
-\`\`\`plaintext
 This is a description
-\`\`\`
 
 **Parameters:**
 - \`title\`: string - The title of the product

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -51,7 +51,7 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
 
     if (liquidDoc.description) {
       const description = liquidDoc.description.content;
-      parts.push('', '**Description:**', '\n', `\`\`\`plaintext\n${description}\n\`\`\``);
+      parts.push('', '**Description:**', '\n', description);
     }
 
     if (liquidDoc.parameters?.length) {


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/600

**The Problem**:
**1**: Hovering renders extra indentation for multi-line examples and descriptions![image](https://github.com/user-attachments/assets/b58ca203-c41e-4323-a6ef-a9fe3c7eef46)

**2**: Rendering descriptions as plaintext results in formatting inconsistencies ![image](https://github.com/user-attachments/assets/933606f1-7714-42a6-9924-539c81177f16)

This PR:
- **1**: Removes the minimum common indentation for multi-line `description` and `example` content
- **2**: Reverts the `description` to be rendered as `markdown` on hover. This prevents the formatting inconsistency while still allowing users to render newlines if they desire, though it would be manual. 

![image](https://github.com/user-attachments/assets/ccfc9c59-77bf-4ad0-b477-e41db1cc8217)
![image](https://github.com/user-attachments/assets/ffe789ec-1613-442b-b429-18a42e49f8a0)



## What did you learn?
- With the way we currently parse multiline content, the first line's content starts at the first character and does not include leading whitespace. I tried modifying this but didn't get anywhere within a reasonable amount of time.

## Before you deploy
- [x] I included a patch bump `changeset`
