### PR TITLE
Allow recommendations in blocks

### DIFF
--- a/.changeset/slimy-stingrays-smile.md
+++ b/.changeset/slimy-stingrays-smile.md
@@ -1,5 +1,6 @@
 ---
 '@shopify/theme-check-common': minor
+'@shopify/theme-language-server-common': minor
 ---
 
 Allow `recommendations` as a global variable in `blocks/`

--- a/.changeset/slimy-stingrays-smile.md
+++ b/.changeset/slimy-stingrays-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Allow `recommendations` as a global variable in `blocks/`

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -191,7 +191,7 @@ function getContextualObjects(relativePath: string): string[] {
   }
 
   if (relativePath.startsWith('blocks/')) {
-    return ['app', 'section', 'block'];
+    return ['app', 'section', 'recommendations', 'block'];
   }
 
   if (relativePath.startsWith('snippets/')) {

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -352,7 +352,7 @@ function getContextualEntries(uri: string): string[] {
     return ['section', 'predictive_search', 'recommendations', 'comment'];
   }
   if (BLOCK_FILE_REGEX.test(normalizedUri)) {
-    return ['app', 'section', 'block'];
+    return ['app', 'section', 'recommendations', 'block'];
   }
   if (SNIPPET_FILE_REGEX.test(normalizedUri)) {
     return ['app'];


### PR DESCRIPTION
## What are you adding in this PR?

This adds support for leveraging the `recommendations` global in `blocks/`, currently we allow it in sections but not in blocks. We've been using this in a block and it's been great so thought I'd add support into the theme check.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [x] If applicable, I've updated the `theme-app-extension.yml` config
  - [x] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (link PR here).
