### PR TITLE
Fix ValidBlockTarget behaviour when it comes to static blocks

### DIFF
--- a/.changeset/silver-ears-sniff.md
+++ b/.changeset/silver-ears-sniff.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fix ValidBlockTarget reporting of static block presets

--- a/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
@@ -24,6 +24,7 @@ describe('Module: ValidSchemaName', () => {
         type: ThemeSchemaType.Section,
         offset: 0,
         value: '',
+        staticBlockDefs: [],
       }),
     });
 

--- a/packages/theme-check-common/src/checks/valid-settings-key/index.ts
+++ b/packages/theme-check-common/src/checks/valid-settings-key/index.ts
@@ -10,7 +10,7 @@ import {
 } from '../../types';
 import { nodeAtPath } from '../../json';
 import { getSchema, isSectionSchema } from '../../to-schema';
-import { BlockNodeWithPath, getBlocks, reportWarning } from '../../utils';
+import { BlockDefNodeWithPath, getBlocks, reportWarning } from '../../utils';
 
 export const ValidSettingsKey: LiquidCheckDefinition = {
   meta: {
@@ -82,7 +82,7 @@ async function validateReferencedBlock(
   context: any,
   offset: number,
   settingsNode: JSONNode | undefined,
-  localBlocks: BlockNodeWithPath[],
+  localBlocks: BlockDefNodeWithPath[],
   referencedBlock: Preset.Block | Section.Block | ThemeBlock.Block,
 ) {
   if (localBlocks.length > 0) {

--- a/packages/theme-check-common/src/types/theme-schemas.ts
+++ b/packages/theme-check-common/src/types/theme-schemas.ts
@@ -9,6 +9,9 @@ export enum ThemeSchemaType {
   Section = 'section',
 }
 
+/** {% content_for 'block', type: type, id: id %}*/
+export type StaticBlockDef = { type: string; id: string };
+
 /**
  * A ThemeSchema represents the `{% schema %}` contents of a block or section file.
  *
@@ -50,6 +53,9 @@ export interface ThemeBlockSchema extends ThemeSchema<ThemeSchemaType.Block> {
    * }
    */
   validSchema: ThemeBlock.Schema | Error;
+
+  /** type/id pairs found in the body of the file */
+  staticBlockDefs: StaticBlockDef[];
 }
 
 /** See {@link ThemeSchema} */
@@ -65,6 +71,9 @@ export interface SectionSchema extends ThemeSchema<ThemeSchemaType.Section> {
    * }
    */
   validSchema: Section.Schema | Error;
+
+  /** type/id pairs found in the body of the file */
+  staticBlockDefs: StaticBlockDef[];
 }
 
 /** TODO setup validSchema like the other ones. */


### PR DESCRIPTION
## What are you adding in this PR?
- Store an array of StaticBlockDefinitions to the ThemeBlockSchema & SectionSchema objects that we cache
  - `schema.staticBlockDefs: { type, id }[]`;
- Validate `Preset.Block` nodes that are `static` against the `StaticBlockDef[]` of the parent's,
  - Report a warning unless the parent has a StaticBlockDef entry with the same id & type
- Two new error messages:
  - `Could not find a static block of type "static" with id "mismatching_id" in this file.` (top level preset)
  - `Could not find a static block of type "static" with id "mismatching_id" in "blocks/slideshow.liquid".` (nested presets)

## What's next? Any followup issues?

No

## What did you learn?

This check did not consider static blocks and was throwing false warnings

## Before you deploy

- [x] I included a patch bump `changeset`
