### PR TITLE
Display filter parameter documentation on hover

### DIFF
--- a/.changeset/gorgeous-rocks-rest.md
+++ b/.changeset/gorgeous-rocks-rest.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Display filter parameter documentation on hover

--- a/packages/theme-language-server-common/src/hover/HoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/HoverProvider.ts
@@ -12,6 +12,7 @@ import { BaseHoverProvider } from './BaseHoverProvider';
 import {
   HtmlAttributeHoverProvider,
   HtmlTagHoverProvider,
+  LiquidFilterArgumentHoverProvider,
   LiquidFilterHoverProvider,
   LiquidObjectAttributeHoverProvider,
   LiquidObjectHoverProvider,
@@ -46,6 +47,7 @@ export class HoverProvider {
       new ContentForArgumentHoverProvider(getDocDefinitionForURI),
       new ContentForTypeHoverProvider(getDocDefinitionForURI),
       new LiquidTagHoverProvider(themeDocset),
+      new LiquidFilterArgumentHoverProvider(themeDocset),
       new LiquidFilterHoverProvider(themeDocset),
       new LiquidObjectHoverProvider(typeSystem),
       new LiquidObjectAttributeHoverProvider(typeSystem),

--- a/packages/theme-language-server-common/src/hover/providers/LiquidFilterArgumentHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidFilterArgumentHoverProvider.spec.ts
@@ -1,0 +1,53 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { DocumentManager } from '../../documents';
+import { HoverProvider } from '../HoverProvider';
+import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
+
+describe('Module: LiquidFilterArgumentHoverProvider', async () => {
+  let provider: HoverProvider;
+
+  beforeEach(async () => {
+    provider = new HoverProvider(
+      new DocumentManager(),
+      {
+        filters: async () => [
+          {
+            name: 'image_url',
+            syntax: 'string | image_url',
+            description: 'image_url description',
+            parameters: [
+              {
+                name: 'width',
+                description: 'width description',
+                types: ['number'],
+                positional: false,
+                required: false,
+              },
+            ],
+            return_type: [{ type: 'string', name: '' }],
+          },
+        ],
+        objects: async () => [],
+        liquidDrops: async () => [],
+        tags: async () => [],
+        systemTranslations: async () => ({}),
+      },
+      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    );
+  });
+
+  it('should return nothing if the filter is unknown', async () => {
+    await expect(provider).to.hover(`{{ foo | not_a_filter: wid█th: 1000 }}`, null);
+  });
+
+  it('should return nothing if the parameter is unknown', async () => {
+    await expect(provider).to.hover(`{{ foo | image_url: pig█eons: 1000 }}`, null);
+  });
+
+  it('should return the hover description of parameter', async () => {
+    await expect(provider).to.hover(
+      `{{ foo | image_url: wid█th: 1000 }}`,
+      '### width\nwidth description',
+    );
+  });
+});

--- a/packages/theme-language-server-common/src/hover/providers/LiquidFilterArgumentHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidFilterArgumentHoverProvider.ts
@@ -1,0 +1,42 @@
+import { NodeTypes } from '@shopify/liquid-html-parser';
+import { LiquidHtmlNode, ThemeDocset } from '@shopify/theme-check-common';
+import { Hover } from 'vscode-languageserver';
+import { render } from '../../docset';
+import { BaseHoverProvider } from '../BaseHoverProvider';
+
+export class LiquidFilterArgumentHoverProvider implements BaseHoverProvider {
+  constructor(private themeDocset: ThemeDocset) {}
+
+  async hover(currentNode: LiquidHtmlNode, ancestors: LiquidHtmlNode[]): Promise<Hover | null> {
+    const parentNode = ancestors.at(-1);
+
+    if (
+      !parentNode ||
+      parentNode.type !== NodeTypes.LiquidFilter ||
+      currentNode.type !== NodeTypes.NamedArgument
+    ) {
+      return null;
+    }
+
+    const parentName = parentNode.name;
+    const entries = await this.themeDocset.filters();
+    const entry = entries.find((entry) => entry.name === parentName);
+
+    if (!entry) {
+      return null;
+    }
+
+    const argument = entry.parameters?.find((argument) => argument.name === currentNode.name);
+
+    if (!argument) {
+      return null;
+    }
+
+    return {
+      contents: {
+        kind: 'markdown',
+        value: render(argument, undefined, 'filter'),
+      },
+    };
+  }
+}

--- a/packages/theme-language-server-common/src/hover/providers/index.ts
+++ b/packages/theme-language-server-common/src/hover/providers/index.ts
@@ -1,5 +1,6 @@
 export { LiquidTagHoverProvider } from './LiquidTagHoverProvider';
 export { LiquidFilterHoverProvider } from './LiquidFilterHoverProvider';
+export { LiquidFilterArgumentHoverProvider } from './LiquidFilterArgumentHoverProvider';
 export { LiquidObjectHoverProvider } from './LiquidObjectHoverProvider';
 export { LiquidObjectAttributeHoverProvider } from './LiquidObjectAttributeHoverProvider';
 export { HtmlTagHoverProvider } from './HtmlTagHoverProvider';


### PR DESCRIPTION
- closes #650 

## What are you adding in this PR?

Previously hovering over [filter parameters](https://shopify.dev/docs/api/liquid/filters) (like width in `{{ product | image_url: width: 200 }}`) wouldn't display documentation. This PR adds a new hover provider to do so. 

<img width="635" alt="named-argument-hover" src="https://github.com/user-attachments/assets/e7a1fcd8-891d-4225-93ec-b99d55a44934" />

Also explored displaying parameter docs while hovering over the value, but it felt misplaced so decided against it.
<!-- Describe your changes. Provide enough context so that someone new can understand the 'why' behind this change. -->


<!-- ## What's next? Any followup issues?-->

<!-- Outline follow up tasks with links to issues so they're tracked. -->

<!-- ## What did you learn? -->

<!-- Totally optional. But... If you learned something interesting, why not share it? -->

## Before you deploy

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible 

