### PR TITLE
Fixup hover of builtin properties of arrays and literals

### DIFF
--- a/.changeset/few-eels-rush.md
+++ b/.changeset/few-eels-rush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Add hover support of builtin array and string properties

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.spec.ts
@@ -19,6 +19,11 @@ describe('Module: LiquidObjectAttributeHoverProvider', async () => {
             return_type: [{ type: 'image', name: '' }],
           },
           {
+            name: 'images',
+            description: 'images description',
+            return_type: [{ type: 'array', array_value: 'image' }],
+          },
+          {
             name: 'title',
             return_type: [{ type: 'string', name: '' }],
           },
@@ -26,7 +31,14 @@ describe('Module: LiquidObjectAttributeHoverProvider', async () => {
       },
       {
         name: 'image',
-        description: 'image description',
+        description: 'description of the image type',
+        properties: [
+          {
+            name: 'height',
+            description: 'height description',
+            return_type: [{ type: 'number', name: '' }],
+          },
+        ],
         access: {
           global: false,
           parents: [],
@@ -65,6 +77,96 @@ describe('Module: LiquidObjectAttributeHoverProvider', async () => {
         expect.stringMatching(/##* featured_image: `image`/),
       );
     }
+  });
+
+  describe('when hovering over an array built-in method', () => {
+    it('should return the hover description of the object property', async () => {
+      const contexts = [
+        '{{ product.images.first█ }}',
+        '{{ product.images.last█ }}',
+        '{% echo product.images.first█ %}',
+      ];
+      for (const context of contexts) {
+        await expect(provider).to.hover(
+          context,
+          expect.stringMatching(/##* (first|last): `image`/),
+        );
+        await expect(provider, context).to.hover(
+          context,
+          expect.stringContaining('description of the image type'),
+        );
+      }
+    });
+
+    it('should return not arbitrarily return the type of the last property', async () => {
+      await expect(provider).to.hover(
+        '{{ product.images.first█.height }}',
+        expect.stringMatching(/##* first: `image`/),
+      );
+      await expect(provider).to.hover(
+        '{{ product.images.firs█t.height }}',
+        expect.stringMatching(/##* first: `image`/),
+      );
+    });
+
+    it('should return the hover description number properties', async () => {
+      const contexts = ['{{ product.images.size█ }}', '{% echo product.images.size█ %}'];
+      for (const context of contexts) {
+        await expect(provider).to.hover(context, expect.stringMatching(/##* size: `number`/));
+      }
+    });
+
+    it('should return nothing if there are no docs for that attribute', async () => {
+      const contexts = ['{{ product.images.length█ }}', '{% echo product.images.length█ %}'];
+      for (const context of contexts) {
+        await expect(provider).to.hover(context, null);
+      }
+    });
+  });
+
+  describe('when hovering over built-in methods of built-in types', () => {
+    it('should return info for size', async () => {
+      const contexts = [
+        '{{ product.title.size█ }}',
+        '{{ product.title.first.size█ }}',
+        '{% echo product.title.size█ %}',
+      ];
+      for (const context of contexts) {
+        await expect(provider).to.hover(context, expect.stringMatching(/##* size: `number`/));
+      }
+    });
+
+    it('should return info for first/last of strings', async () => {
+      const contexts = [
+        '{{ product.title.last█ }}',
+        '{{ product.title.first█ }}',
+        '{{ product.title.first.first█ }}',
+        '{% echo product.title.first█ %}',
+      ];
+      for (const context of contexts) {
+        await expect(provider).to.hover(
+          context,
+          expect.stringMatching(/##* (first|last): `string`/),
+        );
+      }
+    });
+
+    it('should return nothing for unknown attributes of built-ins', async () => {
+      const contexts = ['{{ product.title.length█ }}', '{% echo product.title.unknown█ %}'];
+      for (const context of contexts) {
+        await expect(provider).to.hover(context, null);
+      }
+    });
+  });
+
+  describe('when the parent is untyped', () => {
+    it('should show a hover window (it is like any of any)', async () => {
+      await expect(provider).to.hover(
+        `{% assign x = product.foo %}
+         {{ x.bar█ }}`,
+        expect.stringMatching(/##* bar: `untyped`/),
+      );
+    });
   });
 
   it('should return nothing if there are no docs for that attribute', async () => {


### PR DESCRIPTION
Add hover support of builtin properties

```liquid
{% # string builtins %}
{{ product.title.size }} -> number
{{ product.title.first }} -> string
{{ product.title.last }} -> string
{{ product.title.last.last }} -> string
{{ product.title.foo }} -> null

{% # array lookups %}
{{ product.images.first }} -> image
{{ product.images.last }} -> image
{{ product.images.size }} -> number
{{ product.images.foo }} -> null
```

Fixes #921

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
