### PR TITLE
No longer lint global objects as invalid parameters in the `ValidDocParamNames` check

### DIFF
--- a/.changeset/nice-masks-rhyme.md
+++ b/.changeset/nice-masks-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+No longer lint global objects as invalid parameters in the `ValidDocParamNames` check

--- a/packages/theme-check-common/src/checks/valid-doc-param-names/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-doc-param-names/index.spec.ts
@@ -42,20 +42,4 @@ describe('Module: ValidDocParamNames', () => {
 
     expect(offenses).to.have.length(0);
   });
-
-  it('should report a warning when a doc param shares a name with a liquid tag', async () => {
-    const sourceCode = `
-      {% doc %}
-        @param param1 - Example param
-        @param product - Example param
-      {% enddoc %}
-    `;
-
-    const offenses = await runLiquidCheck(ValidDocParamNames, sourceCode);
-
-    expect(offenses).to.have.length(1);
-    expect(offenses[0].message).to.equal(
-      "The parameter 'product' shares the same name with a global liquid object.",
-    );
-  });
 });

--- a/packages/theme-check-common/src/checks/valid-doc-param-names/index.ts
+++ b/packages/theme-check-common/src/checks/valid-doc-param-names/index.ts
@@ -1,5 +1,5 @@
 import { TextNode } from '@shopify/liquid-html-parser';
-import { LiquidCheckDefinition, ObjectEntry, Severity, SourceCodeType } from '../../types';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 
 export const ValidDocParamNames: LiquidCheckDefinition = {
   meta: {
@@ -19,34 +19,17 @@ export const ValidDocParamNames: LiquidCheckDefinition = {
 
   create(context) {
     const tagsPromise = context.themeDocset?.tags();
-    const objectsPromise = context.themeDocset?.objects();
-
-    function isGlobal(object: ObjectEntry) {
-      return !object.access || object.access?.global === true || object.access?.template.length > 0;
-    }
 
     return {
       async LiquidDocParamNode(node) {
         const paramName = node.paramName.value;
 
         const tags = (await tagsPromise)?.map((tag) => tag.name) || [];
-        const objects =
-          (await objectsPromise)
-            ?.filter((object) => isGlobal(object))
-            .map((object) => object.name) || [];
 
         if (tags.includes(paramName)) {
           reportWarning(
             context,
             `The parameter '${paramName}' shares the same name with a liquid tag.`,
-            node.paramName,
-          );
-        }
-
-        if (objects.includes(paramName)) {
-          reportWarning(
-            context,
-            `The parameter '${paramName}' shares the same name with a global liquid object.`,
             node.paramName,
           );
         }


### PR DESCRIPTION
## What are you adding in this PR?

We've noticed that linting global object names actually limits the use of expressive naming. This limitation ends up being worse than any ambiguity the global names might cause.

This PR aims to narrow the scope of `ValidDocParamNames` so it only lints tag names.

## What's next? Any follow-up issues?

Update https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-doc-param-names

## Before you deploy

- [x] I included a patch bump `changeset`