### PR TITLE
Support for SVGs and images in theme-graph

### DIFF
--- a/.changeset/dirty-flies-grow.md
+++ b/.changeset/dirty-flies-grow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-graph': patch
+---
+
+Allow SVGs and images to appear on theme-graph dependencies

--- a/packages/theme-graph/src/graph/module.ts
+++ b/packages/theme-graph/src/graph/module.ts
@@ -1,12 +1,15 @@
 import { path, UriString } from '@shopify/theme-check-common';
 import {
   CssModule,
+  ImageModule,
   JavaScriptModule,
   JsonModule,
   JsonModuleKind,
   LiquidModule,
   LiquidModuleKind,
   ModuleType,
+  SUPPORTED_ASSET_IMAGE_EXTENSIONS,
+  SvgModule,
   ThemeGraph,
   ThemeModule,
 } from '../types';
@@ -134,36 +137,32 @@ export function getSectionGroupModule(
 export function getAssetModule(
   themeGraph: ThemeGraph,
   asset: string,
-): JavaScriptModule | CssModule | undefined {
-  // return undefined;
+): JavaScriptModule | CssModule | SvgModule | ImageModule | undefined {
   const extension = extname(asset);
-  switch (extension) {
-    case 'js': {
-      const uri = path.join(themeGraph.rootUri, 'assets', asset);
-      return module(themeGraph, {
-        type: ModuleType.JavaScript,
-        kind: 'unused',
-        dependencies: [],
-        references: [],
-        uri: uri,
-      });
-    }
 
-    case 'css': {
-      const uri = path.join(themeGraph.rootUri, 'assets', asset);
-      return module(themeGraph, {
-        type: ModuleType.Css,
-        kind: 'unused',
-        dependencies: [],
-        references: [],
-        uri: uri,
-      });
-    }
+  let type: ModuleType | undefined = undefined;
 
-    default: {
-      return undefined;
-    }
+  if (SUPPORTED_ASSET_IMAGE_EXTENSIONS.includes(extension)) {
+    type = ModuleType.Image;
+  } else if (extension === 'js') {
+    type = ModuleType.JavaScript;
+  } else if (extension === 'css') {
+    type = ModuleType.Css;
+  } else if (extension === 'svg') {
+    type = ModuleType.Svg;
   }
+
+  if (!type) {
+    return undefined;
+  }
+
+  return module(themeGraph, {
+    type,
+    kind: 'unused',
+    dependencies: [],
+    references: [],
+    uri: path.join(themeGraph.rootUri, 'assets', asset),
+  });
 }
 
 export function getSnippetModule(themeGraph: ThemeGraph, snippet: string): LiquidModule {

--- a/packages/theme-graph/src/graph/traverse.ts
+++ b/packages/theme-graph/src/graph/traverse.ts
@@ -73,7 +73,9 @@ export async function traverseModule(
       return; // TODO graph import/exports ?
     }
 
-    case ModuleType.Css: {
+    case ModuleType.Css:
+    case ModuleType.Svg:
+    case ModuleType.Image: {
       return; // Nothing to do??
     }
 
@@ -97,9 +99,10 @@ async function traverseLiquidModule(
     { target: ThemeModule; sourceRange: Range; targetRange?: Range }
   > = {
     // {{ 'theme.js' | asset_url }}
-    // {{ 'theme.css' | asset_url }}
+    // {{ 'image.png' | asset_img_url }}
+    // {{ 'icon.svg' | inline_asset_content }}
     LiquidFilter: (node, ancestors) => {
-      if (node.name === 'asset_url') {
+      if (['asset_url', 'asset_img_url', 'inline_asset_content'].includes(node.name)) {
         const parentNode = ancestors[ancestors.length - 1]!;
         if (parentNode.type !== NodeTypes.LiquidVariable) return;
         if (parentNode.expression.type !== NodeTypes.String) return;

--- a/packages/theme-graph/src/index.ts
+++ b/packages/theme-graph/src/index.ts
@@ -1,5 +1,5 @@
 export { buildThemeGraph } from './graph/build';
 export { serializeThemeGraph } from './graph/serialize';
 export { getWebComponentMap, findWebComponentReferences } from './getWebComponentMap';
-export { toCssSourceCode, toJsSourceCode, toSourceCode } from './toSourceCode';
+export { toCssSourceCode, toJsSourceCode, toSourceCode, toSvgSourceCode } from './toSourceCode';
 export * from './types';

--- a/packages/theme-graph/src/toSourceCode.ts
+++ b/packages/theme-graph/src/toSourceCode.ts
@@ -1,19 +1,39 @@
-import {
-  asError,
-  JSONSourceCode,
-  LiquidSourceCode,
-  toSourceCode as tcToSourceCode,
-  UriString,
-} from '@shopify/theme-check-common';
+import { asError, toSourceCode as tcToSourceCode, UriString } from '@shopify/theme-check-common';
 import { parse as acornParse, Program } from 'acorn';
-import { CssSourceCode, JsSourceCode } from './types';
+import {
+  CssSourceCode,
+  FileSourceCode,
+  ImageSourceCode,
+  JsSourceCode,
+  SUPPORTED_ASSET_IMAGE_EXTENSIONS,
+  SvgSourceCode,
+} from './types';
+import { extname } from './utils';
 
 export async function toCssSourceCode(uri: UriString, source: string): Promise<CssSourceCode> {
   return {
     type: 'css',
     uri,
     source,
-    ast: new Error('CSS parsing not implemented yet'), // Placeholder for CSS parsing
+    ast: new Error('File parsing not implemented yet'), // Placeholder for CSS parsing
+  };
+}
+
+export async function toSvgSourceCode(uri: UriString, source: string): Promise<SvgSourceCode> {
+  return {
+    type: 'svg',
+    uri,
+    source,
+    ast: new Error('File parsing not implemented yet'), // Placeholder for SVG parsing
+  };
+}
+
+async function toImageSourceCode(uri: UriString, source: string): Promise<ImageSourceCode> {
+  return {
+    type: 'image',
+    uri,
+    source,
+    ast: new Error('Image files are not parsed'),
   };
 }
 
@@ -37,16 +57,19 @@ export function parseJs(source: string): Program | Error {
   }
 }
 
-export async function toSourceCode(
-  uri: UriString,
-  source: string,
-): Promise<JSONSourceCode | LiquidSourceCode | JsSourceCode | CssSourceCode> {
-  if (uri.endsWith('.json') || uri.endsWith('.liquid')) {
+export async function toSourceCode(uri: UriString, source: string): Promise<FileSourceCode> {
+  const extension = extname(uri);
+
+  if (extension === 'json' || extension === 'liquid') {
     return tcToSourceCode(uri, source);
-  } else if (uri.endsWith('.js')) {
+  } else if (extension === 'js') {
     return toJsSourceCode(uri, source);
-  } else if (uri.endsWith('.css')) {
+  } else if (extension === 'css') {
     return toCssSourceCode(uri, source);
+  } else if (extension === 'svg') {
+    return toCssSourceCode(uri, source);
+  } else if (SUPPORTED_ASSET_IMAGE_EXTENSIONS.includes(extension)) {
+    return toImageSourceCode(uri, source);
   } else {
     throw new Error(`Unknown source code type for ${uri}`);
   }

--- a/packages/theme-graph/src/types.ts
+++ b/packages/theme-graph/src/types.ts
@@ -22,9 +22,7 @@ export interface IDependencies {
   getSectionSchema: NonNullable<ThemeCheckDependencies['getSectionSchema']>;
 
   /** Optional perf improvement if you somehow have access to pre-computed source code info */
-  getSourceCode?: (
-    uri: UriString,
-  ) => Promise<JSONSourceCode | LiquidSourceCode | JsSourceCode | CssSourceCode>;
+  getSourceCode?: (uri: UriString) => Promise<FileSourceCode>;
 
   /** A way to link <custom-element> to its window.customElements.define statement */
   getWebComponentDefinitionReference: (
@@ -44,7 +42,21 @@ export interface ThemeGraph {
   modules: Record<UriString, ThemeModule>;
 }
 
-export type ThemeModule = LiquidModule | JsonModule | JavaScriptModule | CssModule;
+export type ThemeModule =
+  | LiquidModule
+  | JsonModule
+  | JavaScriptModule
+  | CssModule
+  | SvgModule
+  | ImageModule;
+
+export type FileSourceCode =
+  | LiquidSourceCode
+  | JSONSourceCode
+  | JsSourceCode
+  | CssSourceCode
+  | SvgSourceCode
+  | ImageSourceCode;
 
 export interface SerializableGraph {
   rootUri: UriString;
@@ -72,6 +84,14 @@ export interface JavaScriptModule extends IThemeModule<ModuleType.JavaScript> {
 }
 
 export interface CssModule extends IThemeModule<ModuleType.Css> {
+  kind: 'unused';
+}
+
+export interface SvgModule extends IThemeModule<ModuleType.Svg> {
+  kind: 'unused';
+}
+
+export interface ImageModule extends IThemeModule<ModuleType.Image> {
   kind: 'unused';
 }
 
@@ -109,6 +129,8 @@ export const enum ModuleType {
   JavaScript = 'JavaScript',
   Json = 'JSON',
   Css = 'CSS',
+  Svg = 'SVG',
+  Image = 'Image',
 }
 
 export const enum JsonModuleKind {
@@ -136,8 +158,32 @@ export const enum LiquidModuleKind {
   Template = 'template',
 }
 
+export const SUPPORTED_ASSET_IMAGE_EXTENSIONS = [
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'webp',
+  'heic',
+  'ico',
+];
+
 export interface CssSourceCode {
   type: 'css';
+  uri: UriString;
+  source: string;
+  ast: any | Error;
+}
+
+export interface SvgSourceCode {
+  type: 'svg';
+  uri: UriString;
+  source: string;
+  ast: any | Error;
+}
+
+export interface ImageSourceCode {
+  type: 'image';
   uri: UriString;
   source: string;
   ast: any | Error;


### PR DESCRIPTION
## What are you adding in this PR?

Fixes https://github.com/Shopify/theme-tools/issues/981
- Added support for SVGs and Images on theme-graph

## Tophat

- Check out branch
- Press F5
- Open a theme repo
- Find a theme file that calls out an SVG or an image file in the assets folder
- It should appear in the Dependencies panel 

<img width="644" alt="image" src="https://github.com/user-attachments/assets/ba08188a-6859-446c-9c15-f7055252d97f" />

## Before you deploy

- [x] I included a patch bump `changeset`
