### PR TITLE
Fix ValidBlockTarget for blocks in `default` and `presets`

### DIFF
--- a/.changeset/many-planets-behave.md
+++ b/.changeset/many-planets-behave.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fix ValidBlockTarget for blocks in `default` and `presets`
+
+- Solves issue so nested blocks inside of `presets` are now validated
+- Solves issue so block types inside of `default` are now validated

--- a/packages/theme-check-common/src/checks/valid-block-target/index.ts
+++ b/packages/theme-check-common/src/checks/valid-block-target/index.ts
@@ -1,12 +1,20 @@
 import { nodeAtPath } from '../../json';
 import { getSchema } from '../../to-schema';
-import { LiquidCheckDefinition, LiteralNode, Severity, SourceCodeType } from '../../types';
+import {
+  LiquidCheckDefinition,
+  LiteralNode,
+  Section,
+  Severity,
+  SourceCodeType,
+  ThemeBlock,
+} from '../../types';
 import {
   getBlocks,
   reportWarning,
   validateBlockFileExistence,
   validateNestedBlocks,
   isInvalidPresetBlock,
+  isInvalidDefaultBlock,
 } from '../../utils';
 
 export const ValidBlockTarget: LiquidCheckDefinition = {
@@ -38,8 +46,12 @@ export const ValidBlockTarget: LiquidCheckDefinition = {
         if (!schema) return;
         const { staticBlockDefs } = schema;
 
-        const { rootLevelThemeBlocks, rootLevelLocalBlocks, presetLevelBlocks } =
-          getBlocks(validSchema);
+        const {
+          rootLevelThemeBlocks,
+          rootLevelLocalBlocks,
+          presetLevelBlocks,
+          defaultLevelBlocks,
+        } = getBlocks(validSchema);
 
         if (rootLevelLocalBlocks.length > 0) return;
 
@@ -50,19 +62,13 @@ export const ValidBlockTarget: LiquidCheckDefinition = {
             const exists = await validateBlockFileExistence(node.type, context);
             if (!exists) {
               errorsInRootLevelBlocks = true;
-              reportWarning(
-                `Theme block 'blocks/${node.type}.liquid' does not exist.`,
-                offset,
-                typeNode,
-                context,
-              );
+              reportWarning(blockDoesNotExistError(node.type), offset, typeNode, context);
             }
           }),
         );
 
         if (errorsInRootLevelBlocks) return;
 
-        let errorsInPresetLevelBlocks = false;
         for (const [depthStr, blocks] of Object.entries(presetLevelBlocks)) {
           const depth = parseInt(depthStr, 10);
 
@@ -71,51 +77,66 @@ export const ValidBlockTarget: LiquidCheckDefinition = {
               blocks.map(async ({ node, path }) => {
                 const typeNode = nodeAtPath(ast, path)! as LiteralNode;
                 const blockId = 'id' in node ? node.id! : path.at(-2)!;
-                const isPrivateBlockType = node.type.startsWith('_');
                 const isStaticBlock = !!node.static;
 
                 if (isInvalidPresetBlock(blockId, node, rootLevelThemeBlocks, staticBlockDefs)) {
-                  errorsInPresetLevelBlocks = true;
                   const errorMessage = isStaticBlock
                     ? `Could not find a static block of type "${node.type}" with id "${blockId}" in this file.`
-                    : isPrivateBlockType
-                    ? `Theme block type "${node.type}" is a private block so it must be explicitly allowed in "blocks" at the root of this schema.`
-                    : `Theme block type "${node.type}" must be allowed in "blocks" at the root of this schema.`;
+                    : reportMissingThemeBlockDefinitionError(node);
                   reportWarning(errorMessage, offset, typeNode, context);
                 }
 
-                if ('blocks' in node && node.blocks) {
-                  await validateNestedBlocks(
-                    context,
-                    node,
-                    node.blocks,
-                    path.slice(0, -1),
-                    offset,
-                    ast,
-                  );
-                }
-              }),
-            );
-          }
-
-          if (!errorsInPresetLevelBlocks) {
-            await Promise.all(
-              blocks.map(async ({ node, path }) => {
-                const typeNode = nodeAtPath(ast, path)! as LiteralNode;
                 const exists = await validateBlockFileExistence(node.type, context);
-                if (!exists) {
-                  reportWarning(
-                    `Theme block 'blocks/${node.type}.liquid' does not exist.`,
-                    offset,
-                    typeNode,
-                    context,
-                  );
+                if (exists) {
+                  if ('blocks' in node && node.blocks) {
+                    await validateNestedBlocks(
+                      context,
+                      node,
+                      node.blocks,
+                      path.slice(0, -1),
+                      offset,
+                      ast,
+                    );
+                  }
+                } else {
+                  reportWarning(blockDoesNotExistError(node.type), offset, typeNode, context);
                 }
               }),
             );
           }
         }
+
+        await Promise.all(
+          defaultLevelBlocks.map(async ({ node, path }) => {
+            const typeNode = nodeAtPath(ast, path)! as LiteralNode;
+
+            if (isInvalidDefaultBlock(node, rootLevelThemeBlocks)) {
+              reportWarning(
+                reportMissingThemeBlockDefinitionError(node),
+                offset,
+                typeNode,
+                context,
+              );
+            }
+
+            const exists = await validateBlockFileExistence(node.type, context);
+            if (!exists) {
+              reportWarning(blockDoesNotExistError(node.type), offset, typeNode, context);
+            }
+          }),
+        );
       },
     };
   },
 };
+
+function reportMissingThemeBlockDefinitionError(node: Section.Block | ThemeBlock.Block) {
+  const isPrivateBlockType = node.type.startsWith('_');
+  return isPrivateBlockType
+    ? `Theme block type "${node.type}" is a private block so it must be explicitly allowed in "blocks" at the root of this schema.`
+    : `Theme block type "${node.type}" must be allowed in "blocks" at the root of this schema.`;
+}
+
+function blockDoesNotExistError(name: string) {
+  return `Theme block 'blocks/${name}.liquid' does not exist.`;
+}


### PR DESCRIPTION
## What are you adding in this PR?

Closes https://github.com/Shopify/theme-tools/issues/751

Solves two separate issues
- `presets` block
  - Did not show an error when the nested block does not exist (see tophat section)
- `default` block
  - Did not show an error when the block does not exist
  - Did not show an error when the block in default is a private block, but `"blocks": [{ "type": "@theme"}]` is enabled in the top-level schema

## Tophat

In the examples below:
- `nested-non-existent`, `_meadow`, `non-existent`, and `_private_and_non_existent` blocks do not exist in blocks folder
- `demo` and `nested-demo` blocks do exist

The schema in the section containing the following code looks like this:
```
{% schema %}
{
  "name": "Demo Section",
  "blocks": [{ "type": "@theme" }],
  "presets": [
    {
      // presets code goes here
    }
  ],
  "default": {
    // default code goes here
  },
}
{% endschema %}
```

| Before | After |
| - | - |
| <img width="343" alt="image" src="https://github.com/user-attachments/assets/f0ecb143-3d7f-4626-ad87-c4536f393f3b" /> | <img width="328" alt="image" src="https://github.com/user-attachments/assets/482fc2b2-6988-4cba-bdfe-a5bef539329d" /> |
| <img width="440" alt="image" src="https://github.com/user-attachments/assets/5ed99367-8e66-461c-92f6-56634c3f26aa" /> | <img width="440" alt="image" src="https://github.com/user-attachments/assets/2a2f70f4-bec3-4888-bc2a-1a23ac38e372" /> |

## Before you deploy

- [x] I included a patch bump `changeset`
