### PR TITLE
Reintroduce support for `context` parameters in the `content_for` tag

### DIFF
--- a/.changeset/old-cars-sort.md
+++ b/.changeset/old-cars-sort.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+---
+
+Reintroduce support for `context` parameters in the `content_for` tag

--- a/packages/theme-check-common/src/checks/valid-content-for-arguments/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-content-for-arguments/index.spec.ts
@@ -22,6 +22,14 @@ describe('Module: ValidContentForArguments', () => {
       expect(offenses).toHaveLength(0);
     });
 
+    it('should accept `context.*` kwargs', async () => {
+      const offenses = await runLiquidCheck(
+        ValidContentForArguments,
+        '{% content_for "blocks", context.product: product %}',
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
     it('should report offenses for non-`closest.*` kwargs', async () => {
       const offenses = await runLiquidCheck(
         ValidContentForArguments,
@@ -29,22 +37,7 @@ describe('Module: ValidContentForArguments', () => {
       );
       expect(offenses).toHaveLength(1);
       expect(offenses[0]!.message).to.equal(
-        `{% content_for "blocks" %} only accepts 'closest.*' arguments`,
-      );
-    });
-
-    it('should report offenses for deprecated `context.*` kwargs', async () => {
-      const offenses = await runLiquidCheck(
-        ValidContentForArguments,
-        '{% content_for "blocks", context.product: product %}',
-      );
-      expect(offenses).toHaveLength(2);
-      expect(offenses[0]!.message).to.equal(
-        `{% content_for "blocks" %} only accepts 'closest.*' arguments`,
-      );
-
-      expect(offenses[1]!.message).to.equal(
-        `{% content_for "blocks" %} only accepts 'closest.*' arguments. The 'context.*' arguments usage has been deprecated.`,
+        `{% content_for "blocks" %} only accepts 'closest.*' and 'context.*' arguments`,
       );
     });
   });
@@ -83,22 +76,7 @@ describe('Module: ValidContentForArguments', () => {
       );
       expect(offenses).toHaveLength(1);
       expect(offenses[0].message).to.equal(
-        `{% content_for "block" %} only accepts 'id', 'type' and 'closest.*' arguments`,
-      );
-    });
-
-    it('should report offenses for deprecated `context.*` kwargs', async () => {
-      const offenses = await runLiquidCheck(
-        ValidContentForArguments,
-        '{% content_for "block", type: "type", id: "static-block", context.product: product %}',
-      );
-      expect(offenses).toHaveLength(2);
-      expect(offenses[0]!.message).to.equal(
-        `{% content_for "block" %} only accepts 'id', 'type' and 'closest.*' arguments`,
-      );
-
-      expect(offenses[1]!.message).to.equal(
-        `{% content_for "block" %} accepts 'closest.*' arguments. The 'context.*' arguments usage has been deprecated.`,
+        `{% content_for "block" %} only accepts 'id', 'type', 'closest.*', and 'context.*' arguments`,
       );
     });
   });

--- a/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
+++ b/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
@@ -1,9 +1,9 @@
 import { ContentForMarkup, NodeTypes } from '@shopify/liquid-html-parser';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 
-// content_for "block" and content_for "blocks" only allow `closest.*` kwargs.
-const isClosestArgument = (argName: string) => argName.startsWith('closest.');
-const isContextArgument = (argName: string) => argName.startsWith('context.');
+const isValidKeywordArgument = (argName: string) => {
+  return argName.startsWith('closest.') || argName.startsWith('context.');
+};
 
 export const ValidContentForArguments: LiquidCheckDefinition = {
   meta: {
@@ -24,19 +24,10 @@ export const ValidContentForArguments: LiquidCheckDefinition = {
   create(context) {
     const validationStrategies = {
       blocks: (node: ContentForMarkup) => {
-        const problematicArguments = node.args.filter((arg) => !isClosestArgument(arg.name));
+        const problematicArguments = node.args.filter((arg) => !isValidKeywordArgument(arg.name));
         for (const arg of problematicArguments) {
           context.report({
-            message: `{% content_for "blocks" %} only accepts 'closest.*' arguments`,
-            startIndex: arg.position.start,
-            endIndex: arg.position.end,
-          });
-        }
-
-        const deprecatedArguments = node.args.filter((arg) => isContextArgument(arg.name));
-        for (const arg of deprecatedArguments) {
-          context.report({
-            message: `{% content_for "blocks" %} only accepts 'closest.*' arguments. The 'context.*' arguments usage has been deprecated.`,
+            message: `{% content_for "blocks" %} only accepts 'closest.*' and 'context.*' arguments`,
             startIndex: arg.position.start,
             endIndex: arg.position.end,
           });
@@ -72,21 +63,12 @@ export const ValidContentForArguments: LiquidCheckDefinition = {
         }
 
         const problematicArguments = node.args.filter(
-          (arg) => !(requiredArguments.includes(arg.name) || isClosestArgument(arg.name)),
+          (arg) => !(requiredArguments.includes(arg.name) || isValidKeywordArgument(arg.name)),
         );
 
         for (const arg of problematicArguments) {
           context.report({
-            message: `{% content_for "block" %} only accepts 'id', 'type' and 'closest.*' arguments`,
-            startIndex: arg.position.start,
-            endIndex: arg.position.end,
-          });
-        }
-
-        const deprecatedArguments = node.args.filter((arg) => isContextArgument(arg.name));
-        for (const arg of deprecatedArguments) {
-          context.report({
-            message: `{% content_for "block" %} accepts 'closest.*' arguments. The 'context.*' arguments usage has been deprecated.`,
+            message: `{% content_for "block" %} only accepts 'id', 'type', 'closest.*', and 'context.*' arguments`,
             startIndex: arg.position.start,
             endIndex: arg.position.end,
           });

--- a/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.spec.ts
@@ -45,6 +45,7 @@ describe('Module: ContentForBlockParameterCompletionProvider', async () => {
       'type',
       'id',
       'closest',
+      'context',
       'testOption',
     ]);
   });
@@ -109,9 +110,9 @@ describe('Module: ContentForBlockParameterCompletionProvider', async () => {
     );
   });
 
-  describe("when we're completing for blocks we only allow `closest`", () => {
+  describe("when we're completing for blocks we allow `closest` and `context`", () => {
     it('does something', async () => {
-      await expect(provider).to.complete('{% content_for "blocks", █ %}', ['closest']);
+      await expect(provider).to.complete('{% content_for "blocks", █ %}', ['closest', 'context']);
     });
   });
 
@@ -173,7 +174,13 @@ describe('Module: ContentForBlockParameterCompletionProvider', async () => {
       it('offers a full list of completion items', async () => {
         const context = `{% content_for "block", █type: "button" %}`;
 
-        await expect(provider).to.complete(context, ['type', 'id', 'closest', 'testOption']);
+        await expect(provider).to.complete(context, [
+          'type',
+          'id',
+          'closest',
+          'context',
+          'testOption',
+        ]);
       });
 
       it('does not replace the existing text', async () => {

--- a/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.ts
@@ -44,6 +44,7 @@ export class ContentForParameterCompletionProvider implements Provider {
     if (parentNode.contentForType.value == 'blocks') {
       options = {
         closest: DEFAULT_COMPLETION_OPTIONS.closest,
+        context: DEFAULT_COMPLETION_OPTIONS.context,
       };
     }
 
@@ -86,8 +87,9 @@ export class ContentForParameterCompletionProvider implements Provider {
 
     let start = document.textDocument.positionAt(node.position.start);
     let end = document.textDocument.positionAt(node.position.end + offset);
-    let newText = name === 'closest' ? `${name}.` : `${name}: '$1'`;
-    let format = name === 'closest' ? InsertTextFormat.PlainText : InsertTextFormat.Snippet;
+    let isValidKeywordArg = name === 'closest' || name === 'context';
+    let newText = isValidKeywordArg ? `${name}.` : `${name}: '$1'`;
+    let format = isValidKeywordArg ? InsertTextFormat.PlainText : InsertTextFormat.Snippet;
 
     // If the cursor is inside the parameter or at the end and it's the same
     // value as the one we're offering a completion for then we want to restrict

--- a/packages/theme-language-server-common/src/completions/providers/data/contentForParameterCompletionOptions.ts
+++ b/packages/theme-language-server-common/src/completions/providers/data/contentForParameterCompletionOptions.ts
@@ -6,4 +6,5 @@ export const DEFAULT_COMPLETION_OPTIONS: { [key: string]: string } = {
   type: "The type (name) of an existing theme block in your theme’s /blocks folder. Only applicable when `content_type` is 'block'.",
   id: "A unique identifier and literal string within the section or block that contains the static blocks. Only applicable when `content_type` is 'block'.",
   closest: 'A path that provides a way to access the closest resource of a given type.',
+  context: 'A path that provides a way to pass context properties to blocks.',
 };


### PR DESCRIPTION
### What are you adding in this PR?

Fixes https://github.com/Shopify/developer-tools-team/issues/637

This PR re-introduces support to `context` parameters in the `content_for` tag.

### Before you deploy

- [x] I included a minor bump `changeset`

### Tophat 🎩

![demo-pr](https://github.com/user-attachments/assets/50d0a92e-ed94-4788-b265-fbec2311978d)



