### PR TITLE
Building blocks for `docs` on `blocks`

### DIFF
--- a/.changeset/dry-fireants-smile.md
+++ b/.changeset/dry-fireants-smile.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+'@shopify/theme-check-node': patch
+---
+
+[internal] Building blocks to support LiquidDoc for blocks

--- a/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/missing-render-snippet-params/index.ts
@@ -72,9 +72,10 @@ export const MissingRenderSnippetParams: LiquidCheckDefinition = {
         }
 
         const snippetName = node.snippet.value;
-        const snippetPath = `snippets/${snippetName}.liquid`;
+
         const snippetDef =
-          context.getDocDefinition && (await context.getDocDefinition(snippetPath));
+          context.getDocDefinition &&
+          (await context.getDocDefinition(`snippets/${snippetName}.liquid`));
 
         if (!snippetDef?.liquidDoc?.parameters) {
           return;

--- a/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
+++ b/packages/theme-check-common/src/checks/unrecognized-render-snippet-params/index.ts
@@ -102,9 +102,9 @@ export const UnrecognizedRenderSnippetParams: LiquidCheckDefinition = {
         }
 
         const snippetName = node.snippet.value;
-        const snippetPath = `snippets/${snippetName}.liquid`;
         const snippetDef =
-          context.getDocDefinition && (await context.getDocDefinition(snippetPath));
+          context.getDocDefinition &&
+          (await context.getDocDefinition(`snippets/${snippetName}.liquid`));
 
         if (!snippetDef?.liquidDoc?.parameters) {
           return;

--- a/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
+++ b/packages/theme-check-common/src/checks/valid-render-snippet-param-types/index.ts
@@ -158,9 +158,9 @@ export const ValidRenderSnippetParamTypes: LiquidCheckDefinition = {
         }
 
         const snippetName = node.snippet.value;
-        const snippetPath = `snippets/${snippetName}.liquid`;
         const snippetDef =
-          context.getDocDefinition && (await context.getDocDefinition(snippetPath));
+          context.getDocDefinition &&
+          (await context.getDocDefinition(`snippets/${snippetName}.liquid`));
 
         if (!snippetDef?.liquidDoc?.parameters) {
           return;

--- a/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
+++ b/packages/theme-check-common/src/liquid-doc/liquidDoc.spec.ts
@@ -1,14 +1,16 @@
-import { expect, it, describe, should } from 'vitest';
+import { expect, it, describe } from 'vitest';
 import { toSourceCode } from '../to-source-code';
 import { LiquidHtmlNode } from '../types';
-import { getSnippetDefinition } from './liquidDoc';
+import { extractDocDefinition } from './liquidDoc';
 
-describe('Unit: getSnippetDefinition', () => {
+describe('Unit: extractDocDefinition', () => {
+  const uri = 'file:///snippets/fake.liquid';
+
   function toAST(code: string) {
-    return toSourceCode('/tmp/foo.liquid', code).ast as LiquidHtmlNode;
+    return toSourceCode(uri, code).ast as LiquidHtmlNode;
   }
 
-  it('should return default snippet definition if no renderable content is present', async () => {
+  it('should return default doc definition if no renderable content is present', async () => {
     const ast = toAST(`
         {% doc %}
           just a description
@@ -16,9 +18,9 @@ describe('Unit: getSnippetDefinition', () => {
         {% enddoc %}
       `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {
         description: {
           content: 'just a description',
@@ -40,9 +42,9 @@ describe('Unit: getSnippetDefinition', () => {
         {% enddoc %}
       `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {
         parameters: [
           {
@@ -100,9 +102,9 @@ describe('Unit: getSnippetDefinition', () => {
         {% enddoc %}
       `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {
         examples: [
           {
@@ -123,9 +125,9 @@ describe('Unit: getSnippetDefinition', () => {
         {% enddoc %}
       `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {
         examples: [
           {
@@ -146,9 +148,9 @@ describe('Unit: getSnippetDefinition', () => {
         {% enddoc %}
       `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {
         parameters: [
           {
@@ -179,9 +181,9 @@ describe('Unit: getSnippetDefinition', () => {
         {% enddoc %}
       `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {
         examples: [
           {
@@ -204,9 +206,9 @@ describe('Unit: getSnippetDefinition', () => {
         {% enddoc %}
       `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {
         description: {
           content: 'This is a description',
@@ -224,9 +226,9 @@ describe('Unit: getSnippetDefinition', () => {
         {% enddoc %}
       `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {
         description: {
           content: 'This is a description',
@@ -241,9 +243,9 @@ describe('Unit: getSnippetDefinition', () => {
       <div>No doc header here</div>
     `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
     });
   });
 
@@ -252,9 +254,9 @@ describe('Unit: getSnippetDefinition', () => {
       {% doc %}{% enddoc %}
     `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {},
     });
   });
@@ -271,9 +273,9 @@ describe('Unit: getSnippetDefinition', () => {
       {% enddoc %}
     `);
 
-    const result = getSnippetDefinition(ast, 'product-card');
+    const result = extractDocDefinition(uri, ast);
     expect(result).to.deep.equal({
-      name: 'product-card',
+      uri,
       liquidDoc: {
         description: {
           content: 'this is an implicit description\nin a header',

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -8,8 +8,8 @@ import {
   check as coreCheck,
   createCorrector,
   Dependencies,
+  extractDocDefinition,
   FixApplicator,
-  getSnippetDefinition,
   isBlock,
   isSection,
   JSONCorrector,
@@ -95,7 +95,7 @@ export async function check(
       if (!file || !isLiquidHtmlNode(file.ast)) {
         return undefined;
       }
-      return getSnippetDefinition(file.ast, path.basename(file.uri, '.liquid'));
+      return extractDocDefinition(file.uri, file.ast);
     },
     themeDocset: {
       async filters() {

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -17,7 +17,7 @@ import {
 } from './jsonc/types';
 import { JsonValidationSet, ThemeDocset } from './types/theme-liquid-docs';
 import { AppBlockSchema, SectionSchema, ThemeBlockSchema } from './types/theme-schemas';
-import { SnippetDefinition } from './liquid-doc/liquidDoc';
+import { DocDefinition } from './liquid-doc/liquidDoc';
 
 export * from './jsonc/types';
 export * from './types/schema-prop-factory';
@@ -347,7 +347,7 @@ export interface Dependencies {
    *
    * Used in theme-checks for cross-file checks rather that going through fs.
    */
-  getDocDefinition?: (relativePath: string) => Promise<SnippetDefinition | undefined>;
+  getDocDefinition?: (relativePath: string) => Promise<DocDefinition | undefined>;
 }
 
 export type ValidateJSON = (

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -1,5 +1,5 @@
 import {
-  GetSnippetDefinitionForURI,
+  GetDocDefinitionForURI,
   MetafieldDefinitionMap,
   SourceCodeType,
   ThemeDocset,
@@ -13,23 +13,23 @@ import { createLiquidCompletionParams } from './params';
 import {
   ContentForCompletionProvider,
   ContentForBlockTypeCompletionProvider,
+  ContentForParameterCompletionProvider,
   FilterCompletionProvider,
+  FilterNamedParameterCompletionProvider,
+  GetSnippetNamesForURI,
   HtmlAttributeCompletionProvider,
   HtmlAttributeValueCompletionProvider,
   HtmlTagCompletionProvider,
+  LiquidDocParamTypeCompletionProvider,
+  LiquidDocTagCompletionProvider,
   LiquidTagsCompletionProvider,
   ObjectAttributeCompletionProvider,
   ObjectCompletionProvider,
   Provider,
   RenderSnippetCompletionProvider,
+  RenderSnippetParameterCompletionProvider,
   TranslationCompletionProvider,
-  FilterNamedParameterCompletionProvider,
-  ContentForParameterCompletionProvider,
 } from './providers';
-import { GetSnippetNamesForURI } from './providers/RenderSnippetCompletionProvider';
-import { RenderSnippetParameterCompletionProvider } from './providers/RenderSnippetParameterCompletionProvider';
-import { LiquidDocTagCompletionProvider } from './providers/LiquidDocTagCompletionProvider';
-import { LiquidDocParamTypeCompletionProvider } from './providers/LiquidDocParamTypeCompletionProvider';
 
 export interface CompletionProviderDependencies {
   documentManager: DocumentManager;
@@ -38,7 +38,7 @@ export interface CompletionProviderDependencies {
   getSnippetNamesForURI?: GetSnippetNamesForURI;
   getThemeSettingsSchemaForURI?: GetThemeSettingsSchemaForURI;
   getMetafieldDefinitions: (rootUri: string) => Promise<MetafieldDefinitionMap>;
-  getSnippetDefinitionForURI?: GetSnippetDefinitionForURI;
+  getDocDefinitionForURI?: GetDocDefinitionForURI;
   getThemeBlockNames?: (rootUri: string, includePrivate: boolean) => Promise<string[]>;
   log?: (message: string) => void;
 }
@@ -56,9 +56,7 @@ export class CompletionsProvider {
     getTranslationsForURI = async () => ({}),
     getSnippetNamesForURI = async () => [],
     getThemeSettingsSchemaForURI = async () => [],
-    getSnippetDefinitionForURI = async (_uri, snippetName) => ({
-      name: snippetName,
-    }),
+    getDocDefinitionForURI = async (uri, _relativePath) => ({ uri }),
     getThemeBlockNames = async (_rootUri: string, _includePrivate: boolean) => [],
     log = () => {},
   }: CompletionProviderDependencies) {
@@ -84,7 +82,7 @@ export class CompletionsProvider {
       new FilterCompletionProvider(typeSystem),
       new TranslationCompletionProvider(documentManager, getTranslationsForURI),
       new RenderSnippetCompletionProvider(getSnippetNamesForURI),
-      new RenderSnippetParameterCompletionProvider(getSnippetDefinitionForURI),
+      new RenderSnippetParameterCompletionProvider(getDocDefinitionForURI),
       new FilterNamedParameterCompletionProvider(themeDocset),
       new LiquidDocTagCompletionProvider(),
       new LiquidDocParamTypeCompletionProvider(themeDocset),

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.spec.ts
@@ -1,13 +1,15 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import { CompletionsProvider } from '../CompletionsProvider';
 import { DocumentManager } from '../../documents';
-import { MetafieldDefinitionMap, SnippetDefinition } from '@shopify/theme-check-common';
+import { MetafieldDefinitionMap, DocDefinition } from '@shopify/theme-check-common';
+
+const uri = 'file:///snippets/product-card.liquid';
 
 describe('Module: RenderSnippetParameterCompletionProvider', async () => {
   let provider: CompletionsProvider;
   const mockSnippetName = 'product-card';
-  const mockSnippetDefinition: SnippetDefinition = {
-    name: mockSnippetName,
+  const mockSnippetDefinition: DocDefinition = {
+    uri,
     liquidDoc: {
       parameters: [
         {
@@ -60,7 +62,7 @@ describe('Module: RenderSnippetParameterCompletionProvider', async () => {
         systemTranslations: async () => ({}),
       },
       getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
-      getSnippetDefinitionForURI: async (_uri, snippetName) => {
+      getDocDefinitionForURI: async (_uri, _type, snippetName) => {
         if (mockSnippetName === snippetName) {
           return mockSnippetDefinition;
         }

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.ts
@@ -10,12 +10,12 @@ import {
 import { CURSOR, LiquidCompletionParams } from '../params';
 import { Provider } from './common';
 import { formatLiquidDocParameter } from '../../utils/liquidDoc';
-import { GetSnippetDefinitionForURI, getDefaultValueForType } from '@shopify/theme-check-common';
+import { GetDocDefinitionForURI, getDefaultValueForType } from '@shopify/theme-check-common';
 
 export type GetSnippetNamesForURI = (uri: string) => Promise<string[]>;
 
 export class RenderSnippetParameterCompletionProvider implements Provider {
-  constructor(private readonly getSnippetDefinitionForURI: GetSnippetDefinitionForURI) {}
+  constructor(private readonly getDocDefinitionForURI: GetDocDefinitionForURI) {}
 
   async completions(params: LiquidCompletionParams): Promise<CompletionItem[]> {
     if (!params.completionContext) return [];
@@ -34,8 +34,10 @@ export class RenderSnippetParameterCompletionProvider implements Provider {
     }
 
     const userInputStr = node.name?.replace(CURSOR, '') || '';
-    const snippetDefinition = await this.getSnippetDefinitionForURI(
+
+    const snippetDefinition = await this.getDocDefinitionForURI(
       params.textDocument.uri,
+      'snippets',
       parentNode.snippet.value,
     );
 

--- a/packages/theme-language-server-common/src/completions/providers/index.ts
+++ b/packages/theme-language-server-common/src/completions/providers/index.ts
@@ -11,4 +11,10 @@ export { ObjectAttributeCompletionProvider } from './ObjectAttributeCompletionPr
 export { ObjectCompletionProvider } from './ObjectCompletionProvider';
 export { TranslationCompletionProvider } from './TranslationCompletionProvider';
 export { RenderSnippetCompletionProvider } from './RenderSnippetCompletionProvider';
+export {
+  GetSnippetNamesForURI,
+  RenderSnippetParameterCompletionProvider,
+} from './RenderSnippetParameterCompletionProvider';
+export { LiquidDocTagCompletionProvider } from './LiquidDocTagCompletionProvider';
+export { LiquidDocParamTypeCompletionProvider } from './LiquidDocParamTypeCompletionProvider';
 export { Provider } from './common/Provider';

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -87,7 +87,7 @@ export function makeRunChecks(
           const uri = path.join(config.rootUri, relativePath);
           const doc = documentManager.get(uri);
           if (doc?.type !== SourceCodeType.LiquidHtml) return undefined;
-          return doc.getLiquidDoc(path.basename(uri, '.liquid'));
+          return doc.getLiquidDoc();
         },
       });
       const offenses = [...themeOffenses, ...cssOffenses];

--- a/packages/theme-language-server-common/src/documents/DocumentManager.ts
+++ b/packages/theme-language-server-common/src/documents/DocumentManager.ts
@@ -19,7 +19,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { ClientCapabilities } from '../ClientCapabilities';
 import { percent, Progress } from '../progress';
 import { AugmentedSourceCode } from './types';
-import { getSnippetDefinition } from '@shopify/theme-check-common';
+import { extractDocDefinition } from '@shopify/theme-check-common';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -195,10 +195,11 @@ export class DocumentManager {
             return toSchema(mode, uri, sourceCode, this.isValidSchema, false);
           }),
           /** Lazy and only computed once per file version */
-          getLiquidDoc: memo(async (snippetName: string) => {
-            if (isError(sourceCode.ast)) return undefined;
+          getLiquidDoc: memo(async () => {
+            const ast = sourceCode.ast;
+            if (isError(ast)) return undefined;
 
-            return getSnippetDefinition(sourceCode.ast, snippetName);
+            return extractDocDefinition(uri, ast);
           }),
         };
       default:

--- a/packages/theme-language-server-common/src/documents/types.ts
+++ b/packages/theme-language-server-common/src/documents/types.ts
@@ -6,7 +6,7 @@ import {
   AppBlockSchema,
 } from '@shopify/theme-check-common';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { SnippetDefinition } from '@shopify/theme-check-common';
+import { DocDefinition } from '@shopify/theme-check-common';
 
 /** Util type to add the common `textDocument` property to the SourceCode. */
 type _AugmentedSourceCode<SCT extends SourceCodeType = SourceCodeType> = SourceCode<SCT> & {
@@ -24,7 +24,7 @@ export type AugmentedJsonSourceCode = _AugmentedSourceCode<SourceCodeType.JSON>;
  */
 export type AugmentedLiquidSourceCode = _AugmentedSourceCode<SourceCodeType.LiquidHtml> & {
   getSchema: () => Promise<SectionSchema | ThemeBlockSchema | AppBlockSchema | undefined>;
-  getLiquidDoc: (snippetName: string) => Promise<SnippetDefinition | undefined>;
+  getLiquidDoc: () => Promise<DocDefinition | undefined>;
 };
 
 /**

--- a/packages/theme-language-server-common/src/hover/HoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/HoverProvider.ts
@@ -1,5 +1,5 @@
 import {
-  GetSnippetDefinitionForURI,
+  GetDocDefinitionForURI,
   MetafieldDefinitionMap,
   SourceCodeType,
   ThemeDocset,
@@ -33,12 +33,7 @@ export class HoverProvider {
     readonly getMetafieldDefinitions: (rootUri: string) => Promise<MetafieldDefinitionMap>,
     readonly getTranslationsForURI: GetTranslationsForURI = async () => ({}),
     readonly getSettingsSchemaForURI: GetThemeSettingsSchemaForURI = async () => [],
-    readonly getSnippetDefinitionForURI: GetSnippetDefinitionForURI = async (
-      _uri,
-      snippetName,
-    ) => ({
-      name: snippetName,
-    }),
+    readonly getDocDefinitionForURI: GetDocDefinitionForURI = async () => undefined,
   ) {
     const typeSystem = new TypeSystem(
       themeDocset,
@@ -54,8 +49,8 @@ export class HoverProvider {
       new HtmlAttributeHoverProvider(),
       new HtmlAttributeValueHoverProvider(),
       new TranslationHoverProvider(getTranslationsForURI, documentManager),
-      new RenderSnippetHoverProvider(getSnippetDefinitionForURI),
-      new RenderSnippetParameterHoverProvider(getSnippetDefinitionForURI),
+      new RenderSnippetHoverProvider(getDocDefinitionForURI),
+      new RenderSnippetParameterHoverProvider(getDocDefinitionForURI),
       new LiquidDocTagHoverProvider(documentManager),
     ];
   }

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -1,15 +1,17 @@
-import { describe, beforeEach, it, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
 import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
-import { GetSnippetDefinitionForURI, SnippetDefinition } from '@shopify/theme-check-common';
+import { GetDocDefinitionForURI, DocDefinition } from '@shopify/theme-check-common';
 import '../../../../theme-check-common/src/test/test-setup';
+
+const uri = 'file:///snippets/product-card.liquid';
 
 describe('Module: RenderSnippetHoverProvider', async () => {
   let provider: HoverProvider;
-  let getSnippetDefinition: GetSnippetDefinitionForURI;
-  const mockSnippetDefinition: SnippetDefinition = {
-    name: 'product-card',
+  let getSnippetDefinition: GetDocDefinitionForURI;
+  const mockSnippetDefinition: DocDefinition = {
+    uri,
     liquidDoc: {
       parameters: [
         {
@@ -96,7 +98,10 @@ This is a description
     });
 
     it('should return null if no LiquidDocDefinition found', async () => {
-      getSnippetDefinition = async () => ({ name: 'unknown-snippet', liquidDoc: undefined });
+      getSnippetDefinition = async () => ({
+        uri,
+        liquidDoc: undefined,
+      });
       provider = createProvider(getSnippetDefinition);
       await expect(provider).to.hover(`{% render 'unknown-sni█ppet' %}`, `### unknown-snippet`);
     });
@@ -114,7 +119,7 @@ This is a description
 
     it('should wrap optional parameters in (Optional)', async () => {
       provider = createProvider(async () => ({
-        name: 'product-card',
+        uri,
         liquidDoc: {
           parameters: [
             {
@@ -142,7 +147,7 @@ This is a description
   });
 });
 
-const createProvider = (getSnippetDefinition: GetSnippetDefinitionForURI) => {
+const createProvider = (getSnippetDefinition: GetDocDefinitionForURI) => {
   return new HoverProvider(
     new DocumentManager(),
     {

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -1,16 +1,16 @@
 import { NodeTypes } from '@shopify/liquid-html-parser';
-import { LiquidHtmlNode, SnippetDefinition, LiquidDocParameter } from '@shopify/theme-check-common';
+import {
+  LiquidHtmlNode,
+  LiquidDocParameter,
+  GetDocDefinitionForURI,
+  path,
+} from '@shopify/theme-check-common';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import { BaseHoverProvider } from '../BaseHoverProvider';
 import { formatLiquidDocParameter } from '../../utils/liquidDoc';
 
 export class RenderSnippetHoverProvider implements BaseHoverProvider {
-  constructor(
-    private getSnippetDefinitionForURI: (
-      uri: string,
-      snippetName: string,
-    ) => Promise<SnippetDefinition | undefined>,
-  ) {}
+  constructor(private getDocDefinitionForURI: GetDocDefinitionForURI) {}
 
   async hover(
     currentNode: LiquidHtmlNode,
@@ -27,8 +27,9 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
     }
 
     const snippetName = currentNode.value;
-    const snippetDefinition = await this.getSnippetDefinitionForURI(
+    const snippetDefinition = await this.getDocDefinitionForURI(
       params.textDocument.uri,
+      'snippets',
       snippetName,
     );
 
@@ -42,12 +43,12 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
       return {
         contents: {
           kind: 'markdown',
-          value: `### ${snippetDefinition.name}`,
+          value: `### ${snippetName}`,
         },
       };
     }
 
-    const parts = [`### ${snippetDefinition.name}`];
+    const parts = [`### ${snippetName}`];
 
     if (liquidDoc.description) {
       const description = liquidDoc.description.content;

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
@@ -2,14 +2,16 @@ import { describe, beforeEach, it, expect } from 'vitest';
 import { DocumentManager } from '../../documents';
 import { HoverProvider } from '../HoverProvider';
 import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
-import { GetSnippetDefinitionForURI, SnippetDefinition } from '@shopify/theme-check-common';
+import { GetDocDefinitionForURI, DocDefinition } from '@shopify/theme-check-common';
 import '../../../../theme-check-common/src/test/test-setup';
+
+const uri = 'file:///snippets/product-card.liquid';
 
 describe('Module: RenderSnippetParameterHoverProvider', async () => {
   let provider: HoverProvider;
-  let getSnippetDefinition: GetSnippetDefinitionForURI;
-  const mockSnippetDefinition: SnippetDefinition = {
-    name: 'product-card',
+  let getSnippetDefinition: GetDocDefinitionForURI;
+  const mockSnippetDefinition: DocDefinition = {
+    uri,
     liquidDoc: {
       parameters: [
         {
@@ -65,7 +67,7 @@ describe('Module: RenderSnippetParameterHoverProvider', async () => {
     // should return null if no parameters are defined
     it('should return null if no parameters are defined in liquidDoc', async () => {
       getSnippetDefinition = async () => ({
-        name: 'product-card',
+        uri,
         liquidDoc: {
           parameters: [],
         },
@@ -108,7 +110,7 @@ describe('Module: RenderSnippetParameterHoverProvider', async () => {
   });
 });
 
-const createProvider = (getSnippetDefinition: GetSnippetDefinitionForURI) => {
+const createProvider = (getSnippetDefinition: GetDocDefinitionForURI) => {
   return new HoverProvider(
     new DocumentManager(),
     {

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.ts
@@ -1,16 +1,11 @@
 import { NodeTypes } from '@shopify/liquid-html-parser';
-import { LiquidHtmlNode, SnippetDefinition } from '@shopify/theme-check-common';
+import { LiquidHtmlNode, GetDocDefinitionForURI } from '@shopify/theme-check-common';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import { BaseHoverProvider } from '../BaseHoverProvider';
 import { formatLiquidDocParameter } from '../../utils/liquidDoc';
 
 export class RenderSnippetParameterHoverProvider implements BaseHoverProvider {
-  constructor(
-    private getSnippetDefinitionForURI: (
-      uri: string,
-      snippetName: string,
-    ) => Promise<SnippetDefinition | undefined>,
-  ) {}
+  constructor(private getDocDefinitionForURI: GetDocDefinitionForURI) {}
 
   async hover(
     currentNode: LiquidHtmlNode,
@@ -27,10 +22,10 @@ export class RenderSnippetParameterHoverProvider implements BaseHoverProvider {
       return null;
     }
 
-    const snippetName = parentNode.snippet.value;
-    const snippetDefinition = await this.getSnippetDefinitionForURI(
+    const snippetDefinition = await this.getDocDefinitionForURI(
       params.textDocument.uri,
-      snippetName,
+      'snippets',
+      parentNode.snippet.value,
     );
 
     if (!snippetDefinition?.liquidDoc?.parameters?.length) {

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -12,7 +12,8 @@ import {
   path,
   recursiveReadDirectory,
   SourceCodeType,
-  SnippetDefinition,
+  DocDefinition,
+  UriString,
 } from '@shopify/theme-check-common';
 import {
   Connection,
@@ -182,19 +183,20 @@ export function startServer(
     return getDefaultSchemaTranslations();
   };
 
-  const getSnippetDefinitionForURI = async (
-    uri: string,
-    snippetName: string,
-  ): Promise<SnippetDefinition | undefined> => {
+  const getDocDefinitionForURI = async (
+    uri: UriString,
+    category: 'snippets' | 'blocks',
+    name: string,
+  ): Promise<DocDefinition | undefined> => {
     const rootUri = await findThemeRootURI(uri);
-    const snippetURI = path.join(rootUri, 'snippets', `${snippetName}.liquid`);
-    const snippet = documentManager.get(snippetURI);
+    const fileUri = path.join(rootUri, category, `${name}.liquid`);
+    const file = documentManager.get(fileUri);
 
-    if (!snippet || snippet.type !== SourceCodeType.LiquidHtml || isError(snippet.ast)) {
+    if (!file || file.type !== SourceCodeType.LiquidHtml || isError(file.ast)) {
       return undefined;
     }
 
-    return snippet.getLiquidDoc(snippetName);
+    return file.getLiquidDoc();
   };
 
   const snippetFilter = ([uri]: FileTuple) => /\.liquid$/.test(uri) && /snippets/.test(uri);
@@ -266,7 +268,7 @@ export function startServer(
     log,
     getThemeBlockNames,
     getMetafieldDefinitions,
-    getSnippetDefinitionForURI,
+    getDocDefinitionForURI,
   });
   const hoverProvider = new HoverProvider(
     documentManager,
@@ -274,7 +276,7 @@ export function startServer(
     getMetafieldDefinitions,
     getTranslationsForURI,
     getThemeSettingsSchemaForURI,
-    getSnippetDefinitionForURI,
+    getDocDefinitionForURI,
   );
 
   const executeCommandProvider = new ExecuteCommandProvider(


### PR DESCRIPTION
## What are you adding in this PR?

closes https://github.com/Shopify/developer-tools-team/issues/670

- Cleans up variables and methods so that we can support blocks in all of our LiquidDoc utils and memoized methods
- Most important pieces are in:
  - `packages/theme-check-common/src/liquid-doc/liquidDoc.ts`
  - `packages/theme-check-node/src/index.ts`
  - `packages/theme-language-server-common/src/diagnostics/runChecks.ts`
  - `packages/theme-language-server-common/src/documents/DocumentManager.ts`
- The rest are just refactors caused by the 4 changes above

## What's next? Any followup issues?

- nothing specific

## Tophat

- Ensure the changed theme checks still work in VSCode AND via terminal

  - MissingRenderSnippetParams
  - UnrecognizedRenderSnippetParams
  - ValidRenderSnippetParamTypes

- VSCode tophatting
  - Open branch in VSCode
  - Press F5
  - Open Theme
  - Create doc in snippet
  - Go to render tag in a different file that renders the changed snippet
  - See theme check error

- terminal tophatting
  - Checkout this branch
  - build the branch `yarn build`
  - cd to a theme with errors (you can create some in the VScode tophatting step)
  - Run `node <path/to-theme-tools>/packages/theme-check-node/dist/cli.js .`


## Before you deploy

- [x] I included a patch bump `changeset`
