### PR TITLE
Support `content_for` tag parameter completion

### DIFF
--- a/.changeset/dull-phones-trade.md
+++ b/.changeset/dull-phones-trade.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Support `content_for` param completion using LiquidDoc

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -72,7 +72,7 @@ export class CompletionsProvider {
     this.providers = [
       new ContentForCompletionProvider(),
       new ContentForBlockTypeCompletionProvider(getThemeBlockNames),
-      new ContentForParameterCompletionProvider(),
+      new ContentForParameterCompletionProvider(getDocDefinitionForURI),
       new HtmlTagCompletionProvider(),
       new HtmlAttributeCompletionProvider(documentManager),
       new HtmlAttributeValueCompletionProvider(),

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.ts
@@ -9,8 +9,8 @@ import {
 } from 'vscode-languageserver';
 import { CURSOR, LiquidCompletionParams } from '../params';
 import { Provider } from './common';
-import { formatLiquidDocParameter } from '../../utils/liquidDoc';
-import { GetDocDefinitionForURI, getDefaultValueForType } from '@shopify/theme-check-common';
+import { formatLiquidDocParameter, getParameterCompletionTemplate } from '../../utils/liquidDoc';
+import { GetDocDefinitionForURI } from '@shopify/theme-check-common';
 
 export type GetSnippetNamesForURI = (uri: string) => Promise<string[]>;
 
@@ -61,10 +61,6 @@ export class RenderSnippetParameterCompletionProvider implements Provider {
       .filter((liquidDocParam) => !existingRenderParams.includes(liquidDocParam.name))
       .filter((liquidDocParam) => liquidDocParam.name.startsWith(userInputStr))
       .map((liquidDocParam) => {
-        const paramDefaultValue = getDefaultValueForType(liquidDocParam.type);
-        const paramValueTemplate =
-          paramDefaultValue === "''" ? `'$1'$0` : `\${1:${paramDefaultValue}}$0`;
-
         return {
           label: liquidDocParam.name,
           kind: CompletionItemKind.Property,
@@ -74,7 +70,7 @@ export class RenderSnippetParameterCompletionProvider implements Provider {
           },
           textEdit: TextEdit.replace(
             Range.create(start, end),
-            `${liquidDocParam.name}: ${paramValueTemplate}`,
+            getParameterCompletionTemplate(liquidDocParam.name, liquidDocParam.type),
           ),
           insertTextFormat: InsertTextFormat.Snippet,
         };

--- a/packages/theme-language-server-common/src/utils/liquidDoc.ts
+++ b/packages/theme-language-server-common/src/utils/liquidDoc.ts
@@ -1,4 +1,4 @@
-import { LiquidDocParameter } from '@shopify/theme-check-common';
+import { getDefaultValueForType, LiquidDocParameter } from '@shopify/theme-check-common';
 import { SupportedDocTagTypes, BasicParamTypes } from '@shopify/theme-check-common';
 
 export function formatLiquidDocParameter(
@@ -52,3 +52,11 @@ export const SUPPORTED_LIQUID_DOC_TAG_HANDLES = {
     template: `description $0`,
   },
 };
+
+export function getParameterCompletionTemplate(name: string, type: string | null) {
+  const paramDefaultValue = getDefaultValueForType(type);
+
+  const valueTemplate = paramDefaultValue === "''" ? `'$1'$0` : `\${1:${paramDefaultValue}}$0`;
+
+  return `${name}: ${valueTemplate}`;
+}


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/664
- If a block contains `doc` tag, we read its params and offer it as completion when you try to do `content_for` tag param completion

<img width="470" alt="image" src="https://github.com/user-attachments/assets/922e5316-327e-4e95-952b-4e61921bf246" />

![15-33-4oi27-14o3i](https://github.com/user-attachments/assets/c04e359b-e10d-433e-ba2d-d8d5987f3494)


## Tophat
- Checkout the code
- Create doc on a block
- Find a `content_for` tag that renders that block
- Trigger code completion within the tag and get offered param completion for params you don't already have

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
