### PR TITLE
Support LiquidDoc param array types

### DIFF
--- a/.changeset/proud-seahorses-cheer.md
+++ b/.changeset/proud-seahorses-cheer.md
@@ -1,0 +1,17 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+---
+
+Support LiquidDoc param array types
+
+- LiquidDoc param types supports 1D arrays as param types
+- Square brackets are placed after the param type to denote arrays
+
+E.g.
+```
+{% doc %}
+  @param {product[]} my_products - an array of products
+  @param {string[]} my_strings - an array of strings
+{% enddoc %}
+```

--- a/packages/theme-check-common/src/checks/valid-doc-param-types/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-doc-param-types/index.spec.ts
@@ -30,6 +30,18 @@ describe('Module: ValidDocParamTypes', () => {
     expect(offenses).to.be.empty;
   });
 
+  it(`should not report an error when a valid liquid object array parameter (product[]) type is used`, async () => {
+    const sourceCode = `
+      {% doc %}
+        @param {product[]} param1 - Example param
+      {% enddoc %}
+    `;
+
+    const offenses = await runLiquidCheck(ValidDocParamTypes, sourceCode);
+
+    expect(offenses).to.be.empty;
+  });
+
   it('should report an error with suggestions when an invalid parameter type is used', async () => {
     const sourceCode = `
       {% doc %}

--- a/packages/theme-check-common/src/liquid-doc/utils.spec.ts
+++ b/packages/theme-check-common/src/liquid-doc/utils.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { BasicParamTypes, parseParamType } from './utils';
+
+describe('liquid-doc/utils', () => {
+  describe('parseParamType', () => {
+    const validParamTypes = new Set([...Object.values(BasicParamTypes), 'product']);
+
+    it('should parse all values provided in the `validParamTypes` set', () => {
+      const tests = {
+        string: ['string', false],
+        product: ['product', false],
+        'string[]': ['string', true],
+        'product[]': ['product', true],
+        invalid: undefined,
+      };
+
+      Object.entries(tests).forEach(([input, expected]) => {
+        const result = parseParamType(validParamTypes, input);
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/theme-check-common/src/liquid-doc/utils.ts
+++ b/packages/theme-check-common/src/liquid-doc/utils.ts
@@ -107,3 +107,19 @@ export function getValidParamTypes(objectEntries: ObjectEntry[]): Map<string, st
 
   return paramTypes;
 }
+
+export function parseParamType(
+  validParamTypes: Set<string>,
+  value: string,
+): [pseudoType: string, isArray: boolean] | undefined {
+  const paramTypeMatch = value.match(/^([a-z_]+)(\[\])?$/);
+
+  if (!paramTypeMatch) return undefined;
+
+  const extractedParamType = paramTypeMatch[1];
+  const isArrayType = !!paramTypeMatch[2];
+
+  if (!validParamTypes.has(extractedParamType)) return undefined;
+
+  return [extractedParamType, isArrayType];
+}

--- a/packages/theme-language-server-common/src/TypeSystem.spec.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.spec.ts
@@ -493,6 +493,27 @@ describe('Module: TypeSystem', () => {
       );
       expect(inferredType).to.eql('product');
     });
+
+    it(`should support array liquid doc params type: product[]`, async () => {
+      const sourceCode = `
+        {% doc %}
+          @param {product[]} data - some data
+        {% enddoc %}
+        {{ data }}
+      `;
+      const ast = toLiquidHtmlAST(sourceCode);
+      const variableOutput = ast.children[1];
+      assert(isLiquidVariableOutput(variableOutput));
+      const inferredType = await typeSystem.inferType(
+        variableOutput.markup,
+        ast,
+        'file:///snippets/example.liquid',
+      );
+      expect(inferredType).to.eql({
+        kind: 'array',
+        valueType: 'product',
+      });
+    });
   });
 
   describe('metafieldDefinitionsObjectMap', async () => {


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/682

- Add support for array types in LiquidDoc

## Tophat

- Open the branch in VSCode
- `yarn install && yarn build`
- Press F5
- Open a theme and create a snippet/block with LiquidDoc
- Try out different types (`string`, `string[]`, `product`, `product[]`, `object`, `object[]`, etc.)
- NOTE: `object` is not a real type. It is treated as "untyped", so `object[]` is treated an array of untyped objects

## Before you deploy
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
