### PR TITLE
[BugFix] Update `doc` tag code completion template

### DIFF
--- a/.changeset/honest-queens-lie.md
+++ b/.changeset/honest-queens-lie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+[BugFix] Update `doc` tag code completion template

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
@@ -3,8 +3,6 @@ import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
 import { MetafieldDefinitionMap, TagEntry } from '@shopify/theme-check-common';
 import { InsertTextFormat, InsertTextMode, TextEdit } from 'vscode-languageserver-protocol';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { CURSOR } from '../params';
 
 const caseSyntax = `{% case variable %}
   {% when first_value %}
@@ -76,6 +74,7 @@ export const tags: TagEntry[] = [
     ],
   },
   { name: 'echo' },
+  { name: 'doc' },
 ];
 
 describe('Module: LiquidTagsCompletionProvider', async () => {
@@ -102,6 +101,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
     await expect(provider).to.complete('{% ren', ['render']);
     await expect(provider).to.complete('{% rend', ['render']);
     await expect(provider).to.complete('{% fo', ['for']);
+    await expect(provider).to.complete('{% d', ['doc']);
   });
 
   it('should complete end tags with the correct thing', async () => {

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.ts
@@ -327,6 +327,8 @@ function toSnippet(tag: TagEntry) {
       return '{% elsif ${1:condition} %}';
     case 'else':
       return '{% else %}';
+    case 'doc':
+      return '{% doc %}\n  $0\n{% enddoc %}';
   }
 
   if (tag.syntax) {


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/developer-tools-team/issues/691

- Bug Fix: When you code complete `doc` tag, it does not place all of the example code in the docs as content

NOTE: There is a bug where `enddoc` does not code complete and this is known. This is a limitation on how our ohm rules are written.

## Tophat

- checkout this code
- `yarn install & yarn build`
- F5
- Create a block/snippet and attempt to add `doc` tag
  - If you select it from the dropdown, it should code complete the tag + it's associated end tag. The cursor should be in the middle of the `doc` tag
  - If you type `@`, it should code complete with `@param`, `@description`, and `@example` without forcing code completion using `ctrl + space`

## Release
- [x] I included a patch bump `changeset`


<video src="https://github.com/user-attachments/assets/8a87a27e-4014-4b35-b072-7e745eaa77eb" />
