### PR TITLE
Update theme blocks to support static arguments only in static blocks without the `context` namespace

### DIFF
--- a/.changeset/short-hairs-tease.md
+++ b/.changeset/short-hairs-tease.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+---
+
+Update theme blocks to support static arguments only in static blocks without the `context` namespace

--- a/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.spec.ts
@@ -45,7 +45,6 @@ describe('Module: ContentForBlockParameterCompletionProvider', async () => {
       'type',
       'id',
       'closest',
-      'context',
       'testOption',
     ]);
   });
@@ -110,9 +109,9 @@ describe('Module: ContentForBlockParameterCompletionProvider', async () => {
     );
   });
 
-  describe("when we're completing for blocks we allow `closest` and `context`", () => {
+  describe("when we're completing for blocks we allow `closest`", () => {
     it('does something', async () => {
-      await expect(provider).to.complete('{% content_for "blocks", █ %}', ['closest', 'context']);
+      await expect(provider).to.complete('{% content_for "blocks", █ %}', ['closest']);
     });
   });
 
@@ -174,13 +173,7 @@ describe('Module: ContentForBlockParameterCompletionProvider', async () => {
       it('offers a full list of completion items', async () => {
         const context = `{% content_for "block", █type: "button" %}`;
 
-        await expect(provider).to.complete(context, [
-          'type',
-          'id',
-          'closest',
-          'context',
-          'testOption',
-        ]);
+        await expect(provider).to.complete(context, ['type', 'id', 'closest', 'testOption']);
       });
 
       it('does not replace the existing text', async () => {

--- a/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.ts
@@ -44,7 +44,6 @@ export class ContentForParameterCompletionProvider implements Provider {
     if (parentNode.contentForType.value == 'blocks') {
       options = {
         closest: DEFAULT_COMPLETION_OPTIONS.closest,
-        context: DEFAULT_COMPLETION_OPTIONS.context,
       };
     }
 
@@ -87,9 +86,8 @@ export class ContentForParameterCompletionProvider implements Provider {
 
     let start = document.textDocument.positionAt(node.position.start);
     let end = document.textDocument.positionAt(node.position.end + offset);
-    let isValidKeywordArg = name === 'closest' || name === 'context';
-    let newText = isValidKeywordArg ? `${name}.` : `${name}: '$1'`;
-    let format = isValidKeywordArg ? InsertTextFormat.PlainText : InsertTextFormat.Snippet;
+    let newText = name === 'closest' ? `${name}.` : `${name}: '$1'`;
+    let format = name === 'closest' ? InsertTextFormat.PlainText : InsertTextFormat.Snippet;
 
     // If the cursor is inside the parameter or at the end and it's the same
     // value as the one we're offering a completion for then we want to restrict

--- a/packages/theme-language-server-common/src/completions/providers/data/contentForParameterCompletionOptions.ts
+++ b/packages/theme-language-server-common/src/completions/providers/data/contentForParameterCompletionOptions.ts
@@ -6,5 +6,4 @@ export const DEFAULT_COMPLETION_OPTIONS: { [key: string]: string } = {
   type: "The type (name) of an existing theme block in your theme’s /blocks folder. Only applicable when `content_type` is 'block'.",
   id: "A unique identifier and literal string within the section or block that contains the static blocks. Only applicable when `content_type` is 'block'.",
   closest: 'A path that provides a way to access the closest resource of a given type.',
-  context: 'A path that provides a way to pass context properties to blocks.',
 };


### PR DESCRIPTION
## What are you adding in this PR?

Fixes https://github.com/Shopify/developer-tools-team/issues/660

This PR updates theme tooling to incorporate the changes introduced by the [#660](https://github.com/Shopify/developer-tools-team/issues/660).

Updates theme tools following the changes introduced by https://github.com/Shopify/developer-tools-team/issues/660 PRs.

Static blocks now support static parameters without requiring a namespace, and `{% content_for "blocks" %}` no longer accepts parameters.

### Before you deploy

- [x] I included a minor bump `changeset`

### Tophat 🎩

![demo-static](https://github.com/user-attachments/assets/fcbd6968-8ccc-4a5a-aa89-ff5b2119e5d8)





