### PR TITLE
[LiquidDoc] Add LiquidDoc header completions support for Theme Blocks

### DIFF
--- a/.changeset/great-phones-hunt.md
+++ b/.changeset/great-phones-hunt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Enable tag and param type completions for LiquidDoc in theme blocks

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.spec.ts
@@ -20,7 +20,7 @@ describe('Module: LiquidDocParamTypeCompletionProvider', async () => {
     });
   });
 
-  it("offers type completions within liquid doc's param type tag", async () => {
+  it("offers type completions within liquid doc's param type tag for snippets", async () => {
     const sources = [`{% doc %} @param {█`, `{% doc %} @param  {  █`];
 
     for (const source of sources) {
@@ -29,6 +29,13 @@ describe('Module: LiquidDocParamTypeCompletionProvider', async () => {
         Object.values(SupportedParamTypes),
       );
     }
+  });
+
+  it('offers completions within liquid doc tag for blocks', async () => {
+    await expect(provider).to.complete(
+      { source: `{% doc %} @█`, relativePath: 'file://blocks/file.liquid' },
+      ['param', 'example', 'description'],
+    );
   });
 
   it("does not offer completion if it's not within liquid doc's param type tag", async () => {
@@ -47,9 +54,19 @@ describe('Module: LiquidDocParamTypeCompletionProvider', async () => {
     }
   });
 
-  it("does not offer completion if it's not within a snippet file", async () => {
+  it("does not offer completion if it's not within a snippet or block", async () => {
     await expect(provider).to.complete(
       { source: `{% doc %} @param {█`, relativePath: 'file://sections/file.liquid' },
+      [],
+    );
+
+    await expect(provider).to.complete(
+      { source: `{% doc %} @param {█`, relativePath: 'file://templates/file.liquid' },
+      [],
+    );
+
+    await expect(provider).to.complete(
+      { source: `{% doc %} @param {█`, relativePath: 'file://layout/file.liquid' },
       [],
     );
   });

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.ts
@@ -3,14 +3,14 @@ import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
 import { LiquidCompletionParams } from '../params';
 import { Provider } from './common';
 import { SupportedDocTagTypes, SupportedParamTypes } from '@shopify/theme-check-common';
-import { isSnippet } from '../../utils/uri';
+import { filePathSupportsLiquidDoc } from '@shopify/theme-check-common';
 
 export class LiquidDocParamTypeCompletionProvider implements Provider {
   constructor() {}
 
   async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
     if (!params.completionContext) return [];
-    if (!isSnippet(params.document.uri)) return [];
+    if (!filePathSupportsLiquidDoc(params.document.uri)) return [];
 
     const { node, ancestors } = params.completionContext;
     const parentNode = ancestors.at(-1);

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.spec.ts
@@ -19,7 +19,7 @@ describe('Module: LiquidDocTagCompletionProvider', async () => {
     });
   });
 
-  it('offers completions within liquid doc tag', async () => {
+  it('offers completions within liquid doc tag for snippets', async () => {
     await expect(provider).to.complete(
       { source: `{% doc %} @█`, relativePath: 'file://snippets/file.liquid' },
       ['param', 'example', 'description'],
@@ -27,6 +27,13 @@ describe('Module: LiquidDocTagCompletionProvider', async () => {
     await expect(provider).to.complete(
       { source: `{% doc %} @par█`, relativePath: 'file://snippets/file.liquid' },
       ['param'],
+    );
+  });
+
+  it('offers completions within liquid doc tag for blocks', async () => {
+    await expect(provider).to.complete(
+      { source: `{% doc %} @█`, relativePath: 'file://blocks/file.liquid' },
+      ['param', 'example', 'description'],
     );
   });
 
@@ -44,9 +51,17 @@ describe('Module: LiquidDocTagCompletionProvider', async () => {
     );
   });
 
-  it('does not offer completion if it is not a snippet file', async () => {
+  it('does not offer completion if it is not a snippet file or block', async () => {
     await expect(provider).to.complete(
       { source: `{% doc %} @█`, relativePath: 'file://sections/file.liquid' },
+      [],
+    );
+    await expect(provider).to.complete(
+      { source: `{% doc %} @█`, relativePath: 'file://templates/file.liquid' },
+      [],
+    );
+    await expect(provider).to.complete(
+      { source: `{% doc %} @█`, relativePath: 'file://layout/file.liquid' },
       [],
     );
   });

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.ts
@@ -10,14 +10,14 @@ import {
 import { LiquidCompletionParams } from '../params';
 import { Provider } from './common';
 import { formatLiquidDocTagHandle, SUPPORTED_LIQUID_DOC_TAG_HANDLES } from '../../utils/liquidDoc';
-import { isSnippet } from '../../utils/uri';
+import { filePathSupportsLiquidDoc } from '@shopify/theme-check-common';
 
 export class LiquidDocTagCompletionProvider implements Provider {
   constructor() {}
 
   async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
     if (!params.completionContext) return [];
-    if (!isSnippet(params.document.uri)) return [];
+    if (!filePathSupportsLiquidDoc(params.document.uri)) return [];
 
     const { node, ancestors } = params.completionContext;
     const parentNode = ancestors.at(-1);


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/654

[block_completions.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/JdHLnhebSbtZTZO01I1e/2dc0c793-f296-4f7f-b7b6-6d9d04f9f1ef.mp4" />](https://app.graphite.dev/media/video/JdHLnhebSbtZTZO01I1e/2dc0c793-f296-4f7f-b7b6-6d9d04f9f1ef.mp4)

## What's next? Any followup issues?
- Hover in the header!

## Before you deploy
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
