### PR TITLE
bump liquid-tm-grammar to latest commit

### DIFF
--- a/.changeset/late-foxes-confess.md
+++ b/.changeset/late-foxes-confess.md
@@ -1,0 +1,5 @@
+---
+'theme-check-vscode': minor
+---
+
+Update liquid-tm-grammar commit to add syntax highlighting for the prompt tag in liquid doc


### PR DESCRIPTION
## What are you adding in this PR?

Bumping the `tm-liquid-grammar` submodule which added syntax highlighting for the `prompt` tag in LiquidDoc.

## Before you deploy
<!-- Public API changes, new features -->
- [X] I included a minor bump `changeset`
- [X] My feature is backward compatible
