### PR TITLE
Fix bug where theme check would fail for theme app extensions

### DIFF
--- a/.changeset/slow-bananas-sing.md
+++ b/.changeset/slow-bananas-sing.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': patch
+---
+
+Fix false positives when running theme check on theme app extensions

--- a/packages/theme-check-node/src/config/load-config.ts
+++ b/packages/theme-check-node/src/config/load-config.ts
@@ -4,6 +4,7 @@ import { loadConfigDescription } from './load-config-description';
 import { resolveConfig } from './resolve';
 import { ModernIdentifier } from './types';
 import { validateConfig } from './validation';
+import fs from 'fs/promises';
 
 /**
  * Given an absolute path to a config file, this function returns
@@ -22,7 +23,18 @@ export async function loadConfig(
   root: AbsolutePath,
 ): Promise<Config> {
   if (!root) throw new Error('loadConfig cannot be called without a root argument');
-  const configDescription = await resolveConfig(configPath ?? 'theme-check:recommended', true);
+  let defaultChecks = 'theme-check:recommended';
+
+  if (!configPath) {
+    const files = await fs.readdir(root);
+    // *.extension.toml implies that we're already in the appropriate extensions
+    // directory. *.app.toml implies that we're inside the root of an app.
+    if (files.some((file) => file.endsWith('.extension.toml') || file.endsWith('.app.toml'))) {
+      defaultChecks = 'theme-check:theme-app-extension';
+    }
+  }
+
+  const configDescription = await resolveConfig(configPath ?? defaultChecks, true);
   const config = await loadConfigDescription(configDescription, root);
   validateConfig(config);
   return config;


### PR DESCRIPTION
## What are you adding in this PR?

- Fixes https://github.com/Shopify/cli/issues/5269#issuecomment-2720241078

This bug only surfaces when a developer would manually run the theme check against a theme app extension from the CLI. Inside the VSCode extension we were already doing the right thing so you wouldn't notice it there and the Shopify CLI hardcodes the check when you build your app so you wouldn't notice it there either.

This adds some logic to where we load the config to check if we're inside of an app by looking for two app-like config files. If so, we use `theme-check:theme-app-extension` as our default checks rather than the recommended. This ensures that our context is appropriately set as 'app' instead of 'theme' and removes false positives when running the check.