### PR TITLE
Make the return type of the default filter be the type of its argument

### DIFF
--- a/.changeset/nasty-cups-breathe.md
+++ b/.changeset/nasty-cups-breathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Make the return type of the default filter be the one of its argument

--- a/packages/theme-language-server-common/src/TypeSystem.spec.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.spec.ts
@@ -36,7 +36,7 @@ describe('Module: TypeSystem', () => {
       {
         name: 'product',
         access: {
-          global: false,
+          global: true,
           parents: [],
           template: [],
         },
@@ -246,6 +246,27 @@ describe('Module: TypeSystem', () => {
     const xVariable = (ast as any).children[0].markup as AssignMarkup;
     const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
     expect(inferredType).to.equal('number');
+  });
+
+  describe('when using the default filter', () => {
+    it('should return the type of the default value literal', async () => {
+      const ast = toLiquidHtmlAST(`
+        {% assign x = x | default: 10 %}
+      `);
+      const xVariable = (ast as any).children[0].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+      expect(inferredType).to.equal('number');
+    });
+
+    it('should return the type of the default value lookup', async () => {
+      const ast = toLiquidHtmlAST(`
+        {% assign d = product.featured_image %}
+        {% assign x = unknown | default: d %}
+      `);
+      const xVariable = (ast as any).children[1].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+      expect(inferredType).to.equal('image');
+    });
   });
 
   it('should return the type of variables in for loop', async () => {

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -638,6 +638,13 @@ function inferType(
     case NodeTypes.LiquidVariable: {
       if (thing.filters.length > 0) {
         const lastFilter = thing.filters.at(-1)!;
+        if (lastFilter.name === 'default') {
+          // default filter is a special case, we need to return the type of the expression
+          // instead of the filter.
+          if (lastFilter.args.length > 0 && lastFilter.args[0].type !== NodeTypes.NamedArgument) {
+            return inferType(lastFilter.args[0], symbolsTable, objectMap, filtersMap);
+          }
+        }
         const filterEntry = filtersMap[lastFilter.name];
         return filterEntry ? filterEntryReturnType(filterEntry) : Untyped;
       } else {


### PR DESCRIPTION
```liquid
{% # x is a 'number' %}
{% assign x = x | default: 10 %}

{% # y has the type of d: a 'string' %}
{% assign d = 'string' %}
{% assign y = y | default: d %}
```

Fixes #914

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
