### PR TITLE
Add `getDocDefinition` to fetch memoized docs

### DIFF
--- a/.changeset/five-peas-deliver.md
+++ b/.changeset/five-peas-deliver.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': patch
+'@shopify/theme-check-node': patch
+---
+
+Fix slow render tag theme checks

--- a/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
@@ -1,6 +1,6 @@
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { RenderMarkup } from '@shopify/liquid-html-parser';
-import { getSnippetDefinition, LiquidDocParameter } from '../../liquid-doc/liquidDoc';
+import { LiquidDocParameter } from '../../liquid-doc/liquidDoc';
 import { isLiquidString } from '../utils';
 import { getDefaultValueForType } from '../../liquid-doc/utils';
 
@@ -73,9 +73,8 @@ export const MissingRenderSnippetParams: LiquidCheckDefinition = {
 
         const snippetName = node.snippet.value;
         const snippetPath = `snippets/${snippetName}.liquid`;
-        const snippetUri = context.toUri(snippetPath);
-
-        const snippetDef = context.getDocDefinition && (await context.getDocDefinition(snippetUri));
+        const snippetDef =
+          context.getDocDefinition && (await context.getDocDefinition(snippetPath));
 
         if (!snippetDef?.liquidDoc?.parameters) {
           return;

--- a/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
@@ -1,6 +1,5 @@
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
-import { LiquidNamedArgument, RenderMarkup } from '@shopify/liquid-html-parser';
-import { toLiquidHtmlAST } from '@shopify/liquid-html-parser';
+import { RenderMarkup } from '@shopify/liquid-html-parser';
 import { getSnippetDefinition, LiquidDocParameter } from '../../liquid-doc/liquidDoc';
 import { isLiquidString } from '../utils';
 import { getDefaultValueForType } from '../../liquid-doc/utils';
@@ -9,7 +8,6 @@ export const MissingRenderSnippetParams: LiquidCheckDefinition = {
   meta: {
     code: 'MissingRenderSnippetParams',
     name: 'Missing Render Snippet Parameters',
-
     docs: {
       description:
         'This check ensures that all required parameters are provided when rendering a snippet.',
@@ -77,11 +75,9 @@ export const MissingRenderSnippetParams: LiquidCheckDefinition = {
         const snippetPath = `snippets/${snippetName}.liquid`;
         const snippetUri = context.toUri(snippetPath);
 
-        const snippetContent = await context.fs.readFile(snippetUri);
-        const snippetAst = toLiquidHtmlAST(snippetContent);
-        const snippetDef = getSnippetDefinition(snippetAst, snippetName);
+        const snippetDef = context.getDocDefinition && (await context.getDocDefinition(snippetUri));
 
-        if (!snippetDef.liquidDoc?.parameters) {
+        if (!snippetDef?.liquidDoc?.parameters) {
           return;
         }
 

--- a/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
@@ -1,6 +1,6 @@
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { LiquidNamedArgument, RenderMarkup } from '@shopify/liquid-html-parser';
-import { getSnippetDefinition, LiquidDocParameter } from '../../liquid-doc/liquidDoc';
+import { LiquidDocParameter } from '../../liquid-doc/liquidDoc';
 import { isLiquidString } from '../utils';
 import { isLastParam } from '../duplicate-render-snippet-params';
 
@@ -113,9 +113,8 @@ export const UnrecognizedRenderSnippetParams: LiquidCheckDefinition = {
 
         const snippetName = node.snippet.value;
         const snippetPath = `snippets/${snippetName}.liquid`;
-        const snippetUri = context.toUri(snippetPath);
-
-        const snippetDef = context.getDocDefinition && (await context.getDocDefinition(snippetUri));
+        const snippetDef =
+          context.getDocDefinition && (await context.getDocDefinition(snippetPath));
 
         if (!snippetDef?.liquidDoc?.parameters) {
           return;

--- a/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
@@ -1,6 +1,5 @@
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { LiquidNamedArgument, RenderMarkup } from '@shopify/liquid-html-parser';
-import { toLiquidHtmlAST } from '@shopify/liquid-html-parser';
 import { getSnippetDefinition, LiquidDocParameter } from '../../liquid-doc/liquidDoc';
 import { isLiquidString } from '../utils';
 import { isLastParam } from '../duplicate-render-snippet-params';
@@ -9,7 +8,6 @@ export const UnrecognizedRenderSnippetParams: LiquidCheckDefinition = {
   meta: {
     code: 'UnrecognizedRenderSnippetParams',
     name: 'Unrecognized Render Snippet Parameters',
-
     docs: {
       description:
         'This check ensures that no unknown parameters are used when rendering a snippet.',
@@ -117,11 +115,9 @@ export const UnrecognizedRenderSnippetParams: LiquidCheckDefinition = {
         const snippetPath = `snippets/${snippetName}.liquid`;
         const snippetUri = context.toUri(snippetPath);
 
-        const snippetContent = await context.fs.readFile(snippetUri);
-        const snippetAst = toLiquidHtmlAST(snippetContent);
-        const snippetDef = getSnippetDefinition(snippetAst, snippetName);
+        const snippetDef = context.getDocDefinition && (await context.getDocDefinition(snippetUri));
 
-        if (!snippetDef.liquidDoc?.parameters) {
+        if (!snippetDef?.liquidDoc?.parameters) {
           return;
         }
 

--- a/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { runLiquidCheck, applySuggestions } from '../../test';
 import { ValidRenderSnippetParamTypes } from '.';
-import { MockFileSystem } from '../../test';
 import { BasicParamTypes } from '../../liquid-doc/utils';
 
 describe('Module: ValidRenderSnippetParamTypes', () => {
@@ -51,17 +50,14 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
 
         test.validValues.forEach((value) => {
           it(`should accept ${value} for ${test.type}`, async () => {
-            const fs = new MockFileSystem({
-              'snippets/card.liquid': makeSnippet(test.type),
-            });
-
             const sourceCode = `{% render 'card', param: ${value} %}`;
             const offenses = await runLiquidCheck(
               ValidRenderSnippetParamTypes,
               sourceCode,
               undefined,
+              {},
               {
-                fs,
+                'snippets/card.liquid': makeSnippet(test.type),
               },
             );
             expect(offenses).toHaveLength(0);
@@ -70,17 +66,14 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
 
         test.invalidValues.forEach(({ value, actualType: expectedType }) => {
           it(`should reject ${value} for ${test.type}`, async () => {
-            const fs = new MockFileSystem({
-              'snippets/card.liquid': makeSnippet(test.type),
-            });
-
             const sourceCode = `{% render 'card', param: ${value} %}`;
             const offenses = await runLiquidCheck(
               ValidRenderSnippetParamTypes,
               sourceCode,
               undefined,
+              {},
               {
-                fs,
+                'snippets/card.liquid': makeSnippet(test.type),
               },
             );
             expect(offenses).toHaveLength(1);
@@ -95,8 +88,14 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
 
   describe('edge cases', () => {
     it('should handle mixed case type annotations', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': `
+      const sourceCode = `{% render 'card', text: "hello", count: 5, flag: true, data: product %}`;
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': `
             {% doc %}
               @param {String} text - The text
               @param {NUMBER} count - The count
@@ -105,92 +104,98 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
             {% enddoc %}
             <div>{{ text }}{{ count }}{{ flag }}{{ data }}</div>
           `,
-      });
-
-      const sourceCode = `{% render 'card', text: "hello", count: 5, flag: true, data: product %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+        },
+      );
       expect(offenses).toHaveLength(0);
     });
 
     it('should ignore variable lookups', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': `
+      const sourceCode = `{% render 'card', title: product_title %}`;
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': `
             {% doc %}
               @param {String} title - The title
             {% enddoc %}
             <div>{{ title }}</div>
           `,
-      });
-
-      const sourceCode = `{% render 'card', title: product_title %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+        },
+      );
       expect(offenses).toHaveLength(0);
     });
 
     it('should not report when snippet has no doc comment', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': `<h1>This snippet has no doc comment</h1>`,
-      });
-
       const sourceCode = `{% render 'card', title: 123 %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': `<h1>This snippet has no doc comment</h1>`,
+        },
+      );
       expect(offenses).toHaveLength(0);
     });
 
     it('should not enforce unsupported types', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': `
+      const sourceCode = `{% render 'card', title: 123 %}`;
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': `
             {% doc %}
               @param {Unsupported} title - The title
             {% enddoc %}
             <div>{{ title }}</div>
           `,
-      });
-
-      const sourceCode = `{% render 'card', title: 123 %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+        },
+      );
       expect(offenses).toHaveLength(0);
     });
 
     it('should not report for unrecognized parameters', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': `
+      const sourceCode = `{% render 'card', title: "hello", unrecognized: 123 %}`;
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': `
             {% doc %}
               @param {String} title - The title
             {% enddoc %}
             <div>{{ title }}</div>
           `,
-      });
-
-      const sourceCode = `{% render 'card', title: "hello", unrecognized: 123 %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+        },
+      );
       expect(offenses).toHaveLength(0);
     });
 
     it('should report when `with` alias is used', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': `
+      const sourceCode = `{% render 'card' with 12 as title %}`;
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': `
           {% doc %}
             @param {String} title - The title
           {% enddoc %}
           <div>{{ title }}</div>
         `,
-      });
-
-      const sourceCode = `{% render 'card' with 12 as title %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+        },
+      );
       expect(offenses).toHaveLength(1);
       expect(offenses[0].message).toBe(
         "Type mismatch for parameter 'title': expected string, got number",
@@ -198,19 +203,21 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should report when `for` alias is used', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': `
+      const sourceCode = `{% render 'card' for 123 as title %}`;
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': `
           {% doc %}
             @param {String} title - The title
           {% enddoc %}
           <div>{{ title }}</div>
         `,
-      });
-
-      const sourceCode = `{% render 'card' for 123 as title %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+        },
+      );
       expect(offenses).toHaveLength(1);
       expect(offenses[0].message).toBe(
         "Type mismatch for parameter 'title': expected string, got number",
@@ -227,14 +234,16 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     `;
 
     it('should suggest replacing with default value for type or removing value', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': makeSnippet('string'),
-      });
-
       const sourceCode = `{% render 'card', param: 123 %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': makeSnippet('string'),
+        },
+      );
 
       expect(offenses).toHaveLength(1);
       expect(offenses[0].suggest).toHaveLength(2);
@@ -248,20 +257,22 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should allow users to fix a single parameter when multiple are provided`', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': `
+      const sourceCode = `{% render 'card', title: 123, count: 5 %}`;
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': `
           {% doc %}
             @param {string} title - The title
             @param {number} count - The count
           {% enddoc %}
           <div>{{ title }} {{ count }}</div>
         `,
-      });
-
-      const sourceCode = `{% render 'card', title: 123, count: 5 %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+        },
+      );
 
       expect(offenses).toHaveLength(1);
       expect(offenses[0].message).toBe(
@@ -273,14 +284,16 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should handle parameters with trailing commas', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': makeSnippet('string'),
-      });
-
       const sourceCode = `{% render 'card', param: 123, %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': makeSnippet('string'),
+        },
+      );
 
       expect(offenses).toHaveLength(1);
 
@@ -289,22 +302,24 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should handle parameters with complex spacing', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': `
+      const sourceCode = `{% render 'card',
+        title: 123,
+        count: 5
+      %}`;
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': `
           {% doc %}
             @param {string} title - The title
             @param {number} count - The count
           {% enddoc %}
         `,
-      });
-
-      const sourceCode = `{% render 'card',
-        title: 123,
-        count: 5
-      %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+        },
+      );
 
       expect(offenses).toHaveLength(1);
 
@@ -316,14 +331,16 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should handle parameter with no space after colon', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': makeSnippet('string'),
-      });
-
       const sourceCode = `{% render 'card', param:123 %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': makeSnippet('string'),
+        },
+      );
 
       expect(offenses).toHaveLength(1);
 
@@ -332,14 +349,16 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should handle parameter with multiple spaces after colon', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': makeSnippet('string'),
-      });
-
       const sourceCode = `{% render 'card', param:     123 %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': makeSnippet('string'),
+        },
+      );
 
       expect(offenses).toHaveLength(1);
 
@@ -348,16 +367,18 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should handle parameter with newlines', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': makeSnippet('string'),
-      });
-
       const sourceCode = `{% render 'card', param: 
         123 
       %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': makeSnippet('string'),
+        },
+      );
 
       expect(offenses).toHaveLength(1);
 
@@ -368,14 +389,16 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should suggest removal and replacement if expected type has a default value', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': makeSnippet('string'),
-      });
-
       const sourceCode = `{% render 'card', param: 123 %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': makeSnippet('string'),
+        },
+      );
 
       expect(offenses).toHaveLength(1);
       expect(offenses[0].suggest).toHaveLength(2);
@@ -384,14 +407,16 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it("should only suggest removal if expected type default value is ''", async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': makeSnippet('object'),
-      });
-
       const sourceCode = `{% render 'card', param: 123 %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': makeSnippet('object'),
+        },
+      );
 
       expect(offenses).toHaveLength(1);
       expect(offenses[0].suggest).toHaveLength(1);
@@ -399,14 +424,16 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should handle when aliases `with` syntax is used', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': makeSnippet('string'),
-      });
-
       const sourceCode = `{% render 'card' with 123 as param %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': makeSnippet('string'),
+        },
+      );
 
       expect(offenses).toHaveLength(1);
       expect(offenses[0].message).toBe(
@@ -418,14 +445,16 @@ describe('Module: ValidRenderSnippetParamTypes', () => {
     });
 
     it('should handle when aliases `for` syntax is used', async () => {
-      const fs = new MockFileSystem({
-        'snippets/card.liquid': makeSnippet('string'),
-      });
-
       const sourceCode = `{% render 'card' for 123 as param %}`;
-      const offenses = await runLiquidCheck(ValidRenderSnippetParamTypes, sourceCode, undefined, {
-        fs,
-      });
+      const offenses = await runLiquidCheck(
+        ValidRenderSnippetParamTypes,
+        sourceCode,
+        undefined,
+        {},
+        {
+          'snippets/card.liquid': makeSnippet('string'),
+        },
+      );
 
       expect(offenses).toHaveLength(1);
       expect(offenses[0].message).toBe(

--- a/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
+++ b/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
@@ -1,6 +1,6 @@
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { LiquidNamedArgument, NodeTypes, RenderMarkup } from '@shopify/liquid-html-parser';
-import { getSnippetDefinition, LiquidDocParameter } from '../../liquid-doc/liquidDoc';
+import { LiquidDocParameter } from '../../liquid-doc/liquidDoc';
 import { isLiquidString } from '../utils';
 import {
   inferArgumentType,
@@ -157,9 +157,8 @@ export const ValidRenderSnippetParamTypes: LiquidCheckDefinition = {
 
         const snippetName = node.snippet.value;
         const snippetPath = `snippets/${snippetName}.liquid`;
-        const snippetUri = context.toUri(snippetPath);
-
-        const snippetDef = context.getDocDefinition && (await context.getDocDefinition(snippetUri));
+        const snippetDef =
+          context.getDocDefinition && (await context.getDocDefinition(snippetPath));
 
         if (!snippetDef?.liquidDoc?.parameters) {
           return;

--- a/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
+++ b/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
@@ -1,6 +1,5 @@
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { LiquidNamedArgument, NodeTypes, RenderMarkup } from '@shopify/liquid-html-parser';
-import { toLiquidHtmlAST } from '@shopify/liquid-html-parser';
 import { getSnippetDefinition, LiquidDocParameter } from '../../liquid-doc/liquidDoc';
 import { isLiquidString } from '../utils';
 import {
@@ -15,7 +14,6 @@ export const ValidRenderSnippetParamTypes: LiquidCheckDefinition = {
   meta: {
     code: 'ValidRenderSnippetParamTypes',
     name: 'Valid Render Snippet Parameter Types',
-
     docs: {
       description:
         'This check ensures that parameters passed to snippet match the expected types defined in the liquidDoc header if present.',
@@ -161,11 +159,9 @@ export const ValidRenderSnippetParamTypes: LiquidCheckDefinition = {
         const snippetPath = `snippets/${snippetName}.liquid`;
         const snippetUri = context.toUri(snippetPath);
 
-        const snippetContent = await context.fs.readFile(snippetUri);
-        const snippetAst = toLiquidHtmlAST(snippetContent);
-        const snippetDef = getSnippetDefinition(snippetAst, snippetName);
+        const snippetDef = context.getDocDefinition && (await context.getDocDefinition(snippetUri));
 
-        if (!snippetDef.liquidDoc?.parameters) {
+        if (!snippetDef?.liquidDoc?.parameters) {
           return;
         }
 

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -90,8 +90,8 @@ export async function check(
         SectionSchema | undefined
       >;
     },
-    async getDocDefinition(uri) {
-      const file = theme.find((file) => file.uri === uri);
+    async getDocDefinition(relativePath) {
+      const file = theme.find((file) => file.uri.endsWith(relativePath));
       if (!file || !isLiquidHtmlNode(file.ast)) {
         return undefined;
       }

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -347,7 +347,7 @@ export interface Dependencies {
    *
    * Used in theme-checks for cross-file checks rather that going through fs.
    */
-  getDocDefinition?: (uri: string) => Promise<SnippetDefinition | undefined>;
+  getDocDefinition?: (relativePath: string) => Promise<SnippetDefinition | undefined>;
 }
 
 export type ValidateJSON = (

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -17,6 +17,7 @@ import {
 } from './jsonc/types';
 import { JsonValidationSet, ThemeDocset } from './types/theme-liquid-docs';
 import { AppBlockSchema, SectionSchema, ThemeBlockSchema } from './types/theme-schemas';
+import { SnippetDefinition } from './liquid-doc/liquidDoc';
 
 export * from './jsonc/types';
 export * from './types/schema-prop-factory';
@@ -339,6 +340,14 @@ export interface Dependencies {
    * See {@link AppBlockSchema} for more information
    */
   getAppBlockSchema?: (name: string) => Promise<AppBlockSchema | undefined>;
+
+  /**
+   * Asynchronously get the Liquid HTML AST for a file.
+   * May return undefined when the theme isn't preloaded.
+   *
+   * Used in theme-checks for cross-file checks rather that going through fs.
+   */
+  getDocDefinition?: (uri: string) => Promise<SnippetDefinition | undefined>;
 }
 
 export type ValidateJSON = (

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -2,7 +2,6 @@ import {
   Config,
   JSONSourceCode,
   JSONValidator,
-  LiquidHtmlNode,
   LiquidSourceCode,
   Offense,
   SectionSchema,
@@ -124,7 +123,7 @@ export async function themeCheckRun(
     theme
       .filter((file) => isSnippet(file.uri))
       .map((file) => [
-        file.uri,
+        path.relative(URI.file(root).toString(), file.uri),
         memo(async (): Promise<SnippetDefinition | undefined> => {
           const ast = file.ast;
           if (!isLiquidHtmlNode(ast)) {
@@ -146,7 +145,7 @@ export async function themeCheckRun(
     getSectionSchema: async (name) => sectionSchemas.get(name)?.(),
     getBlockSchema: async (name) => blockSchemas.get(name)?.(),
     getAppBlockSchema: async (name) => blockSchemas.get(name)?.() as any, // cheating... but TODO
-    getDocDefinition: async (uri) => docDefinitions.get(uri)?.(),
+    getDocDefinition: async (relativePath) => docDefinitions.get(relativePath)?.(),
   });
 
   return {

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -2,21 +2,26 @@ import {
   Config,
   JSONSourceCode,
   JSONValidator,
+  LiquidHtmlNode,
   LiquidSourceCode,
   Offense,
   SectionSchema,
+  SnippetDefinition,
   Theme,
   ThemeBlockSchema,
   toSourceCode as commonToSourceCode,
   check as coreCheck,
+  getSnippetDefinition,
   isBlock,
   isIgnored,
   isSection,
+  isSnippet,
   memo,
   path as pathUtils,
   toSchema,
 } from '@shopify/theme-check-common';
 import { ThemeLiquidDocsManager } from '@shopify/theme-check-docs-updater';
+import { isLiquidHtmlNode } from '@shopify/liquid-html-parser';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -115,6 +120,20 @@ export async function themeCheckRun(
       toSchema(config.context, source.uri, source, isValidSchema) as Promise<SectionSchema | undefined>
     )
   ]));
+  const docDefinitions = new Map(
+    theme
+      .filter((file) => isSnippet(file.uri))
+      .map((file) => [
+        file.uri,
+        memo(async (): Promise<SnippetDefinition | undefined> => {
+          const ast = file.ast;
+          if (!isLiquidHtmlNode(ast)) {
+            return undefined;
+          }
+          return getSnippetDefinition(ast, path.basename(file.uri, '.liquid'));
+        }),
+      ]),
+  );
 
   const offenses = await coreCheck(theme, config, {
     fs: NodeFileSystem,
@@ -127,6 +146,7 @@ export async function themeCheckRun(
     getSectionSchema: async (name) => sectionSchemas.get(name)?.(),
     getBlockSchema: async (name) => blockSchemas.get(name)?.(),
     getAppBlockSchema: async (name) => blockSchemas.get(name)?.() as any, // cheating... but TODO
+    getDocDefinition: async (uri) => docDefinitions.get(uri)?.(),
   });
 
   return {

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -83,7 +83,8 @@ export function makeRunChecks(
           return schema as SectionSchema | undefined;
         },
 
-        async getDocDefinition(uri) {
+        async getDocDefinition(relativePath) {
+          const uri = path.join(config.rootUri, relativePath);
           const doc = documentManager.get(uri);
           if (doc?.type !== SourceCodeType.LiquidHtml) return undefined;
           return doc.getLiquidDoc(path.basename(uri, '.liquid'));

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -82,6 +82,12 @@ export function makeRunChecks(
           const schema = await doc.getSchema();
           return schema as SectionSchema | undefined;
         },
+
+        async getDocDefinition(uri) {
+          const doc = documentManager.get(uri);
+          if (doc?.type !== SourceCodeType.LiquidHtml) return undefined;
+          return doc.getLiquidDoc(path.basename(uri, '.liquid'));
+        },
       });
       const offenses = [...themeOffenses, ...cssOffenses];
 


### PR DESCRIPTION
## What are you adding in this PR?

Fixes https://github.com/Shopify/theme-tools/issues/880
- A few of our LiquidDoc related theme checks were slowing down theme checks because they directly access the file system rather than access it using our memoized system
- CLI theme check does not have access to the DocumentManager which provides proper caching
  - to follow existing patterns we use an injected method (that should also be flexible when we want to support fetching LiquidDoc from blocks)

<img width="971" alt="image" src="https://github.com/user-attachments/assets/695f8b2f-b3f7-4821-8b94-84a1ff518727" />


### 📊 RESULT
| **Before**                                                                 | **After**                                                                 |
|----------------------------------------------------------------------------|---------------------------------------------------------------------------|
| 19.04s real             27.24s user             1.83s sys                  | 5.52s real              6.74s user              0.33s sys                 |


## Tophatting

- Checkout repo
- Run `yarn install && yarn build`
- Go to a theme repo
- Create a doc tag in one of its snippets
- Go to the file that renders that snippet, and ensure at least one warning/error exists on the render tag from liquiddoc
  - Ensure one of the errors that appears is `MissingRenderSnippetParams`, `UnrecognizedRenderSnippetParams`, or `ValidRenderSnippetParamTypes` (since that's what got changed in this PR)
- In the theme repo, run the the following

```
  node <path-to-theme-tools>/Shopify/theme-tools/packages/theme-check-node/dist/cli.js .
```

- three items should be consoled (offences, config, and theme files)
  - check to see if your render tag offence exists in the logs

#### BONUS TOPHATTING
- If you prepend the command above with `/usr/bin/time -l -h `, you will get stats on its performance

## What did you learn?

- Just new areas of the code i haven't explored before (specifically how we inject things into theme-checks)

## Before you deploy

- [x] I included a patch bump `changeset`
