### PR TITLE
Restrict block `doc` param names

### DIFF
--- a/.changeset/rare-rice-worry.md
+++ b/.changeset/rare-rice-worry.md
@@ -1,0 +1,26 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Restrict LiquidDoc param names in blocks based on `content_for` tag params
+
+- LiquidDoc inside blocks have limitations on names because `content_for` tag uses the following param names:
+  - id
+  - type
+  - attributes
+  - block
+  - blocks
+  - class
+  - context
+  - inherit
+  - resource
+  - resources
+  - schema
+  - section
+  - sections
+  - settings
+  - snippet
+  - snippets
+  - template
+  - templates

--- a/.changeset/violet-cooks-mate.md
+++ b/.changeset/violet-cooks-mate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Add reserved parameters to the `content_for` tag

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -29,6 +29,7 @@ import { SchemaPresetsBlockOrder } from './schema-presets-block-order';
 import { SchemaPresetsStaticBlocks } from './schema-presets-static-blocks';
 import { RemoteAsset } from './remote-asset';
 import { RequiredLayoutThemeObject } from './required-layout-theme-object';
+import { ReservedDocParamNames } from './reserved-doc-param-names';
 import { TranslationKeyExists } from './translation-key-exists';
 import { UnclosedHTMLElement } from './unclosed-html-element';
 import { UndefinedObject } from './undefined-object';
@@ -90,6 +91,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   SchemaPresetsStaticBlocks,
   RemoteAsset,
   RequiredLayoutThemeObject,
+  ReservedDocParamNames,
   TranslationKeyExists,
   UnclosedHTMLElement,
   UndefinedObject,

--- a/packages/theme-check-common/src/checks/reserved-doc-param-names/index.spec.ts
+++ b/packages/theme-check-common/src/checks/reserved-doc-param-names/index.spec.ts
@@ -1,0 +1,62 @@
+import { expect, describe, it } from 'vitest';
+import { ReservedDocParamNames } from './index';
+import { runLiquidCheck } from '../../test';
+
+describe('Module: ReservedDocParamNames', () => {
+  describe('block file', () => {
+    it(`should not report an error when no doc params share names with reserved content_for tag params`, async () => {
+      const sourceCode = `
+        {% doc %}
+          @param param1 - Example param
+        {% enddoc %}
+      `;
+
+      const offenses = await runLiquidCheck(
+        ReservedDocParamNames,
+        sourceCode,
+        'blocks/file.liquid',
+      );
+
+      expect(offenses).to.be.empty;
+    });
+
+    it('should report an error when a doc param shares names with reserved content_for tag params', async () => {
+      const sourceCode = `
+        {% doc %}
+          @param param1 - Example param
+          @param id - Example param
+        {% enddoc %}
+      `;
+
+      const offenses = await runLiquidCheck(
+        ReservedDocParamNames,
+        sourceCode,
+        'blocks/file.liquid',
+      );
+
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.contain(
+        `The parameter name is not supported because it's a reserved argument for 'content_for' tags.`,
+      );
+    });
+  });
+
+  describe('snippet file', () => {
+    it('should not report an error when a doc param shares names with reserved content_for tag params', async () => {
+      const sourceCode = `
+        {% doc %}
+          @param param1 - Example param
+          @param id - Example param
+        {% enddoc %}
+      `;
+
+      const offenses = await runLiquidCheck(
+        ReservedDocParamNames,
+        sourceCode,
+        'snippets/file.liquid',
+      );
+
+      expect(offenses).to.have.length(0);
+    });
+  });
+});

--- a/packages/theme-check-common/src/checks/reserved-doc-param-names/index.ts
+++ b/packages/theme-check-common/src/checks/reserved-doc-param-names/index.ts
@@ -1,0 +1,57 @@
+import { TextNode } from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { isBlock } from '../../to-schema';
+import {
+  REQUIRED_CONTENT_FOR_ARGUMENTS,
+  RESERVED_CONTENT_FOR_ARGUMENTS,
+} from '../../tags/content-for';
+
+export const ReservedDocParamNames: LiquidCheckDefinition = {
+  meta: {
+    code: 'ReservedDocParamNames',
+    name: 'Valid doc parameter names',
+    docs: {
+      description:
+        'This check exists to ensure any parameter names defined in LiquidDoc do not collide with reserved words.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/reserved-doc-param-names',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    if (!isBlock(context.file.uri)) {
+      return {};
+    }
+
+    const defaultParameterNames = [
+      ...REQUIRED_CONTENT_FOR_ARGUMENTS,
+      ...RESERVED_CONTENT_FOR_ARGUMENTS,
+    ];
+
+    return {
+      async LiquidDocParamNode(node) {
+        const paramName = node.paramName.value;
+
+        if (defaultParameterNames.includes(paramName)) {
+          reportWarning(
+            context,
+            `The parameter name is not supported because it's a reserved argument for 'content_for' tags.`,
+            node.paramName,
+          );
+        }
+      },
+    };
+  },
+};
+
+function reportWarning(context: any, message: string, node: TextNode) {
+  context.report({
+    message,
+    startIndex: node.position.start,
+    endIndex: node.position.end,
+  });
+}

--- a/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
+++ b/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
@@ -1,5 +1,9 @@
 import { ContentForMarkup, NodeTypes } from '@shopify/liquid-html-parser';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import {
+  REQUIRED_CONTENT_FOR_ARGUMENTS,
+  RESERVED_CONTENT_FOR_ARGUMENTS,
+} from '../../tags/content-for';
 
 export const ValidContentForArguments: LiquidCheckDefinition = {
   meta: {
@@ -32,28 +36,8 @@ export const ValidContentForArguments: LiquidCheckDefinition = {
       },
 
       block: (node: ContentForMarkup) => {
-        const requiredArguments = ['id', 'type'];
-        const reservedArguments = [
-          'attributes',
-          'block',
-          'blocks',
-          'class',
-          'context',
-          'inherit',
-          'resource',
-          'resources',
-          'schema',
-          'section',
-          'sections',
-          'settings',
-          'snippet',
-          'snippets',
-          'template',
-          'templates',
-        ];
-
         // Make sure the id and string arguments are present and are strings
-        for (const requiredArgumentName of requiredArguments) {
+        for (const requiredArgumentName of REQUIRED_CONTENT_FOR_ARGUMENTS) {
           const arg = node.args.find((arg) => arg.name === requiredArgumentName);
 
           if (!arg) {
@@ -78,7 +62,7 @@ export const ValidContentForArguments: LiquidCheckDefinition = {
         }
 
         const problematicArguments = node.args.filter((arg) =>
-          reservedArguments.includes(arg.name),
+          RESERVED_CONTENT_FOR_ARGUMENTS.includes(arg.name),
         );
 
         for (const arg of problematicArguments) {

--- a/packages/theme-check-common/src/checks/valid-doc-param-names/index.ts
+++ b/packages/theme-check-common/src/checks/valid-doc-param-names/index.ts
@@ -7,7 +7,7 @@ export const ValidDocParamNames: LiquidCheckDefinition = {
     name: 'Valid doc parameter names',
     docs: {
       description:
-        'This check exists to ensure any parameter names defined in LiquidDoc do not collide with liquid tags and global variables.',
+        'This check exists to ensure any parameter names defined in LiquidDoc do not collide with liquid tags or global variables.',
       recommended: true,
       url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-doc-param-names',
     },

--- a/packages/theme-check-common/src/checks/valid-doc-param-names/index.ts
+++ b/packages/theme-check-common/src/checks/valid-doc-param-names/index.ts
@@ -7,7 +7,7 @@ export const ValidDocParamNames: LiquidCheckDefinition = {
     name: 'Valid doc parameter names',
     docs: {
       description:
-        'This check exists to ensure any parameter names defined in LiquidDoc do not collide with reserved words.',
+        'This check exists to ensure any parameter names defined in LiquidDoc do not collide with liquid tags and global variables.',
       recommended: true,
       url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-doc-param-names',
     },

--- a/packages/theme-check-common/src/tags/content-for.ts
+++ b/packages/theme-check-common/src/tags/content-for.ts
@@ -1,0 +1,20 @@
+export const RESERVED_CONTENT_FOR_ARGUMENTS = [
+  'attributes',
+  'block',
+  'blocks',
+  'class',
+  'context',
+  'inherit',
+  'resource',
+  'resources',
+  'schema',
+  'section',
+  'sections',
+  'settings',
+  'snippet',
+  'snippets',
+  'template',
+  'templates',
+];
+
+export const REQUIRED_CONTENT_FOR_ARGUMENTS = ['id', 'type'];

--- a/packages/theme-check-common/src/tags/content-for.ts
+++ b/packages/theme-check-common/src/tags/content-for.ts
@@ -13,6 +13,9 @@ export const RESERVED_CONTENT_FOR_ARGUMENTS = [
   'settings',
   'snippet',
   'snippets',
+  'src',
+  'style',
+  'styles',
   'template',
   'templates',
 ];

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -100,6 +100,9 @@ RemoteAsset:
 RequiredLayoutThemeObject:
   enabled: true
   severity: 0
+ReservedDocParamNames:
+  enabled: true
+  severity: 0
 SchemaPresetsBlockOrder:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -78,6 +78,9 @@ RemoteAsset:
 RequiredLayoutThemeObject:
   enabled: true
   severity: 0
+ReservedDocParamNames:
+  enabled: true
+  severity: 0
 SchemaPresetsBlockOrder:
   enabled: true
   severity: 1


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/671
- Restrict `content_for` param names inside of `doc` tag to avoid collision
- Unlike our `ValidDocParamNames`, this one is an error because the collision could be fatal rather than just ambiguous

## Tophat

- Checkout this branch
- `yarn build`
- F5
- Open a theme
- Create a block file
- Add `doc` tag to it and create a `param` with the name `id`, `type`, or `closest` - you should see an error

![17-32-jq5wk-fg2kd](https://github.com/user-attachments/assets/9ad8c830-9bb4-4651-8063-3cebf6f87642)



## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
