### PR TITLE
Warn developers that `{% stylesheet %}` and `{% javascript %}` tags only support static content

### DIFF
--- a/.changeset/good-hornets-obey.md
+++ b/.changeset/good-hornets-obey.md
@@ -1,5 +1,6 @@
 ---
 '@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
 ---
 
 Introduce check that warn developers that `{% stylesheet %}` and `{% javascript %}` tags only support static content

--- a/.changeset/good-hornets-obey.md
+++ b/.changeset/good-hornets-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Introduce check that warn developers that `{% stylesheet %}` and `{% javascript %}` tags only support static content

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -34,6 +34,7 @@ import { SchemaPresetsStaticBlocks } from './schema-presets-static-blocks';
 import { RemoteAsset } from './remote-asset';
 import { RequiredLayoutThemeObject } from './required-layout-theme-object';
 import { ReservedDocParamNames } from './reserved-doc-param-names';
+import { StaticStylesheetAndJavascriptTags } from './static-stylesheet-and-javascript-tags';
 import { TranslationKeyExists } from './translation-key-exists';
 import { UnclosedHTMLElement } from './unclosed-html-element';
 import { UndefinedObject } from './undefined-object';
@@ -75,9 +76,9 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   CdnPreconnect,
   ContentForHeaderModification,
   DeprecateBgsizes,
+  DeprecateLazysizes,
   DeprecatedFilter,
   DeprecatedTag,
-  DeprecateLazysizes,
   DuplicateContentForArguments,
   DuplicateRenderSnippetArguments,
   EmptyBlockContent,
@@ -99,6 +100,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   RemoteAsset,
   RequiredLayoutThemeObject,
   ReservedDocParamNames,
+  StaticStylesheetAndJavascriptTags,
   TranslationKeyExists,
   UnclosedHTMLElement,
   UndefinedObject,

--- a/packages/theme-check-common/src/checks/static-stylesheet-and-javascript-tags/index.spec.ts
+++ b/packages/theme-check-common/src/checks/static-stylesheet-and-javascript-tags/index.spec.ts
@@ -1,0 +1,257 @@
+import { check, highlightedOffenses } from '../../test';
+import { expect, describe, it } from 'vitest';
+import { StaticStylesheetAndJavascriptTags } from './index';
+
+describe('Module: StaticStylesheetAndJavascriptTags', () => {
+  it('should not report errors for static CSS content in stylesheet tags', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% stylesheet %}
+          .button {
+            background-color: blue;
+            color: white;
+            padding: 10px 20px;
+          }
+        {% endstylesheet %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(0);
+  });
+
+  it('should not report errors for static JavaScript content in javascript tags', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% javascript %}
+          function greet(name) {
+            console.log('Hello, ' + name + '!');
+          }
+          greet('World');
+        {% endjavascript %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(0);
+  });
+
+  it('should report error for liquid variable in stylesheet tag', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% stylesheet %}
+          .button {
+            background-color: {{ settings.button_color }};
+            color: white;
+          }
+        {% endstylesheet %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal(
+      'Liquid variable found in CSS block. {% stylesheet %} tags should only contain static CSS code.',
+    );
+
+    const highlights = highlightedOffenses(theme, offenses);
+    expect(highlights).to.eql(['{{ settings.button_color }}']);
+  });
+
+  it('should report error for liquid variable in javascript tag', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% javascript %}
+          const apiUrl = '{{ shop.url }}';
+          fetch(apiUrl);
+        {% endjavascript %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal(
+      'Liquid variable found in JavaScript block. {% javascript %} tags should only contain static JavaScript code.',
+    );
+
+    const highlights = highlightedOffenses(theme, offenses);
+    expect(highlights).to.eql(['{{ shop.url }}']);
+  });
+
+  it('should report error for liquid tag in stylesheet tag', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% stylesheet %}
+          .button {
+            {% if settings.enable_hover %}
+              background-color: blue;
+            {% endif %}
+          }
+        {% endstylesheet %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal(
+      'Liquid tag found in CSS block. {% stylesheet %} tags should only contain static CSS code.',
+    );
+
+    const highlights = highlightedOffenses(theme, offenses);
+    expect(highlights).to.eql([
+      `{% if settings.enable_hover %}
+              background-color: blue;
+            {% endif %}`,
+    ]);
+  });
+
+  it('should report error for liquid tag in javascript tag', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% javascript %}
+          {% if settings.enable_analytics %}
+            console.log('Analytics enabled');
+          {% endif %}
+        {% endjavascript %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal(
+      'Liquid tag found in JavaScript block. {% javascript %} tags should only contain static JavaScript code.',
+    );
+
+    const highlights = highlightedOffenses(theme, offenses);
+    expect(highlights).to.eql([
+      `{% if settings.enable_analytics %}
+            console.log('Analytics enabled');
+          {% endif %}`,
+    ]);
+  });
+
+  it('should report multiple errors for multiple liquid nodes', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% stylesheet %}
+          .button {
+            background-color: {{ settings.button_color }};
+            {% if settings.show_border %}
+              border: 1px solid {{ settings.border_color }};
+            {% endif %}
+          }
+        {% endstylesheet %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(2);
+    expect(offenses[0].message).to.include('Liquid variable found in CSS block');
+    expect(offenses[1].message).to.include('Liquid tag found in CSS block');
+
+    const highlights = highlightedOffenses(theme, offenses);
+    expect(highlights).to.eql([
+      '{{ settings.button_color }}',
+      `{% if settings.show_border %}
+              border: 1px solid {{ settings.border_color }};
+            {% endif %}`,
+    ]);
+  });
+
+  it('should not report errors for other raw tags like schema', async () => {
+    const theme = {
+      'sections/test.liquid': `
+        {% schema %}
+        {
+          "name": "Section",
+          "settings": [
+            {
+              "id": "color",
+              "type": "color",
+              "default": "{{ settings.default_color }}"
+            }
+          ]
+        }
+        {% endschema %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(0);
+  });
+
+  it('should not report errors for liquid in regular content outside raw tags', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        <div style="color: {{ settings.text_color }};">
+          {% if product.available %}
+            <button>Buy now</button>
+          {% endif %}
+        </div>
+
+        {% stylesheet %}
+          .static-style {
+            margin: 10px;
+          }
+        {% endstylesheet %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(0);
+  });
+
+  it('should report nested raw tags inside stylesheet tags', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% stylesheet %}
+          /* This should trigger an error */
+          {% raw %}
+            .nested { color: red; }
+          {% endraw %}
+        {% endstylesheet %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.include('Liquid tag found in CSS block');
+
+    const highlights = highlightedOffenses(theme, offenses);
+    expect(highlights).to.eql([
+      `{% raw %}
+            .nested { color: red; }
+          {% endraw %}`,
+    ]);
+  });
+
+  it('should not report offenses for empty stylesheet and javascript blocks', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% stylesheet %}
+        {% endstylesheet %}
+
+        {% javascript %}
+        {% endjavascript %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(0);
+  });
+
+  it('should not report errors for liquid in style tags (different from stylesheet)', async () => {
+    const theme = {
+      'templates/test.liquid': `
+        {% style %}
+          .button {
+            color: {{ settings.color }};
+          }
+        {% endstyle %}
+      `,
+    };
+
+    const offenses = await check(theme, [StaticStylesheetAndJavascriptTags]);
+    expect(offenses).to.have.length(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/static-stylesheet-and-javascript-tags/index.ts
+++ b/packages/theme-check-common/src/checks/static-stylesheet-and-javascript-tags/index.ts
@@ -1,0 +1,48 @@
+import { NodeTypes } from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+
+export const StaticStylesheetAndJavascriptTags: LiquidCheckDefinition = {
+  meta: {
+    code: 'StaticStylesheetAndJavascriptTags',
+    name: 'Reports non static stylesheet and javascript tags',
+    docs: {
+      description:
+        'Reports the usage of Liquid within {% stylesheet %} and {% javascript %} tags, which should only contain static content.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/static-stylesheet-and-javascript-tags',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    return {
+      async LiquidRawTag(node) {
+        if (node.name !== 'stylesheet' && node.name !== 'javascript') {
+          return;
+        }
+
+        const liquidNodes = node.body.nodes.filter(
+          (childNode) =>
+            childNode.type === NodeTypes.LiquidVariableOutput ||
+            childNode.type === NodeTypes.LiquidTag ||
+            childNode.type === NodeTypes.LiquidRawTag,
+        );
+
+        for (const liquidNode of liquidNodes) {
+          const tagType = node.name === 'stylesheet' ? 'CSS' : 'JavaScript';
+          const liquidType =
+            liquidNode.type === NodeTypes.LiquidVariableOutput ? 'variable' : 'tag';
+
+          context.report({
+            message: `Liquid ${liquidType} found in ${tagType} block. {% ${node.name} %} tags should only contain static ${tagType} code.`,
+            startIndex: liquidNode.position.start,
+            endIndex: liquidNode.position.end,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -115,6 +115,9 @@ SchemaPresetsBlockOrder:
 SchemaPresetsStaticBlocks:
   enabled: true
   severity: 0
+StaticStylesheetAndJavascriptTags:
+  enabled: true
+  severity: 0
 TranslationKeyExists:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -93,6 +93,9 @@ SchemaPresetsBlockOrder:
 SchemaPresetsStaticBlocks:
   enabled: true
   severity: 0
+StaticStylesheetAndJavascriptTags:
+  enabled: true
+  severity: 0
 TranslationKeyExists:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?

Using Liquid code inside `{% stylesheet %}` or `{% javascript %}` tags, as shown below, is not allowed:

```liquid
{% stylesheet %}
  .button {
    background-color: {{ settings.button_color }};
    color: white;
  }
{% endstylesheet %}
```

This is a common and easy mistake to make, so adding linting will help developers quickly catch and address this issue.

![image](https://github.com/user-attachments/assets/6d731bf5-339c-46b8-85b6-941dcc03765a)

## What's next? Any follow-up issues?

After this PR is merged, I will create the corresponding documentation page on shopify.dev.

## Before you deploy

<!-- Check changes -->
- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config
  - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (I'm working on that)

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`