### PR TITLE
handle static blocks in template validation

### DIFF
--- a/.changeset/rotten-dots-breathe.md
+++ b/.changeset/rotten-dots-breathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fix validation for static blocks in JSON templates

--- a/packages/theme-check-common/src/checks/json-missing-block/index.spec.ts
+++ b/packages/theme-check-common/src/checks/json-missing-block/index.spec.ts
@@ -353,7 +353,7 @@ describe('Module: JsonMissingBlock', () => {
             "name": "Static Block",
           }
           {% endschema %}
-        `
+        `,
       };
 
       const offenses = await check(theme, [JSONMissingBlock]);

--- a/packages/theme-check-common/src/checks/json-missing-block/index.spec.ts
+++ b/packages/theme-check-common/src/checks/json-missing-block/index.spec.ts
@@ -302,6 +302,63 @@ describe('Module: JsonMissingBlock', () => {
       const erroredContent = content.slice(offenses[0].start.index, offenses[0].end.index);
       expect(erroredContent).to.equal('"_private_block"');
     });
+
+    it('should not report an offense when a static block exists and is not in the block liquid schema', async () => {
+      const theme: MockTheme = {
+        'templates/product.static.json': `{
+          "sections": {
+            "custom-section": {
+              "type": "custom-section",
+              "blocks": {
+                "child_block": {
+                  "type": "text"
+                },
+                "static_block": {
+                  "type": "static_block",
+                  "static": true
+                }
+              },
+              "block_order": ["child_block"]
+            }
+          },
+          "order": ["custom-section"]
+        }`,
+        'sections/custom-section.liquid': `
+          {% schema %}
+          {
+            "name": "Custom Section",
+            "blocks": [
+              {
+                "type": "text"
+              }
+            ]
+          }
+          {% endschema %}
+        `,
+        'blocks/text.liquid': `
+        {% schema %}
+          {
+            "name": "Text Block",
+            "blocks": [
+              {
+                "type": "@theme"
+              }
+            ]
+          }
+          {% endschema %}
+        `,
+        'blocks/static_block.liquid': `
+        {% schema %}
+          {
+            "name": "Static Block",
+          }
+          {% endschema %}
+        `
+      };
+
+      const offenses = await check(theme, [JSONMissingBlock]);
+      expect(offenses).to.have.length(0);
+    });
   });
 
   describe('Edge case validation', () => {

--- a/packages/theme-check-common/src/checks/json-missing-block/missing-block-utils.ts
+++ b/packages/theme-check-common/src/checks/json-missing-block/missing-block-utils.ts
@@ -63,6 +63,7 @@ async function getThemeBlocks(
 
 async function validateBlock(
   blockType: string,
+  blockStatic: boolean,
   blockPath: JSONNode,
   ancestorType: string,
   currentPath: string[],
@@ -80,12 +81,15 @@ async function validateBlock(
       blockPath,
       context,
     );
+  } else if (blockStatic) {
+    // Static blocks are not required to be in the schema blocks array
+    return;
   } else {
     const isPrivateBlock = blockType.startsWith('_');
-    const isThemeInRootLevel = themeBlocks.includes('@theme');
-    const isPresetInRootLevel = themeBlocks.includes(blockType);
+    const schemaIncludesAtTheme = themeBlocks.includes('@theme');
+    const schemaIncludesBlockType = themeBlocks.includes(blockType);
 
-    if (!isPrivateBlock ? isPresetInRootLevel || isThemeInRootLevel : isPresetInRootLevel) {
+    if (!isPrivateBlock ? schemaIncludesBlockType || schemaIncludesAtTheme : schemaIncludesBlockType) {
       return;
     } else {
       const location = isNestedBlock(currentPath) ? 'blocks' : 'sections';
@@ -114,7 +118,7 @@ export async function getAllBlocks(
         const blockPath = nodeAtPath(ast, typePath)! as JSONNode;
 
         if (blockPath) {
-          await validateBlock(block.type, blockPath, ancestorType, currentPath, offset, context);
+          await validateBlock(block.type, block.static, blockPath, ancestorType, currentPath, offset, context);
         }
       }
 

--- a/packages/theme-check-common/src/checks/json-missing-block/missing-block-utils.ts
+++ b/packages/theme-check-common/src/checks/json-missing-block/missing-block-utils.ts
@@ -89,7 +89,9 @@ async function validateBlock(
     const schemaIncludesAtTheme = themeBlocks.includes('@theme');
     const schemaIncludesBlockType = themeBlocks.includes(blockType);
 
-    if (!isPrivateBlock ? schemaIncludesBlockType || schemaIncludesAtTheme : schemaIncludesBlockType) {
+    if (
+      !isPrivateBlock ? schemaIncludesBlockType || schemaIncludesAtTheme : schemaIncludesBlockType
+    ) {
       return;
     } else {
       const location = isNestedBlock(currentPath) ? 'blocks' : 'sections';
@@ -118,7 +120,15 @@ export async function getAllBlocks(
         const blockPath = nodeAtPath(ast, typePath)! as JSONNode;
 
         if (blockPath) {
-          await validateBlock(block.type, block.static, blockPath, ancestorType, currentPath, offset, context);
+          await validateBlock(
+            block.type,
+            block.static,
+            blockPath,
+            ancestorType,
+            currentPath,
+            offset,
+            context,
+          );
         }
       }
 


### PR DESCRIPTION
## What are you adding in this PR?

Fixes: https://github.com/Shopify/theme-tools/issues/933

As the issue says, static blocks do not need to be in the `blocks` array. In fact, they often aren't to prevent adding multiple blocks intended only to be included once.

## What's next? Any followup issues?

PR removes erroneous theme-check error in template files. However, it does not check if a static block referenced in the template is actually used by the Liquid section/block file.  New issue made: https://github.com/Shopify/theme-tools/issues/941


## Before you deploy


<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
