### PR TITLE
Gracefully handle files that are not from a theme

### DIFF
--- a/.changeset/violet-cycles-yawn.md
+++ b/.changeset/violet-cycles-yawn.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-language-server-node': patch
+'@shopify/theme-check-common': patch
+'theme-check-vscode': patch
+---
+
+Gracefully handle files that are not part of a theme

--- a/packages/theme-check-common/src/checks/valid-visible-if/visible-if-utils.ts
+++ b/packages/theme-check-common/src/checks/valid-visible-if/visible-if-utils.ts
@@ -1,13 +1,6 @@
-import {
-  type LiquidVariableLookup,
-  toLiquidHtmlAST,
-  NodeTypes,
-  LiquidVariableOutput,
-} from '@shopify/liquid-html-parser';
+import { type LiquidVariableLookup, NodeTypes, toLiquidHtmlAST } from '@shopify/liquid-html-parser';
 import { Context, SourceCodeType } from '../..';
-import { findRoot } from '../../find-root';
 import { parseJSON } from '../../json';
-import { join } from '../../path';
 import { visit } from '../../visitor';
 
 export type Vars = { [key: string]: Vars | true };
@@ -140,11 +133,8 @@ export async function getGlobalSettings(context: Context<SourceCodeType>) {
   const globalSettings: string[] = [];
 
   try {
-    const path = join(
-      await findRoot(context.file.uri, context.fileExists),
-      'config/settings_schema.json',
-    );
-    const settingsFile = await context.fs.readFile(path);
+    const uri = context.toUri('config/settings_schema.json');
+    const settingsFile = await context.fs.readFile(uri);
     const settings = parseJSON(settingsFile);
     if (Array.isArray(settings)) {
       for (const group of settings) {

--- a/packages/theme-check-common/src/index.ts
+++ b/packages/theme-check-common/src/index.ts
@@ -144,7 +144,7 @@ function createContext<T extends SourceCodeType, S extends Schema>(
     ...dependencies,
     validateJSON,
     settings: createSettings(checkSettings, check.meta.schema),
-    toUri: (relativePath) => path.join(config.rootUri, relativePath),
+    toUri: (relativePath) => path.join(config.rootUri, ...relativePath.split('/')),
     toRelativePath: (uri) => path.relative(uri, config.rootUri),
     report(problem: Problem<T>): void {
       offenses.push({

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -75,7 +75,7 @@ export async function check(
   const isValidSchema = async () => true;
 
   const defaultMockDependencies: Dependencies = {
-    fs: new MockFileSystem(themeDesc),
+    fs: new MockFileSystem({ '.theme-check.yml': '', ...themeDesc }),
     async getBlockSchema(name) {
       const block = blocks.get(name);
       if (!block) return undefined;

--- a/packages/theme-check-node/src/find-root.spec.ts
+++ b/packages/theme-check-node/src/find-root.spec.ts
@@ -4,6 +4,10 @@ import { NodeFileSystem } from './NodeFileSystem';
 import { makeTempWorkspace, Workspace } from './test/test-helpers';
 
 const theme = {
+  assets: {
+    'theme.js': '',
+    'theme.css': '',
+  },
   locales: {
     'en.default.json': JSON.stringify({ beverage: 'coffee' }),
     'fr.json': '{}',

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -43,7 +43,7 @@ export function makeRunChecks(
     // then we recheck theme1
     const fileExists = makeFileExists(fs);
     const rootURIs = await Promise.all(triggerURIs.map((uri) => findRoot(uri, fileExists)));
-    const deduplicatedRootURIs = new Set(rootURIs);
+    const deduplicatedRootURIs = new Set<string>(rootURIs.filter((x): x is string => !!x));
     await Promise.all([...deduplicatedRootURIs].map(runChecksForRoot));
 
     return;

--- a/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.ts
+++ b/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.ts
@@ -4,13 +4,14 @@ import { DocumentLink, Range } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI, Utils } from 'vscode-uri';
 
-import { DocumentManager } from '../documents';
 import { visit, Visitor } from '@shopify/theme-check-common';
+import { DocumentManager } from '../documents';
+import { FindThemeRootURI } from '../internal-types';
 
 export class DocumentLinksProvider {
   constructor(
     private documentManager: DocumentManager,
-    private findThemeRootURI: (uri: string) => Promise<string>,
+    private findThemeRootURI: FindThemeRootURI,
   ) {}
 
   async documentLinks(uriString: string): Promise<DocumentLink[]> {
@@ -24,6 +25,10 @@ export class DocumentLinksProvider {
     }
 
     const rootUri = await this.findThemeRootURI(uriString);
+    if (!rootUri) {
+      return [];
+    }
+
     const visitor = documentLinksVisitor(sourceCode.textDocument, URI.parse(rootUri));
     return visit(sourceCode.ast, visitor);
   }

--- a/packages/theme-language-server-common/src/internal-types.ts
+++ b/packages/theme-language-server-common/src/internal-types.ts
@@ -1,0 +1,1 @@
+export type FindThemeRootURI = (uri: string) => Promise<string | null>;

--- a/packages/theme-language-server-common/src/rename/RenameProvider.ts
+++ b/packages/theme-language-server-common/src/rename/RenameProvider.ts
@@ -14,6 +14,7 @@ import { HtmlTagNameRenameProvider } from './providers/HtmlTagNameRenameProvider
 import { LiquidVariableRenameProvider } from './providers/LiquidVariableRenameProvider';
 import { Connection } from 'vscode-languageserver';
 import { ClientCapabilities } from '../ClientCapabilities';
+import { FindThemeRootURI } from '../internal-types';
 
 /**
  * RenameProvider is responsible for providing rename support for the theme language server.
@@ -27,7 +28,7 @@ export class RenameProvider {
     connection: Connection,
     clientCapabilities: ClientCapabilities,
     private documentManager: DocumentManager,
-    findThemeRootURI: (uri: string) => Promise<string>,
+    findThemeRootURI: FindThemeRootURI,
   ) {
     this.providers = [
       new HtmlTagNameRenameProvider(documentManager),

--- a/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.ts
+++ b/packages/theme-language-server-common/src/rename/providers/LiquidVariableRenameProvider.ts
@@ -1,18 +1,17 @@
-import { BaseRenameProvider } from '../BaseRenameProvider';
-import { AugmentedLiquidSourceCode, DocumentManager, isLiquidSourceCode } from '../../documents';
 import {
+  AssignMarkup,
+  ForMarkup,
   LiquidHtmlNode,
   LiquidTagFor,
   LiquidTagTablerow,
+  LiquidVariableLookup,
   NamedTags,
   NodeTypes,
   Position,
   RenderMarkup,
-  AssignMarkup,
   TextNode,
-  LiquidVariableLookup,
-  ForMarkup,
 } from '@shopify/liquid-html-parser';
+import { JSONNode, SourceCodeType, visit } from '@shopify/theme-check-common';
 import { Connection, Range } from 'vscode-languageserver';
 import {
   ApplyWorkspaceEditRequest,
@@ -24,16 +23,18 @@ import {
   WorkspaceEdit,
 } from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { JSONNode, SourceCodeType, visit } from '@shopify/theme-check-common';
-import { snippetName } from '../../utils/uri';
 import { ClientCapabilities } from '../../ClientCapabilities';
+import { AugmentedLiquidSourceCode, DocumentManager, isLiquidSourceCode } from '../../documents';
+import { FindThemeRootURI } from '../../internal-types';
+import { snippetName } from '../../utils/uri';
+import { BaseRenameProvider } from '../BaseRenameProvider';
 
 export class LiquidVariableRenameProvider implements BaseRenameProvider {
   constructor(
     private connection: Connection,
     private clientCapabilities: ClientCapabilities,
     private documentManager: DocumentManager,
-    private findThemeRootURI: (uri: string) => Promise<string>,
+    private findThemeRootURI: FindThemeRootURI,
   ) {}
 
   async prepare(
@@ -71,7 +72,7 @@ export class LiquidVariableRenameProvider implements BaseRenameProvider {
     const rootUri = await this.findThemeRootURI(params.textDocument.uri);
     const textDocument = document?.textDocument;
 
-    if (!textDocument || !node || !ancestors) return null;
+    if (!rootUri || !textDocument || !node || !ancestors) return null;
     if (document.ast instanceof Error) return null;
     if (!supportedTags(node, ancestors)) return null;
 

--- a/packages/theme-language-server-common/src/renamed/RenameHandler.ts
+++ b/packages/theme-language-server-common/src/renamed/RenameHandler.ts
@@ -2,11 +2,12 @@ import { Connection } from 'vscode-languageserver';
 import { RenameFilesParams } from 'vscode-languageserver-protocol';
 import { ClientCapabilities } from '../ClientCapabilities';
 import { DocumentManager } from '../documents';
+import { FindThemeRootURI } from '../internal-types';
 import { BaseRenameHandler } from './BaseRenameHandler';
 import { AssetRenameHandler } from './handlers/AssetRenameHandler';
 import { BlockRenameHandler } from './handlers/BlockRenameHandler';
-import { SnippetRenameHandler } from './handlers/SnippetRenameHandler';
 import { SectionRenameHandler } from './handlers/SectionRenameHandler';
+import { SnippetRenameHandler } from './handlers/SnippetRenameHandler';
 
 /**
  * The RenameHandler is responsible for handling workspace/didRenameFiles notifications.
@@ -22,7 +23,7 @@ export class RenameHandler {
     connection: Connection,
     capabilities: ClientCapabilities,
     documentManager: DocumentManager,
-    findThemeRootURI: (uri: string) => Promise<string>,
+    findThemeRootURI: FindThemeRootURI,
   ) {
     this.handlers = [
       new SnippetRenameHandler(documentManager, connection, capabilities, findThemeRootURI),

--- a/packages/theme-language-server-common/src/renamed/handlers/AssetRenameHandler.ts
+++ b/packages/theme-language-server-common/src/renamed/handlers/AssetRenameHandler.ts
@@ -12,6 +12,7 @@ import { ClientCapabilities } from '../../ClientCapabilities';
 import { DocumentManager, isLiquidSourceCode } from '../../documents';
 import { assetName, isAsset } from '../../utils/uri';
 import { BaseRenameHandler } from '../BaseRenameHandler';
+import { FindThemeRootURI } from '../../internal-types';
 
 /**
  * The AssetRenameHandler will handle asset renames.
@@ -30,7 +31,7 @@ export class AssetRenameHandler implements BaseRenameHandler {
     private documentManager: DocumentManager,
     private connection: Connection,
     private capabilities: ClientCapabilities,
-    private findThemeRootURI: (uri: string) => Promise<string>,
+    private findThemeRootURI: FindThemeRootURI,
   ) {}
 
   async onDidRenameFiles(params: RenameFilesParams): Promise<void> {
@@ -44,6 +45,7 @@ export class AssetRenameHandler implements BaseRenameHandler {
     if (relevantRenames.length !== 1) return;
     const rename = relevantRenames[0];
     const rootUri = await this.findThemeRootURI(path.dirname(params.files[0].oldUri));
+    if (!rootUri) return;
     await this.documentManager.preload(rootUri);
     const theme = this.documentManager.theme(rootUri, true);
     const liquidSourceCodes = theme.filter(isLiquidSourceCode);

--- a/packages/theme-language-server-common/src/renamed/handlers/BlockRenameHandler.ts
+++ b/packages/theme-language-server-common/src/renamed/handlers/BlockRenameHandler.ts
@@ -36,6 +36,7 @@ import {
 import { blockName, isBlock, isSection, isSectionGroup, isTemplate } from '../../utils/uri';
 import { BaseRenameHandler } from '../BaseRenameHandler';
 import { isValidSectionGroup, isValidTemplate } from './utils';
+import { FindThemeRootURI } from '../../internal-types';
 
 type DocumentChange = TextDocumentEdit;
 
@@ -69,7 +70,7 @@ export class BlockRenameHandler implements BaseRenameHandler {
     private documentManager: DocumentManager,
     private connection: Connection,
     private capabilities: ClientCapabilities,
-    private findThemeRootURI: (uri: string) => Promise<string>,
+    private findThemeRootURI: FindThemeRootURI,
   ) {}
 
   async onDidRenameFiles(params: RenameFilesParams): Promise<void> {
@@ -83,6 +84,7 @@ export class BlockRenameHandler implements BaseRenameHandler {
     if (relevantRenames.length !== 1) return;
     const rename = relevantRenames[0];
     const rootUri = await this.findThemeRootURI(path.dirname(params.files[0].oldUri));
+    if (!rootUri) return;
     await this.documentManager.preload(rootUri);
     const theme = this.documentManager.theme(rootUri, true);
     const liquidFiles = theme.filter(isLiquidSourceCode);

--- a/packages/theme-language-server-common/src/renamed/handlers/SectionRenameHandler.ts
+++ b/packages/theme-language-server-common/src/renamed/handlers/SectionRenameHandler.ts
@@ -27,6 +27,7 @@ import {
   isJsonSourceCode,
   isLiquidSourceCode,
 } from '../../documents';
+import { FindThemeRootURI } from '../../internal-types';
 import { isSection, isSectionGroup, isTemplate, sectionName } from '../../utils/uri';
 import { BaseRenameHandler } from '../BaseRenameHandler';
 import { isValidSectionGroup, isValidTemplate } from './utils';
@@ -48,7 +49,7 @@ export class SectionRenameHandler implements BaseRenameHandler {
     private documentManager: DocumentManager,
     private connection: Connection,
     private capabilities: ClientCapabilities,
-    private findThemeRootURI: (uri: string) => Promise<string>,
+    private findThemeRootURI: FindThemeRootURI,
   ) {}
 
   async onDidRenameFiles(params: RenameFilesParams): Promise<void> {
@@ -62,6 +63,7 @@ export class SectionRenameHandler implements BaseRenameHandler {
     if (relevantRenames.length !== 1) return;
     const rename = relevantRenames[0];
     const rootUri = await this.findThemeRootURI(path.dirname(params.files[0].oldUri));
+    if (!rootUri) return;
     await this.documentManager.preload(rootUri);
     const theme = this.documentManager.theme(rootUri, true);
     const liquidFiles = theme.filter(isLiquidSourceCode);

--- a/packages/theme-language-server-common/src/renamed/handlers/SnippetRenameHandler.ts
+++ b/packages/theme-language-server-common/src/renamed/handlers/SnippetRenameHandler.ts
@@ -12,6 +12,7 @@ import { ClientCapabilities } from '../../ClientCapabilities';
 import { DocumentManager, isLiquidSourceCode } from '../../documents';
 import { isSnippet, snippetName } from '../../utils/uri';
 import { BaseRenameHandler } from '../BaseRenameHandler';
+import { FindThemeRootURI } from '../../internal-types';
 
 /**
  * The SnippetRenameHandler will handle snippet renames.
@@ -30,7 +31,7 @@ export class SnippetRenameHandler implements BaseRenameHandler {
     private documentManager: DocumentManager,
     private connection: Connection,
     private capabilities: ClientCapabilities,
-    private findThemeRootURI: (uri: string) => Promise<string>,
+    private findThemeRootURI: FindThemeRootURI,
   ) {}
 
   async onDidRenameFiles(params: RenameFilesParams): Promise<void> {
@@ -43,6 +44,7 @@ export class SnippetRenameHandler implements BaseRenameHandler {
     if (relevantRenames.length !== 1) return;
     const rename = relevantRenames[0];
     const rootUri = await this.findThemeRootURI(path.dirname(params.files[0].oldUri));
+    if (!rootUri) return;
     await this.documentManager.preload(rootUri);
     const theme = this.documentManager.theme(rootUri, true);
     const liquidSourceCodes = theme.filter(isLiquidSourceCode);

--- a/packages/theme-language-server-common/src/server/ThemeGraphManager.ts
+++ b/packages/theme-language-server-common/src/server/ThemeGraphManager.ts
@@ -25,6 +25,7 @@ import {
   ThemeGraphDidUpdateNotification,
 } from '../types';
 import { debounce } from '../utils';
+import { FindThemeRootURI } from '../internal-types';
 
 export class ThemeGraphManager {
   graphs: Map<string, ReturnType<typeof buildThemeGraph>> = new Map();
@@ -33,11 +34,15 @@ export class ThemeGraphManager {
     private connection: Connection,
     private documentManager: DocumentManager,
     private fs: AbstractFileSystem,
-    private findThemeRootURI: (uri: string) => Promise<string>,
+    private findThemeRootURI: FindThemeRootURI,
   ) {}
 
   async getThemeGraphForURI(uri: string) {
     const rootUri = await this.findThemeRootURI(uri);
+    if (!rootUri) {
+      return undefined;
+    }
+
     if (!this.graphs.has(rootUri)) {
       this.graphs.set(rootUri, this.buildThemeGraph(rootUri));
     }
@@ -199,6 +204,8 @@ export class ThemeGraphManager {
 
     const anyUri = operations[0];
     const rootUri = await this.findThemeRootURI(anyUri);
+    if (!rootUri) return;
+
     const graph = await this.graphs.get(rootUri);
     if (!graph) return;
 

--- a/packages/theme-language-server-common/src/server/startServer.spec.ts
+++ b/packages/theme-language-server-common/src/server/startServer.spec.ts
@@ -58,7 +58,7 @@ describe('Module: server', () => {
       }
     });
 
-    fileTree = { 'snippets/code.liquid': fileContents };
+    fileTree = { '.theme-check.yml': '', 'snippets/code.liquid': fileContents };
     logger = vi.fn();
     dependencies = getDependencies(logger, fileTree);
 

--- a/packages/theme-language-server-node/src/dependencies.ts
+++ b/packages/theme-language-server-node/src/dependencies.ts
@@ -31,7 +31,12 @@ const hasThemeAppExtensionConfig = async (rootUri: string, fs: AbstractFileSyste
 export const loadConfig: Dependencies['loadConfig'] = async function loadConfig(uriString, fs) {
   const fileUri = path.normalize(uriString);
   const fileExists = makeFileExists(fs);
-  const rootUri = URI.parse(await findRoot(fileUri, fileExists));
+  const rootUriString = await findRoot(fileUri, fileExists);
+  if (!rootUriString) {
+    throw new Error(`Could not find theme root for ${fileUri}`);
+  }
+
+  const rootUri = URI.parse(rootUriString);
   const scheme = rootUri.scheme;
   const configUri = Utils.joinPath(rootUri, '.theme-check.yml');
   const [configExists, isDefinitelyThemeAppExtension] = await Promise.all([

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -40,6 +40,7 @@ This VS Code extensions comes with batteries included.
 - `"themeCheck.checkOnOpen": boolean`, (default: `true`) makes it so theme check runs on file open.
 - `"themeCheck.checkOnChange": boolean`, (default: `true`) makes it so theme check runs on file change.
 - `"themeCheck.checkOnSave": boolean`, (default: `true`) makes it so theme check runs on file save.
+- `"themeCheck.preloadOnBoot": boolean`, (default: `true`) makes it so all files are preloaded on extension activation.
 
 ## License
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -145,6 +145,13 @@
           ],
           "description": "When true, theme check runs on file save.",
           "default": true
+        },
+        "themeCheck.preloadOnBoot": {
+          "type": [
+            "boolean"
+          ],
+          "description": "When true, theme check preloads all the files from your theme for fast rename handling and theme graph generation.",
+          "default": true
         }
       }
     },

--- a/packages/vscode-extension/src/browser/server.ts
+++ b/packages/vscode-extension/src/browser/server.ts
@@ -34,6 +34,10 @@ const dependencies: Dependencies = {
   loadConfig: async (uri, fs) => {
     const fileExists = makeFileExists(fs);
     const rootUri = await findRoot(uri, fileExists);
+    if (!rootUri) {
+      throw new Error(`Could not find theme root for ${uri}`);
+    }
+
     return {
       context: 'theme',
       settings: {},


### PR DESCRIPTION
Make findThemeRootURI return null when it can't find a root

Make everywhere handle null when no root is found

Should fix "preloading" of theme when looking at `$HOME/Library/Application Support/Code/User/settings.json`

Also, `snippets` can be found in `$HOME/Library/Application Support/Code/User` and is a VS Code-owned, non theme thing. So had to modify the findRoot algo to search for assets _and_ snippets folder existence.

Fixes #973

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`
