### PR TITLE
Fix attribute hover when directly after the dot

### DIFF
--- a/.changeset/smooth-carrots-prove.md
+++ b/.changeset/smooth-carrots-prove.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-check-common': patch
+---
+
+Fix hover when cursor is directly after a `.`

--- a/packages/theme-check-common/src/visitor.spec.ts
+++ b/packages/theme-check-common/src/visitor.spec.ts
@@ -1,7 +1,8 @@
 import { LiquidHtmlNode, LiquidHtmlNodeTypes, SourceCodeType } from './types';
-import { toSourceCode } from './to-source-code';
-import { expect, describe, it } from 'vitest';
-import { Visitor, visit } from './visitor';
+import { toLiquidHTMLAST, toSourceCode } from './to-source-code';
+import { expect, describe, it, assert } from 'vitest';
+import { Visitor, findCurrentNode, visit } from './visitor';
+import { NodeTypes } from '@shopify/liquid-html-parser';
 
 describe('Module: visitor', () => {
   it('should return an array of the return type of the visitor', () => {
@@ -34,4 +35,93 @@ describe('Module: visitor', () => {
   function toAST(code: string) {
     return toSourceCode('/tmp/foo.liquid', code).ast as LiquidHtmlNode;
   }
+});
+
+describe('findCurrentNode', () => {
+  it.each([
+    {
+      desc: 'at the end of a tag name',
+      source: '{% render█ "a" %}',
+      expected: NodeTypes.LiquidTag,
+      ancestors: [NodeTypes.Document],
+    },
+    {
+      desc: 'at the end of a lookup',
+      source: '{{ product.title█ }}',
+      expected: NodeTypes.String,
+      ancestors: [
+        NodeTypes.Document,
+        NodeTypes.LiquidVariableOutput,
+        NodeTypes.LiquidVariable,
+        NodeTypes.VariableLookup,
+      ],
+    },
+    {
+      desc: 'at the beginning of a lookup',
+      source: '{{ product.█title }}',
+      expected: NodeTypes.String,
+      ancestors: [
+        NodeTypes.Document,
+        NodeTypes.LiquidVariableOutput,
+        NodeTypes.LiquidVariable,
+        NodeTypes.VariableLookup,
+      ],
+    },
+    {
+      desc: 'at the start of a condition',
+      source: '{% if █cond %}{% endif %}',
+      expected: NodeTypes.VariableLookup,
+      ancestors: [NodeTypes.Document, NodeTypes.LiquidTag],
+    },
+    {
+      desc: 'at the start of a child condition',
+      source: '{% if cond %}{% elsif █cond %}{% endif %}',
+      expected: NodeTypes.VariableLookup,
+      ancestors: [NodeTypes.Document, NodeTypes.LiquidTag, NodeTypes.LiquidBranch],
+    },
+    {
+      desc: 'at the start of a comparison',
+      source: '{% if █cond < b %}{% endif %}',
+      expected: NodeTypes.VariableLookup,
+      ancestors: [NodeTypes.Document, NodeTypes.LiquidTag, NodeTypes.Comparison],
+    },
+    {
+      desc: 'at the start of a logical expression',
+      source: '{% if █cond and b %}{% endif %}',
+      expected: NodeTypes.VariableLookup,
+      ancestors: [NodeTypes.Document, NodeTypes.LiquidTag, NodeTypes.LogicalExpression],
+    },
+    {
+      desc: 'at the start of a named-variable variable lookup',
+      source: '{{ product[█key] }}',
+      expected: NodeTypes.VariableLookup,
+      ancestors: [
+        NodeTypes.Document,
+        NodeTypes.LiquidVariableOutput,
+        NodeTypes.LiquidVariable,
+        NodeTypes.VariableLookup,
+      ],
+    },
+    {
+      desc: 'between the end of a text node and the start of a tag',
+      source: '{% if open %}<div>foo█{% else %}</div>{% endif %}',
+      expected: NodeTypes.TextNode,
+      ancestors: [
+        NodeTypes.Document,
+        NodeTypes.LiquidTag,
+        NodeTypes.LiquidBranch,
+        NodeTypes.HtmlElement,
+      ],
+    },
+  ])('should find the current node and ancestors when $desc', ({ source, expected, ancestors }) => {
+    const CURSOR = '█';
+    const offset = source.indexOf(CURSOR);
+    const ast = toLiquidHTMLAST(source.replace(CURSOR, ''));
+    assert(!(ast instanceof Error), 'AST should not be an error');
+
+    const [currentNode, actualAncestors] = findCurrentNode(ast, offset);
+
+    expect(actualAncestors.map((x) => x.type)).to.eql(ancestors, `In "${source}"`);
+    expect(currentNode.type).to.equal(expected, `In "${source}"`);
+  });
 });

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.spec.ts
@@ -82,6 +82,7 @@ describe('Module: LiquidObjectAttributeHoverProvider', async () => {
   describe('when hovering over an array built-in method', () => {
     it('should return the hover description of the object property', async () => {
       const contexts = [
+        '{{ product.images.█first }}',
         '{{ product.images.first█ }}',
         '{{ product.images.last█ }}',
         '{% echo product.images.first█ %}',

--- a/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.spec.ts
@@ -28,7 +28,6 @@ describe('Module: LiquidTagHoverProvider', async () => {
     await expect(provider).to.hover(`{%█ if cond %}{% endif %}`, expect.stringContaining('if'));
     await expect(provider).to.hover(`{% i█f cond %}{% endif %}`, expect.stringContaining('if'));
     await expect(provider).to.hover(`{% if█ cond %}{% endif %}`, expect.stringContaining('if'));
-    await expect(provider).to.hover(`{% if █cond %}{% endif %}`, expect.stringContaining('if'));
     await expect(provider).to.hover(`{% if cond █%}{% endif %}`, expect.stringContaining('if'));
     await expect(provider).to.hover(`{% if cond %}{% █ endif %}`, expect.stringContaining('if'));
     await expect(provider).to.hover(`{% echo█ 'hi' %}`, expect.stringContaining('echo'));


### PR DESCRIPTION
and in other places... by adding a bunch of tests to findCurrentNode
and fixing a couple of edge cases

Fixes #925

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
