### PR TITLE
Allow `//`, `/*`, `*/` inside of strings in template

### DIFF
--- a/.changeset/wild-games-flow.md
+++ b/.changeset/wild-games-flow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Allow `//`, `/*`, `*/` inside of strings in template JSON

--- a/packages/theme-check-common/src/checks/json-missing-block/index.ts
+++ b/packages/theme-check-common/src/checks/json-missing-block/index.ts
@@ -24,7 +24,7 @@ export const JSONMissingBlock: JSONCheckDefinition = {
     return {
       async onCodePathEnd() {
         const schema = await getSchemaFromJSON(context);
-        const { ast, offset } = schema ?? {};
+        const { ast } = schema ?? {};
         if (!ast || ast instanceof Error) return;
         if (!schema) return;
 
@@ -41,7 +41,7 @@ export const JSONMissingBlock: JSONCheckDefinition = {
             ) {
               await getAllBlocks(
                 ast,
-                offset,
+                0,
                 section.type,
                 section.blocks,
                 ['sections', sectionKey, 'blocks'],

--- a/packages/theme-check-common/src/to-schema.ts
+++ b/packages/theme-check-common/src/to-schema.ts
@@ -199,17 +199,13 @@ export function getSchema(context: Context<SourceCodeType.LiquidHtml, Schema>) {
 
 export async function getSchemaFromJSON(context: Context<SourceCodeType.JSON, Schema>) {
   const originalSource = context.file.source;
-  const strippedSource = originalSource.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '').trim();
 
-  const offset = originalSource.indexOf(strippedSource);
-
-  const parsed = parseJSON(strippedSource);
-  const ast = toJSONAST(strippedSource);
+  const parsed = parseJSON(originalSource);
+  const ast = toJSONAST(originalSource);
 
   return {
     parsed,
     ast,
-    offset,
   };
 }
 


### PR DESCRIPTION
## What are you adding in this PR?

Resolves https://github.com/Shopify/theme-tools/issues/934

- We used to explicitly remove `/*`, `*/`, `//` characters from JSON templates because we didn't support comments
  - This was done naively so it would affect unintended areas like URL strings (e.g. `"shopify://path/to/file`)
  - We no longer have to strip out comments manually because our JSON parser can handle comments in JSON

## Tophat

- Make a theme check error inside of a template file
- Add a URL inside of a string value in the JSON
- Originally, this would invalidate the JSON, and the other theme checks would "disappear" because the entire JSON is considered invalid
- Now, the original theme check error should still appear because `//` is not considered a invalid characters

## Before you deploy

- [x] I included a patch bump `changeset`
