### PR TITLE
Normalize URIs sent to language server by ReferencesProvider

### DIFF
--- a/.changeset/dry-seahorses-walk.md
+++ b/.changeset/dry-seahorses-walk.md
@@ -1,0 +1,5 @@
+---
+'theme-check-vscode': patch
+---
+
+Fix URI normalization bug in ReferencesProvider

--- a/packages/vscode-extension/src/common/ReferencesProvider.ts
+++ b/packages/vscode-extension/src/common/ReferencesProvider.ts
@@ -99,12 +99,13 @@ export class ReferencesProvider implements TreeDataProvider<TreeItem> {
   }
 
   public async refresh() {
-    const uri = window.activeTextEditor?.document.uri.toString();
-    if (!uri) {
+    const activeDocument = window.activeTextEditor?.document;
+    if (!activeDocument) {
       this.references = [ReferencesProvider.SelectFileTreeItem];
       return;
     }
 
+    const uri = path.normalize(activeDocument.uri.toString(true));
     this.references = [ReferencesProvider.LoadingTreeItem(path.basename(uri), this.mode)];
 
     const command =


### PR DESCRIPTION
URI encoding made it so graph.modules[uri] was returning undefined
when it shouldn't have.
