### PR TITLE
Completion + Hover support for presets/default section block settings

### DIFF
--- a/.changeset/quiet-clouds-push.md
+++ b/.changeset/quiet-clouds-push.md
@@ -1,0 +1,46 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Add completion + hover support for presets/default section block settings
+
+- Preset + Default block settings will pick up Section block for completion + hover support
+  - If the setting label is a translation, it will be translated during hover
+
+E.g.
+
+```
+{
+  "name": "Example Section",
+  "blocks": [
+    {
+      "type": "local_block",
+      "name": "My local block",
+      "settings": [
+        {
+          "type": "text",
+          "id": "local_block_text",
+          "label": "Local Block Text",
+          "default": "This is a block"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Preset Example Section",
+      "category": "Custom",
+      "blocks": [
+        {
+          "type": "local_block",
+          "name": "Preset Block Text",
+          "settings": {
+            // Code completion will show `local_block_text` with "Local Block Text" during hover
+            "█": ""
+          }
+        }
+      ]
+    }
+  ]
+}
+```

--- a/packages/theme-language-server-common/src/json/completions/providers/SettingsPropertyCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/SettingsPropertyCompletionProvider.ts
@@ -6,7 +6,7 @@ import { isBlockFile, isSectionFile } from '../../utils';
 import { JSONCompletionProvider } from '../JSONCompletionProvider';
 import { GetTranslationsForURI } from '../../../translations';
 import { isSectionOrBlockSchema } from './BlockTypeCompletionProvider';
-import { schemaSettingsPropertyCompletionItems } from './helpers/schemaSettings';
+import { schemaSettingsPropertyCompletionItems } from '../../schemaSettings';
 
 /**
  * The SettingsPropertyCompletionProvider offers property completions for:
@@ -62,7 +62,7 @@ export class SettingsPropertyCompletionProvider implements JSONCompletionProvide
 
     const translations = await this.getDefaultSchemaTranslations(doc.textDocument.uri);
 
-    return schemaSettingsPropertyCompletionItems(parsedSchema, translations);
+    return schemaSettingsPropertyCompletionItems(parsedSchema.settings, translations);
   }
 }
 

--- a/packages/theme-language-server-common/src/json/schemaSettings.spec.ts
+++ b/packages/theme-language-server-common/src/json/schemaSettings.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { schemaSettingsPropertyCompletionItems } from './schemaSettings';
+import { getSectionBlockByName, schemaSettingsPropertyCompletionItems } from './schemaSettings';
 
 describe('Unit: schemaSettings', () => {
   const translations = {
@@ -9,14 +9,12 @@ describe('Unit: schemaSettings', () => {
   describe('schemaSettingsPropertyCompletionItems', () => {
     it('returns completion item if setting has a valid id', () => {
       const completions = schemaSettingsPropertyCompletionItems(
-        {
-          settings: [
-            {
-              id: 'setting-id',
-              label: 'Setting Label',
-            },
-          ],
-        },
+        [
+          {
+            id: 'setting-id',
+            label: 'Setting Label',
+          },
+        ],
         translations,
       );
 
@@ -33,14 +31,13 @@ describe('Unit: schemaSettings', () => {
 
     it('returns translated completion item', () => {
       const completions = schemaSettingsPropertyCompletionItems(
-        {
-          settings: [
-            {
-              id: 'setting-id',
-              label: 't:title',
-            },
-          ],
-        },
+        [
+          {
+            id: 'setting-id',
+            label: 't:title',
+          },
+        ],
+
         translations,
       );
 
@@ -57,16 +54,50 @@ describe('Unit: schemaSettings', () => {
 
     it("does not return completion item if setting doesn't have id", () => {
       const completions = schemaSettingsPropertyCompletionItems(
-        {
-          settings: [
-            {
-              label: 'Setting Label',
-            },
-          ],
-        },
+        [
+          {
+            label: 'Setting Label',
+          },
+        ],
         translations,
       );
       expect(completions).to.have.lengthOf(0);
+    });
+  });
+
+  describe('getSectionBlockByName', () => {
+    it('does not return block if parsedSchema is empty', () => {
+      expect(getSectionBlockByName(undefined, 'block-name')).toBeUndefined();
+    });
+
+    it('does not return block if it is not a section block is empty', () => {
+      expect(
+        getSectionBlockByName(
+          {
+            blocks: [
+              {
+                type: 'block-name',
+              },
+            ],
+          },
+          'block-name',
+        ),
+      ).toBeUndefined();
+    });
+
+    it('does return block if it is a section block is empty', () => {
+      const block = {
+        type: 'block-name',
+        name: 'block name',
+      };
+      expect(
+        getSectionBlockByName(
+          {
+            blocks: [block],
+          },
+          'block-name',
+        ),
+      ).toBe(block);
     });
   });
 });

--- a/packages/theme-language-server-common/src/json/schemaSettings.ts
+++ b/packages/theme-language-server-common/src/json/schemaSettings.ts
@@ -1,15 +1,15 @@
 import { CompletionItemKind, MarkupKind } from 'vscode-json-languageservice';
-import { renderTranslation, translationValue } from '../../../../translations';
-import { Translations } from '@shopify/theme-check-common';
-import { JSONCompletionItem } from 'vscode-json-languageservice/lib/umd/jsonContributions';
+import { renderTranslation, translationValue } from '../translations';
+import { Section, Setting, Translations } from '@shopify/theme-check-common';
+import { JSONCompletionItem } from './completions/JSONCompletionProvider';
 
 export function schemaSettingsPropertyCompletionItems(
-  parsedSchema: any,
+  parsedSettings: Partial<Setting.Any>[],
   translations: Translations,
 ): JSONCompletionItem[] {
-  return parsedSchema.settings
-    .filter((setting: any) => setting.id)
-    .map((setting: any) => {
+  return parsedSettings
+    .filter((setting) => setting.id)
+    .map((setting) => {
       let docValue = '';
 
       if (setting.label) {
@@ -36,4 +36,18 @@ export function schemaSettingsPropertyCompletionItems(
         },
       };
     });
+}
+
+/*
+ * JSONCompletionProviders have to be more fault tolerant since there can be errors
+ * while typing the schema. This is why parsedSchemas (untyped) are used instead of
+ * validSchemas (typed).
+ */
+export function getSectionBlockByName(
+  parsedSchema: any = {},
+  blockName: string,
+): Partial<Section.LocalBlock> | undefined {
+  return parsedSchema.blocks
+    ?.filter((block: any) => 'name' in block)
+    ?.find((block: any) => block.type === blockName);
 }


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/theme-tools/issues/755
Allow code completion + hover for block settings referencing section blocks

## What's next? Any followup issues?

<!-- Outline follow up tasks with links to issues so they're tracked. -->

## Tophat

- Create a section with the following schema
```
{
  "name": "Example Section",
  // This is a section block - a block that is defined in the schema itself, rather than one in the `/blocks` folder
  "blocks": [
    {
      "type": "local_block",
      "name": "My local block",
      "settings": [
        {
          "type": "text",
          "id": "local_block_text",
          "label": "Local Block Text",
          "default": "This is a block"
        }
      ]
    }
  ],
  "presets": [
    {
      "name": "Preset Example Section",
      "category": "Custom",
      "blocks": [
        {
          "type": "local_block",
          "name": "Preset Block Text",
          "settings": {
            // Code completion will show `local_block_text` with "Local Block Text" during hover
            "█": ""
          }
        }
      ]
    }
  ]
}
```
- Code completion should show `local_block_text` with "Local Block Text" as description (you can force code completion + description using ctrl + space)
- Change the `settings.label` to a translation. You can do `t:` and pick any from code-completion options.
- Hover over `local_block_text` to ensure the description is translated
- Change `presets` key to `default` and remove the square brackets around the value
- Ensure code-completion + hover also works for `default`


## Before you deploy

- [x] I included a patch bump `changeset`
