### PR TITLE
Amend UndefinedObject theme check to recognize @param variables

### DIFF
--- a/.changeset/wild-seals-agree.md
+++ b/.changeset/wild-seals-agree.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Updated UndefinedObject check to recognize variables declared via `@param` within doc tags in blocks

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -346,4 +346,36 @@ describe('Module: UndefinedObject', () => {
 
     expect(offenses).toHaveLength(0);
   });
+
+  it('should not report an offense when object is defined with @param in a block file', async () => {
+    const sourceCode = `
+      {% doc %}
+        @param {string} text
+      {% enddoc %}
+
+      {{ text }}
+    `;
+
+    const filePath = 'blocks/my-custom-block.liquid';
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode, filePath);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('should report an offense when an undefined object is used alongside @param in a block file', async () => {
+    const sourceCode = `
+      {% doc %}
+        @param {string} text
+      {% enddoc %}
+
+      {{ text }}
+      {{ undefined_variable }}
+    `;
+
+    const filePath = 'blocks/my-custom-block.liquid';
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode, filePath);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe("Unknown object 'undefined_variable' used.");
+  });
 });

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -1,4 +1,5 @@
 import {
+  LiquidDocParamNode,
   LiquidHtmlNode,
   LiquidTag,
   LiquidTagAssign,
@@ -61,6 +62,13 @@ export const UndefinedObject: LiquidCheckDefinition = {
     }
 
     return {
+      async LiquidDocParamNode(node: LiquidDocParamNode) {
+        const paramName = node.paramName?.value;
+        if (paramName) {
+          variableScopes.set(paramName, []);
+        }
+      },
+
       async LiquidTag(node) {
         if (isLiquidTagAssign(node)) {
           indexVariableScope(node.markup.name, {


### PR DESCRIPTION
## What are you adding in this PR?
Closes https://github.com/Shopify/developer-tools-team/issues/667

This change updates the `UndefinedObject` check to correctly identify variables declared using the `@param` tag within liquid doc blocks.

This is resolved by:

1. Adding a visitor for `LiquidDocParamNode` to the check
2. If we find a valid parameter name we add it to the `variableScopes` map with an empty array which treats it as a global variable within the file.

## Follow Up
I will open a separate issue/PR to allow snippets to use this check.

## Testing

- Pull down the branch
- Build the branch
- Hit F5 to start the development server
- Try adding a variable in a block file such as `{{ mage }}` and make sure it's caught as `UndefinedObject`
- Add a doc block (mini template here)
```javascript
{% doc %}
@param {string} mage
{% enddoc %}
```
- Watch the check disappear

I also added tests which you can run.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [X] This PR includes a new checks or changes the configuration of a check
  - [X] I included a minor bump `changeset`
  - [X] I ran `yarn build` and committed the updated configuration files
  - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (link PR here).
