### PR TITLE
Complete var name before type in liquiddoc

### DIFF
--- a/.changeset/eight-olives-lick.md
+++ b/.changeset/eight-olives-lick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Complete variable name before type in LiquidDoc @param completion

--- a/packages/theme-language-server-common/src/utils/liquidDoc.ts
+++ b/packages/theme-language-server-common/src/utils/liquidDoc.ts
@@ -35,7 +35,7 @@ export const SUPPORTED_LIQUID_DOC_TAG_HANDLES = {
       "  @param {string} name - The person's name\n" +
       "  @param {number} [fav_num] - The person's favorite number\n" +
       '{% enddoc %}\n',
-    template: `param {$1} $2 - $0`,
+    template: `param {$2} $1 - $0`,
   },
   [SupportedDocTagTypes.Example]: {
     description: 'Provides an example on how to use the snippet.',


### PR DESCRIPTION
I'm writing liquiddoc for swatches and found it weird that it was asking me to complete the type of the variable instead of its name, by changing the order of the placeholders it will be name -> type -> desc