### PR TITLE
Make preloading fs.readFile error resilient

### DIFF
--- a/.changeset/fresh-badgers-sin.md
+++ b/.changeset/fresh-badgers-sin.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-browser': patch
+'@shopify/theme-language-server-common': patch
+---
+
+Make theme preload fs.readFile error resilient

--- a/packages/theme-language-server-browser/src/index.ts
+++ b/packages/theme-language-server-browser/src/index.ts
@@ -23,6 +23,5 @@ export function startServer(
   dependencies: Dependencies,
   connection = getConnection(worker),
 ) {
-  console.info('staging server', worker, dependencies, connection);
   startCoreServer(connection, dependencies);
 }

--- a/packages/theme-language-server-common/src/documents/DocumentManager.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.ts
@@ -146,7 +146,11 @@ export class DocumentManager {
         filesToLoad.map(async (file) => {
           // This is what is important, we are loading the file from the file system
           // And setting their initial version to `undefined` to mean "on disk".
-          this.set(file, await fs.readFile(file), undefined);
+          try {
+            this.set(file, await fs.readFile(file), undefined);
+          } catch (error) {
+            console.error('Failed to preload', file, error);
+          }
 
           // This is just doing progress reporting
           if (++i % 10 === 0) {
@@ -155,7 +159,6 @@ export class DocumentManager {
           }
         }),
       );
-
       progress.end('Completed');
     },
     (rootUri) => rootUri,


### PR DESCRIPTION
- **Remove browser LS console logging on init**
- **Make preloading resilient to readFile errors**
