### PR TITLE
Allow `closest.` args in `content_for` tags

### DIFF
--- a/.changeset/purple-onions-camp.md
+++ b/.changeset/purple-onions-camp.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Bugfix ensures `content_for` argument theme check allows `closest.` args

--- a/packages/theme-check-common/src/checks/unrecognized-content-for-arguments/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unrecognized-content-for-arguments/index.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { runLiquidCheck } from '../../test';
 import { UnrecognizedContentForArguments } from '.';
+import { RESERVED_CONTENT_FOR_ARGUMENTS } from '../../tags/content-for';
 
 function check(snippet: string, source: string) {
   return runLiquidCheck(
@@ -108,6 +109,34 @@ describe('Module: UnrecognizedContentForArguments', () => {
               <div>{{ description }}</div>
             `,
         },
+      );
+
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('should not report when argument begins with `.closest`', async () => {
+      const offenses = await check(
+        `
+        {% doc %}
+          @param {string} title - The title of the card
+        {% enddoc %}
+        <div>{{ title }}</div>
+        `,
+        `{% content_for 'block', type: 'card', id: '123', closest.product: product %}`,
+      );
+
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('should not report when argument is a reserved word', async () => {
+      const offenses = await check(
+        `
+        {% doc %}
+          @param {string} title - The title of the card
+        {% enddoc %}
+        <div>{{ title }}</div>
+        `,
+        `{% content_for 'block', type: 'card', id: '123', ${RESERVED_CONTENT_FOR_ARGUMENTS[0]}: product %}`,
       );
 
       expect(offenses).toHaveLength(0);

--- a/packages/theme-check-common/src/checks/unrecognized-content-for-arguments/index.ts
+++ b/packages/theme-check-common/src/checks/unrecognized-content-for-arguments/index.ts
@@ -6,6 +6,7 @@ import {
   reportUnknownArguments,
 } from '../../liquid-doc/arguments';
 import {
+  CLOSEST_ARGUMENT,
   REQUIRED_CONTENT_FOR_ARGUMENTS,
   RESERVED_CONTENT_FOR_ARGUMENTS,
 } from '../../tags/content-for';
@@ -44,7 +45,8 @@ export const UnrecognizedContentForArguments: LiquidCheckDefinition = {
 
         const unknownProvidedParams = node.args
           .filter((p) => !liquidDocParameters.has(p.name))
-          .filter((p) => !DEFAULT_CONTENT_FOR_ARGS.has(p.name));
+          .filter((p) => !DEFAULT_CONTENT_FOR_ARGS.has(p.name))
+          .filter((p) => !p.name.startsWith(CLOSEST_ARGUMENT));
 
         reportUnknownArguments(context, node, unknownProvidedParams, blockName);
       },

--- a/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
+++ b/packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts
@@ -1,6 +1,7 @@
 import { ContentForMarkup, NodeTypes } from '@shopify/liquid-html-parser';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import {
+  CLOSEST_ARGUMENT,
   REQUIRED_CONTENT_FOR_ARGUMENTS,
   RESERVED_CONTENT_FOR_ARGUMENTS,
 } from '../../tags/content-for';
@@ -24,7 +25,9 @@ export const ValidContentForArguments: LiquidCheckDefinition = {
   create(context) {
     const validationStrategies = {
       blocks: (node: ContentForMarkup) => {
-        const problematicArguments = node.args.filter((arg) => !arg.name.startsWith('closest.'));
+        const problematicArguments = node.args.filter(
+          (arg) => !arg.name.startsWith(CLOSEST_ARGUMENT),
+        );
 
         for (const arg of problematicArguments) {
           context.report({

--- a/packages/theme-check-common/src/tags/content-for.ts
+++ b/packages/theme-check-common/src/tags/content-for.ts
@@ -21,3 +21,5 @@ export const RESERVED_CONTENT_FOR_ARGUMENTS = [
 ];
 
 export const REQUIRED_CONTENT_FOR_ARGUMENTS = ['id', 'type'];
+
+export const CLOSEST_ARGUMENT = 'closest.';


### PR DESCRIPTION
## What are you adding in this PR?

- I forgot that `closest.` args operate slightly different from other reserved words for `content_for` tag
- Added it similar to `packages/theme-check-common/src/checks/valid-content-for-arguments/index.ts`
- updated the tests to ensure we cover `closest` and reserved args for `content_for`

## Tophat

- Create a block with a doc tag

```
{% doc %}
  @param {product} [my_prod]
  @param {string} my_string
  @param {number} my_number
{% enddoc %}
```

- Render the block in a section using `closest.` arg

```
{% content_for 'block',
  type: 'swatches',
  id: 'fake-7',
  my_string: product.title,
  my_number: 0,
  closest.product: product,
  not_real: '123'
%}
```
 
The only arg that should throw a warning is `not_real`

## Before you deploy

- [x] I included a patch bump `changeset`
