### PR TITLE
For aliased filters, show the doc of the base filter

### DIFF
--- a/.changeset/clever-candles-know.md
+++ b/.changeset/clever-candles-know.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+For aliased filters, show the docs of the base docset entry

--- a/packages/theme-check-common/src/AugmentedThemeDocset.ts
+++ b/packages/theme-check-common/src/AugmentedThemeDocset.ts
@@ -10,7 +10,25 @@ import {
 import { memo } from './utils';
 
 const toFilterEntry = (name: string): FilterEntry => ({ name });
-const aliasedFilters = ['camelcase', 'handle', 't'];
+const aliasedFilters: [string, string][] = [
+  ['camelcase', 'camelize'],
+  ['handle', 'handleize'],
+  ['t', 'translate'],
+];
+
+const toAliasedFilterEntry =
+  (entries: FilterEntry[]) =>
+  ([alias, baseName]: [string, string]): FilterEntry => {
+    const baseEntry = entries.find((entry) => entry.name === baseName);
+    if (!baseEntry) {
+      return toFilterEntry(alias);
+    }
+    return {
+      ...baseEntry,
+      name: alias,
+    };
+  };
+
 const undocumentedFilters = [
   '_online_store_editor_live_setting',
   'addresses_url',
@@ -86,9 +104,10 @@ export class AugmentedThemeDocset implements ThemeDocset {
   public isAugmented = true;
 
   filters = memo(async (): Promise<FilterEntry[]> => {
+    const officialFilters = await this.themeDocset.filters();
     return [
-      ...(await this.themeDocset.filters()),
-      ...aliasedFilters.map(toFilterEntry),
+      ...officialFilters,
+      ...aliasedFilters.map(toAliasedFilterEntry(officialFilters)),
       ...undocumentedFilters.map(toFilterEntry),
     ];
   });


### PR DESCRIPTION
Noticed that the `t` filter had a silly hover window.

Now the `t` filter will show the docs of the `translate` filter.

![image](https://github.com/user-attachments/assets/29c69552-2d49-4047-87be-72860bd084b9)


- [x] I have a patch changeset
