### PR TITLE
Fix fun URI.parse error when root finding didn't work

### DIFF
--- a/.changeset/lucky-phones-train.md
+++ b/.changeset/lucky-phones-train.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': patch
+---
+
+Fix readDirectory issue when root finding did not work

--- a/packages/theme-check-node/src/NodeFileSystem.ts
+++ b/packages/theme-check-node/src/NodeFileSystem.ts
@@ -18,7 +18,10 @@ export const NodeFileSystem: AbstractFileSystem = {
     // console.error('fs/readDirectory', uri);
     const files = await fs.readdir(path.fsPath(uri), { withFileTypes: true });
     return files.map((file) => {
-      return [`${uri}/${file.name}`, file.isDirectory() ? FileType.Directory : FileType.File];
+      return [
+        `${uri}/${file.name}`.replace('file:////', 'file:///'), // fun edge case
+        file.isDirectory() ? FileType.Directory : FileType.File,
+      ];
     });
   },
 


### PR DESCRIPTION
We had a weird issue that made it so `rootURI` resolved to `file:///`

And when that happened the first time `readDirectory` was called on the
root, the URI would be `file:////filename`. And that 4 slash was
throwing an error

fixes #586
