### PR TITLE
Update UnsupportedDocTag to allow usage in blocks

### DIFF
--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -398,6 +398,7 @@ LiquidDoc <: Helpers {
     | paramNode
     | exampleNode
     | descriptionNode
+	  | promptNode
     | fallbackNode
   
   endOfDescription = strictSpace* openControl
@@ -421,6 +422,8 @@ LiquidDoc <: Helpers {
 
   paramDescription = (~"]" anyExceptStar<endOfParam>)
   endOfParam = strictSpace* (newline | end)
+  
+  promptNode = "@prompt" space* exampleContent
 
   exampleNode = "@example" space* exampleContent
   exampleContent = anyExceptStar<endOfExample>

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1436,6 +1436,96 @@ describe('Unit: Stage 1 (CST)', () => {
           expectPath(cst, '0.children.1.type').to.equal('TextNode');
           expectPath(cst, '0.children.1.value').to.equal('@-like characters: @@test');
         });
+
+        it('should parse @prompt node', () => {
+          const testStr = `{% doc %} @prompt hello there {% enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocPromptNode');
+          expectPath(cst, '0.children.0.name').to.equal('prompt');
+          expectPath(cst, '0.children.0.content.value').to.equal('hello there');
+        });
+
+        it('should parse a basic prompt tag', () => {
+          const testStr = `{% doc -%} @prompt {%- enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.name').to.equal('doc');
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocPromptNode');
+          expectPath(cst, '0.children.0.content.value').to.equal('');
+        });
+
+        it('should parse prompt tag with content that has leading whitespace', () => {
+          const testStr = `{% doc %} @prompt         hello there       {%- enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.name').to.equal('doc');
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocPromptNode');
+          expectPath(cst, '0.children.0.name').to.equal('prompt');
+          expectPath(cst, '0.children.0.content.value').to.equal('hello there');
+          expectPath(cst, '0.children.0.content.locStart').to.equal(testStr.indexOf('hello there'));
+          expectPath(cst, '0.children.0.content.locEnd').to.equal(
+            testStr.indexOf('hello there') + 'hello there'.length,
+          );
+        });
+
+        it('should parse a prompt tag with a value', () => {
+          const testStr = `{% doc %}
+        @prompt
+        This is a prompt
+        It supports multiple lines
+      {% enddoc %}`;
+
+          cst = toCST(testStr);
+          expectPath(cst, '0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.name').to.equal('doc');
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocPromptNode');
+          expectPath(cst, '0.children.0.name').to.equal('prompt');
+          expectPath(cst, '0.children.0.content.value').to.equal(
+            'This is a prompt\n        It supports multiple lines\n',
+          );
+        });
+
+        it('should parse prompt node and stop at the next @', () => {
+          const testStr = `{% doc %}
+        @prompt
+        This is a prompt
+        @param param1
+      {% enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocPromptNode');
+          expectPath(cst, '0.children.0.name').to.equal('prompt');
+          expectPath(cst, '0.children.0.content.value').to.equal('This is a prompt\n');
+          expectPath(cst, '0.children.1.type').to.equal('LiquidDocParamNode');
+          expectPath(cst, '0.children.1.paramName.content.value').to.equal('param1');
+        });
+
+        it('should parse prompt node with whitespace and new lines', () => {
+          const testStr = `{% doc %}
+        @prompt hello      there        my    friend
+        This is a prompt
+        It supports multiple lines
+      {% enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.type').to.equal('LiquidRawTag');
+          expectPath(cst, '0.name').to.equal('doc');
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocPromptNode');
+          expectPath(cst, '0.children.0.name').to.equal('prompt');
+          expectPath(cst, '0.children.0.content.value').to.equal(
+            'hello      there        my    friend\n        This is a prompt\n        It supports multiple lines\n',
+          );
+        });
+
+        it('should parse multiple prompt nodes', () => {
+          const testStr = `{% doc %}
+        @prompt first prompt
+        @prompt second prompt
+      {% enddoc %}`;
+          cst = toCST(testStr);
+          expectPath(cst, '0.children.0.type').to.equal('LiquidDocPromptNode');
+          expectPath(cst, '0.children.0.content.value').to.equal('first prompt\n');
+          expectPath(cst, '0.children.1.type').to.equal('LiquidDocPromptNode');
+          expectPath(cst, '0.children.1.content.value').to.equal('second prompt\n');
+        });
       }
     });
   });

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -88,6 +88,7 @@ export enum ConcreteNodeTypes {
   LiquidDocParamNameNode = 'LiquidDocParamNameNode',
   LiquidDocDescriptionNode = 'LiquidDocDescriptionNode',
   LiquidDocExampleNode = 'LiquidDocExampleNode',
+  LiquidDocPromptNode = 'LiquidDocPromptNode',
 }
 
 export const LiquidLiteralValues = {
@@ -140,6 +141,12 @@ export interface ConcreteLiquidDocExampleNode
   isInline: boolean;
 }
 
+export interface ConcreteLiquidDocPromptNode
+  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocPromptNode> {
+  name: 'prompt';
+  content: ConcreteTextNode;
+  isInline: boolean;
+}
 export interface ConcreteHtmlNodeBase<T> extends ConcreteBasicNode<T> {
   attrList?: ConcreteAttributeNode[];
 }
@@ -482,7 +489,8 @@ export type LiquidCST = LiquidConcreteNode[];
 export type LiquidDocConcreteNode =
   | ConcreteLiquidDocParamNode
   | ConcreteLiquidDocExampleNode
-  | ConcreteLiquidDocDescriptionNode;
+  | ConcreteLiquidDocDescriptionNode
+  | ConcreteLiquidDocPromptNode;
 
 interface Mapping {
   [k: string]: number | TemplateMapping | TopLevelFunctionMapping;
@@ -1447,6 +1455,17 @@ function toLiquidDocAST(source: string, matchingSource: string, offset: number) 
     exampleNode: {
       type: ConcreteNodeTypes.LiquidDocExampleNode,
       name: 'example',
+      locStart,
+      locEnd,
+      source,
+      content: 2,
+      isInline: function (this: Node) {
+        return !this.children[1].sourceString.includes('\n');
+      },
+    },
+    promptNode: {
+      type: ConcreteNodeTypes.LiquidDocPromptNode,
+      name: 'prompt',
       locStart,
       locEnd,
       source,

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -1431,6 +1431,52 @@ describe('Unit: Stage 2 (AST)', () => {
         'with a description annotation\n',
       );
       expectPath(ast, 'children.0.body.nodes.1.isImplicit').to.eql(false);
+
+      ast = toLiquidAST(`
+        {% doc -%}
+        @prompt
+        This is a prompt
+        It can have multiple lines
+        {% enddoc %}
+      `);
+      expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
+      expectPath(ast, 'children.0.name').to.eql('doc');
+      expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocPromptNode');
+      expectPath(ast, 'children.0.body.nodes.0.name').to.eql('prompt');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql(
+        'This is a prompt\n        It can have multiple lines\n',
+      );
+      expectPath(ast, 'children.0.body.nodes.0.isInline').to.eql(false);
+
+      ast = toLiquidAST(`
+        {% doc -%}
+        @prompt This is an inline prompt
+        {% enddoc %}
+      `);
+      expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
+      expectPath(ast, 'children.0.name').to.eql('doc');
+      expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocPromptNode');
+      expectPath(ast, 'children.0.body.nodes.0.name').to.eql('prompt');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('This is an inline prompt\n');
+      expectPath(ast, 'children.0.body.nodes.0.isInline').to.eql(true);
+
+      ast = toLiquidAST(`
+        {% doc -%}
+        @prompt First prompt
+        @prompt Second prompt
+        @param {String} paramName - param description
+        {% enddoc %}
+      `);
+      expectPath(ast, 'children.0.type').to.eql('LiquidRawTag');
+      expectPath(ast, 'children.0.name').to.eql('doc');
+      expectPath(ast, 'children.0.body.nodes.0.type').to.eql('LiquidDocPromptNode');
+      expectPath(ast, 'children.0.body.nodes.0.name').to.eql('prompt');
+      expectPath(ast, 'children.0.body.nodes.0.content.value').to.eql('First prompt\n');
+      expectPath(ast, 'children.0.body.nodes.1.type').to.eql('LiquidDocPromptNode');
+      expectPath(ast, 'children.0.body.nodes.1.name').to.eql('prompt');
+      expectPath(ast, 'children.0.body.nodes.1.content.value').to.eql('Second prompt\n');
+      expectPath(ast, 'children.0.body.nodes.2.type').to.eql('LiquidDocParamNode');
+      expectPath(ast, 'children.0.body.nodes.2.paramName.value').to.eql('paramName');
     });
 
     it('should parse unclosed tables with assignments', () => {

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -110,7 +110,8 @@ export type LiquidHtmlNode =
   | TextNode
   | LiquidDocParamNode
   | LiquidDocExampleNode
-  | LiquidDocDescriptionNode;
+  | LiquidDocDescriptionNode
+  | LiquidDocPromptNode;
 
 /** The root node of all LiquidHTML ASTs. */
 export interface DocumentNode extends ASTNode<NodeTypes.Document> {
@@ -802,6 +803,12 @@ export interface LiquidDocExampleNode extends ASTNode<NodeTypes.LiquidDocExample
   isInline: boolean;
 }
 
+/** Represents a `@prompt` node in a LiquidDoc comment - `@prompt exampleContent` */
+export interface LiquidDocPromptNode extends ASTNode<NodeTypes.LiquidDocPromptNode> {
+  name: 'prompt';
+  content: TextNode;
+  isInline: boolean;
+}
 export interface ASTNode<T> {
   /**
    * The type of the node, as a string.
@@ -1346,6 +1353,18 @@ function buildAst(
       case ConcreteNodeTypes.LiquidDocExampleNode: {
         builder.push({
           type: NodeTypes.LiquidDocExampleNode,
+          name: node.name,
+          position: position(node),
+          source: node.source,
+          content: toTextNode(node.content),
+          isInline: node.isInline,
+        });
+        break;
+      }
+
+      case ConcreteNodeTypes.LiquidDocPromptNode: {
+        builder.push({
+          type: NodeTypes.LiquidDocPromptNode,
           name: node.name,
           position: position(node),
           source: node.source,

--- a/packages/liquid-html-parser/src/types.ts
+++ b/packages/liquid-html-parser/src/types.ts
@@ -47,6 +47,7 @@ export enum NodeTypes {
   LiquidDocDescriptionNode = 'LiquidDocDescriptionNode',
   LiquidDocParamNode = 'LiquidDocParamNode',
   LiquidDocExampleNode = 'LiquidDocExampleNode',
+  LiquidDocPromptNode = 'LiquidDocPromptNode',
 }
 
 // These are officially supported with special node types

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -131,6 +131,7 @@ function getCssDisplay(node: AugmentedNode<WithSiblings>, options: LiquidParserO
     case NodeTypes.LiquidDocParamNode:
     case NodeTypes.LiquidDocExampleNode:
     case NodeTypes.LiquidDocDescriptionNode:
+    case NodeTypes.LiquidDocPromptNode:
       return 'should not be relevant';
 
     default:
@@ -239,6 +240,7 @@ function getNodeCssStyleWhiteSpace(
     case NodeTypes.LiquidDocParamNode:
     case NodeTypes.LiquidDocExampleNode:
     case NodeTypes.LiquidDocDescriptionNode:
+    case NodeTypes.LiquidDocPromptNode:
       return 'should not be relevant';
 
     default:

--- a/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/liquid.ts
@@ -6,6 +6,7 @@ import {
   LiquidDocParamNode,
   LiquidDocExampleNode,
   LiquidDocDescriptionNode,
+  LiquidDocPromptNode,
 } from '@shopify/liquid-html-parser';
 import { Doc, doc } from 'prettier';
 
@@ -562,6 +563,26 @@ export function printLiquidDocExample(
 ): Doc {
   const node = path.getValue();
   const parts: Doc[] = ['@example'];
+
+  const content = node.content.value;
+  if (content.trimEnd().includes('\n') || !node.isInline) {
+    parts.push(hardline);
+  } else {
+    parts.push(' ');
+  }
+  parts.push(content.trim());
+
+  return parts;
+}
+
+export function printLiquidDocPrompt(
+  path: AstPath<LiquidDocPromptNode>,
+  options: LiquidParserOptions,
+  _print: LiquidPrinter,
+  _args: LiquidPrinterArgs,
+): Doc {
+  const node = path.getValue();
+  const parts: Doc[] = ['@prompt'];
 
   const content = node.content.value;
   if (content.trimEnd().includes('\n') || !node.isInline) {

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -3,6 +3,7 @@ import {
   LiquidDocDescriptionNode,
   LiquidDocExampleNode,
   LiquidDocParamNode,
+  LiquidDocPromptNode,
   NodeTypes,
   Position,
   RawMarkupKinds,
@@ -51,6 +52,7 @@ import {
   printLiquidDocParam,
   printLiquidDocExample,
   printLiquidDocDescription,
+  printLiquidDocPrompt,
 } from './print/liquid';
 import { printClosingTagSuffix, printOpeningTagPrefix } from './print/tag';
 import { bodyLines, hasLineBreakInRange, isEmpty, isTextLikeNode, reindent } from './utils';
@@ -565,6 +567,10 @@ function printNode(
 
     case NodeTypes.LiquidDocExampleNode: {
       return printLiquidDocExample(path as AstPath<LiquidDocExampleNode>, options, print, args);
+    }
+
+    case NodeTypes.LiquidDocPromptNode: {
+      return printLiquidDocPrompt(path as AstPath<LiquidDocPromptNode>, options, print, args);
     }
 
     case NodeTypes.LiquidDocDescriptionNode: {

--- a/packages/theme-check-common/src/checks/unsupported-doc-tag/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unsupported-doc-tag/index.spec.ts
@@ -13,7 +13,9 @@ describe('Module: UnsupportedDocTag', () => {
     );
 
     expect(offenses).to.have.length(1);
-    expect(offenses[0].message).to.equal('The `doc` tag can only be used within a snippet.');
+    expect(offenses[0].message).to.equal(
+      'The `doc` tag can only be used within a snippet or block.',
+    );
   });
 
   it('should apply suggestion when `doc` tag is used outside snippets', async () => {

--- a/packages/theme-check-common/src/checks/unsupported-doc-tag/index.ts
+++ b/packages/theme-check-common/src/checks/unsupported-doc-tag/index.ts
@@ -1,5 +1,5 @@
+import { isSnippet, isBlock } from '../../to-schema';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
-import { dirname } from '../../path';
 
 export const UnsupportedDocTag: LiquidCheckDefinition = {
   meta: {
@@ -19,7 +19,7 @@ export const UnsupportedDocTag: LiquidCheckDefinition = {
   create(context) {
     const docTagName = 'doc';
 
-    if (dirname(context.file.uri).endsWith('snippets')) {
+    if (isBlock(context.file.uri) || isSnippet(context.file.uri)) {
       return {};
     }
 
@@ -29,7 +29,7 @@ export const UnsupportedDocTag: LiquidCheckDefinition = {
           return;
         }
         context.report({
-          message: `The \`${docTagName}\` tag can only be used within a snippet.`,
+          message: `The \`${docTagName}\` tag can only be used within a snippet or block.`,
           startIndex: node.position.start,
           endIndex: node.position.end,
           suggest: [

--- a/packages/theme-check-common/src/to-schema.ts
+++ b/packages/theme-check-common/src/to-schema.ts
@@ -46,6 +46,10 @@ export function isSection(uri: UriString) {
   return path.dirname(uri).endsWith('sections');
 }
 
+export function isSnippet(uri: UriString) {
+  return path.dirname(uri).endsWith('snippets');
+}
+
 export function isBlockSchema(
   schema: AppBlockSchema | SectionSchema | ThemeBlockSchema | undefined,
 ): schema is ThemeBlockSchema {

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -408,7 +408,8 @@ function findCurrentNode(
       case NodeTypes.Number:
       case NodeTypes.LiquidDocParamNode:
       case NodeTypes.LiquidDocExampleNode:
-      case NodeTypes.LiquidDocDescriptionNode: {
+      case NodeTypes.LiquidDocDescriptionNode:
+      case NodeTypes.LiquidDocPromptNode: {
         break;
       }
 


### PR DESCRIPTION
## What are you adding in this PR?

<!-- Describe your changes. Provide enough context so that someone new can understand the 'why' behind this change. -->
<!-- Remember to use `fixes` or `solves` keywords to close issues automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

## What's next? Any followup issues?

<!-- Outline follow up tasks with links to issues so they're tracked. -->

## What did you learn?

<!-- Totally optional. But... If you learned something interesting, why not share it? -->

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config
  - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (link PR here).

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
