### PR TITLE
Update liquid paginate by max limit rule from 50 to 250

### DIFF
--- a/packages/theme-check-common/src/checks/pagination-size/index.spec.ts
+++ b/packages/theme-check-common/src/checks/pagination-size/index.spec.ts
@@ -12,7 +12,7 @@ describe('Module: PaginationSize', () => {
 
     expect(offenses).to.have.length(1);
     expect(offenses[0].message).to.equal(
-      'Pagination size must be a positive integer between 1 and 50.',
+      'Pagination size must be a positive integer between 1 and 250.',
     );
 
     const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
@@ -21,7 +21,7 @@ describe('Module: PaginationSize', () => {
 
   it('should report an offense when paginate size is greater than maxSize', async () => {
     const sourceCode = `
-      {% paginate collection.products by 100 %}
+      {% paginate collection.products by 251 %}
       {% endpaginate %}
     `;
 
@@ -29,11 +29,11 @@ describe('Module: PaginationSize', () => {
 
     expect(offenses).to.have.length(1);
     expect(offenses[0].message).to.equal(
-      'Pagination size must be a positive integer between 1 and 50.',
+      'Pagination size must be a positive integer between 1 and 250.',
     );
 
     const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
-    expect(highlights).to.eql(['100']);
+    expect(highlights).to.eql(['251']);
   });
 
   it('should not report an offense when paginate size is within the minSize and maxSize range', async () => {
@@ -86,7 +86,7 @@ describe('Module: PaginationSize', () => {
               "type": "number",
               "id": "products_per_page",
               "label": "Products per Page",
-              "default": 51
+              "default": 251
             }
           ]
         }
@@ -96,7 +96,7 @@ describe('Module: PaginationSize', () => {
     const offenses = await runLiquidCheck(PaginationSize, sourceCode);
     expect(offenses).to.have.length(1);
     expect(offenses[0].message).to.equal(
-      `This setting's default value should be between 1 and 50 but is currently 51.`,
+      `This setting's default value should be between 1 and 250 but is currently 251.`,
     );
     const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
     expect(highlights).to.eql(['section.settings.products_per_page']);

--- a/packages/theme-check-common/src/checks/pagination-size/index.ts
+++ b/packages/theme-check-common/src/checks/pagination-size/index.ts
@@ -11,7 +11,7 @@ import { parseJSON } from '../../json';
 
 const schema = {
   minSize: SchemaProp.number(1),
-  maxSize: SchemaProp.number(50),
+  maxSize: SchemaProp.number(250),
 };
 
 export const PaginationSize: LiquidCheckDefinition<typeof schema> = {

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -105,7 +105,7 @@ PaginationSize:
   enabled: true
   severity: 1
   minSize: 1
-  maxSize: 50
+  maxSize: 250
 ParserBlockingScript:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -83,7 +83,7 @@ PaginationSize:
   enabled: true
   severity: 1
   minSize: 1
-  maxSize: 50
+  maxSize: 250
 ParserBlockingScript:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?
We have update liquid `paginate` max limit from `50` to `250`  recently. 

<img width="879" height="630" alt="image" src="https://github.com/user-attachments/assets/b937626a-4ff3-4f0e-9e88-09de03fdbd8d" />

 
<img width="838" height="64" alt="image" src="https://github.com/user-attachments/assets/64d8982b-3938-41b8-b922-16277e95a167" />
