### PR TITLE
Disable theme checks for the next Liquid statement

### DIFF
--- a/.changeset/stale-kings-wink.md
+++ b/.changeset/stale-kings-wink.md
@@ -1,0 +1,9 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Introduce ability the disable theme checks for the next Liquid statement
+
+- Add `{% # theme-check-disable-next-line %}` to disable theme checks on the next Liquid statement
+- To disable a specific theme-check rule, add the name(s) after `theme-check-disable-next-line`
+in a comma separated format

--- a/packages/theme-check-common/src/checks/unused-assign/index.ts
+++ b/packages/theme-check-common/src/checks/unused-assign/index.ts
@@ -55,8 +55,10 @@ export const UnusedAssign: LiquidCheckDefinition = {
           if (!usedVariables.has(variable) && !variable.startsWith('_')) {
             context.report({
               message: `The variable '${variable}' is assigned but not used`,
-              startIndex: node.position.start,
-              endIndex: node.position.end,
+              startIndex: isLiquidTagCapture(node)
+                ? node.blockStartPosition.start
+                : node.position.start,
+              endIndex: isLiquidTagCapture(node) ? node.blockStartPosition.end : node.position.end,
               suggest: [
                 {
                   message: `Remove the unused variable '${variable}'`,

--- a/packages/theme-check-common/src/disabled-checks/index.ts
+++ b/packages/theme-check-common/src/disabled-checks/index.ts
@@ -1,5 +1,14 @@
-import { Position } from '@shopify/liquid-html-parser';
-import { LiquidCheckDefinition, Offense, UriString } from '../types';
+import { LiquidHtmlNode, LiquidRawTag, LiquidTag, Position } from '@shopify/liquid-html-parser';
+import {
+  LiquidCheckDefinition,
+  LiquidHtmlNodeTypes,
+  Offense,
+  SourceCode,
+  SourceCodeType,
+  UriString,
+} from '../types';
+import { findCurrentNode } from '../visitor';
+import { isError } from '../utils';
 
 type CheckName = string;
 type DisabledChecksMap = Map<UriString, Map<CheckName, { from: number; to?: number }[]>>;
@@ -9,32 +18,50 @@ export function createDisabledChecksModule() {
   const INLINE_COMMENT_TAG = '#';
   const disabledChecks: DisabledChecksMap = new Map();
 
-  function determineRanges(uri: string, value: string, position: Position) {
+  function determineRanges(
+    file: SourceCode<SourceCodeType.LiquidHtml>,
+    value: string,
+    node: LiquidTag | LiquidRawTag,
+  ) {
     const [_, command, checksJoined] =
-      value.trim().match(/^(?:theme\-check\-(disable|enable)) ?(.*)/) || [];
+      value.trim().match(/^(?:theme\-check\-(disable-next-line|disable|enable)) ?(.*)/) || [];
 
     const checks = checksJoined ? checksJoined.split(/,[ ]*/) : [SPECIFIC_CHECK_NOT_DEFINED];
 
     checks.forEach((check) => {
-      const disabledRanges = disabledChecks.get(uri)!;
+      const disabledRanges = disabledChecks.get(file.uri)!;
+
+      if (command === 'disable-next-line' && !isError(file.ast)) {
+        const nextLinePosition = findNextLinePosition(file.ast, node);
+
+        if (nextLinePosition) {
+          if (!disabledRanges.has(check)) {
+            disabledRanges.set(check, []);
+          }
+          disabledRanges.get(check)!.push({
+            from: nextLinePosition.start,
+            to: nextLinePosition.end,
+          });
+        }
+      }
 
       if (command === 'disable') {
         if (!disabledRanges.has(check)) {
           disabledRanges.set(check, []);
         }
-        disabledRanges.get(check)!.push({ from: position.end });
+        disabledRanges.get(check)!.push({ from: node.position.end });
       }
 
       if (command === 'enable') {
         let disabledRangesForCheck = disabledRanges.get(check);
         if (disabledRangesForCheck) {
-          disabledRangesForCheck[disabledRangesForCheck.length - 1].to = position.start;
+          disabledRangesForCheck[disabledRangesForCheck.length - 1].to = node.position.start;
         } else {
           if (check === SPECIFIC_CHECK_NOT_DEFINED) {
             for (let ranges of disabledRanges.values()) {
               for (let range of ranges) {
                 if (!range.to) {
-                  range.to = position.start;
+                  range.to = node.position.start;
                 }
               }
             }
@@ -56,7 +83,7 @@ export function createDisabledChecksModule() {
           return;
         }
 
-        determineRanges(file.uri, node.body.value, node.position);
+        determineRanges(file, node.body.value, node);
       },
 
       async LiquidTag(node) {
@@ -64,7 +91,7 @@ export function createDisabledChecksModule() {
           return;
         }
 
-        determineRanges(file.uri, node.markup, node.position);
+        determineRanges(file, node.markup, node);
       },
     }),
   };
@@ -89,4 +116,74 @@ export function createDisabledChecksModule() {
     DisabledChecksVisitor,
     isDisabled,
   };
+}
+
+export function findNextLinePosition(
+  ast: LiquidHtmlNode,
+  node: LiquidHtmlNode,
+): Position | undefined {
+  const [currentNode, ancestors] = findCurrentNode(ast, node.position.end);
+  const parentNode = ancestors.at(-1);
+  const grandParentNode = ancestors.at(-2);
+
+  let nextNode = getNextNode(parentNode, currentNode);
+  /*
+   * If there is no "next" node, assume they mean the parent block's next node.
+   *
+   * E.g. The following disables check for `elsif` tag
+   *
+   * {% if condition %}
+   *   {% #theme-check-disable-next-line %}
+   * {% elsif other_condition %}
+   *   {{ prouduct }}
+   * {% endif %}
+   *
+   * NOTE: We don't want to do this recursively since it doesn't make sense to go
+   * past 1 depth.
+   */
+  if (!nextNode) {
+    if (parentNode) {
+      nextNode = getNextNode(grandParentNode, parentNode);
+    }
+
+    if (!nextNode) {
+      return;
+    }
+  }
+
+  /*
+   * If the node contains children nodes, we don't want to disable checks for them.
+   * We want to keep it exclusively to the tag itself.
+   */
+  if ('blockStartPosition' in nextNode) {
+    return nextNode.blockStartPosition;
+  }
+
+  return nextNode.position;
+}
+
+function getNextNode(
+  parentNode: LiquidHtmlNode | undefined,
+  node: LiquidHtmlNode,
+): LiquidHtmlNode | undefined {
+  if (!parentNode) {
+    return;
+  }
+
+  let siblingNodes: LiquidHtmlNode[] = [];
+
+  // Could be sibling nodes within a `liquid` tag
+  if (parentNode.type === LiquidHtmlNodeTypes.LiquidTag && Array.isArray(parentNode.markup)) {
+    siblingNodes = parentNode.markup;
+  } else if ('children' in parentNode) {
+    siblingNodes = parentNode.children || [];
+  }
+
+  const currentNodeIdx = siblingNodes.findIndex((c) => c === node);
+
+  if (currentNodeIdx === -1) return;
+
+  const nextNode = siblingNodes.at(currentNodeIdx + 1);
+
+  return nextNode;
 }


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/theme-tools/issues/788

Thank you @graygilmore for doing the [preliminary work](https://github.com/Shopify/theme-tools/pull/796) on exploring how to disable checks ❤️

NOTE: This *DOES NOT* work for LiquidDoc because the content inside is considered "raw" (like `raw` tag). This is a known issue.

## Tophat

- Try to disable a theme check using many techniques

Inside `liquid` tag
```
{% liquid
  # theme-check-disable-next-line UnusedAssign
  assign prod = 'prod'
%}
```

HTML with Liquid
```
{% # theme-check-disable-next-line %}
<div class="{{ fff }}">
  <div class="{{ fff }}"></div>
</div>
```

Multiline statement:
```
{% # theme-check-disable-next-line %}
{% content_for 'block',
  type: 'swatches',
  id: 'fake-7',
  my_string: product.title,
  not_a_arg: product.title,
  closest.product: product,
  closest.article: article
%}
```


## What's next? Any followup issues?

- need to update dev docs for this feature

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
