### PR TITLE
QOL Improvement: Fixes Issue with Accidental Double Spacing in Disable Comments

### DIFF
--- a/packages/theme-check-common/src/disabled-checks/index.spec.ts
+++ b/packages/theme-check-common/src/disabled-checks/index.spec.ts
@@ -5,8 +5,8 @@ import { LiquidFilter, RenderMarkup } from './test-checks';
 import { UndefinedObject } from '../checks/undefined-object';
 
 const commentTypes = [
-  (text: string) => `{% # ${text} %}`,
-  (text: string) => `{% comment %}${text}{% endcomment %}`,
+  (text: string) => `{% # ${text.replace(/\s+/g, ' ').trim()} %}`,
+  (text: string) => `{% comment %}${text.replace(/\s+/g, ' ').trim()} {% endcomment %}`,
 ];
 
 function expectLiquidFilterOffense(offenses: Offense[], file: string, assetName: string) {


### PR DESCRIPTION
This PR addresses an issue where theme check disable comments with accidental double spaces would not work correctly.

Issue Fixed:
Disable comments like the following were not being respected due to extra spacing:

{%  # theme-check-disable  LiquidFilter, RenderMarkup %}

Changes Made:

Updated packages/theme-check-common/src/disabled-checks/index.spec.ts to collapse multiple spaces into a single space when parsing disable comments.