### PR TITLE
Fix incorrect lodash reference

### DIFF
--- a/.changeset/beige-planes-draw.md
+++ b/.changeset/beige-planes-draw.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+[Internal] Fix incorrect references to libraries

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -30,13 +30,13 @@
     "cross-fetch": "^4.0.0",
     "jsonc-parser": "^3.2.0",
     "line-column": "^1.0.2",
-    "lodash-es": "^4.17.21",
+    "lodash": "^4.17.21",
     "minimatch": "^9.0.1",
     "vscode-json-languageservice": "^5.3.10",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {
     "@types/line-column": "^1.0.0",
-    "@types/lodash-es": "^4.17.12"
+    "@types/lodash": "^4.17.20"
   }
 }

--- a/packages/theme-check-common/src/checks/variable-name/index.ts
+++ b/packages/theme-check-common/src/checks/variable-name/index.ts
@@ -6,10 +6,7 @@ import {
   NodeTypes,
 } from '@shopify/liquid-html-parser';
 import { LiquidCheckDefinition, SchemaProp, Severity, SourceCodeType } from '../../types';
-
-import camelCase from 'lodash/camelCase';
-import kebabCase from 'lodash/kebabCase';
-import snakeCase from 'lodash/snakeCase';
+import { camelCase, kebabCase, snakeCase } from 'lodash';
 
 const pascalCase = (string: string) => {
   const camelCased = camelCase(string);

--- a/packages/theme-check-common/src/fixes/correctors/json-corrector.ts
+++ b/packages/theme-check-common/src/fixes/correctors/json-corrector.ts
@@ -1,5 +1,4 @@
-import lodashSet from 'lodash/set';
-import lodashUnset from 'lodash/unset';
+import { set as lodashSet, unset as lodashUnset } from 'lodash';
 import { Fix } from '../../types';
 import { BaseCorrector } from './base-corrector';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,17 +1309,10 @@
   resolved "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.4.tgz#def6a9bb0ce78140860602f16ace37a9997f086a"
   integrity sha512-hPpIeeHb/2UuCw06kSNAOVWgehBLXEo0/fUs0mw3W2qhqX89PI2yvok83MnuctYGCPrabGIoi0fFso4DQ+sNUQ==
 
-"@types/lodash-es@^4.17.12":
-  version "4.17.12"
-  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
-  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.196"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.196.tgz"
-  integrity sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==
+"@types/lodash@^4.17.20":
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.20.tgz#1ca77361d7363432d29f5e55950d9ec1e1c6ea93"
+  integrity sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==
 
 "@types/markdown-it@^13.0.4":
   version "13.0.4"
@@ -5179,11 +5172,6 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
-
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.includes@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
## What are you adding in this PR?

This PR fixes incorrect references to lodash libraries in the variable-name check. 

Original error seen:
```
node:internal/modules/cjs/loader:1405
  const err = new Error(message);
              ^

Error: Cannot find module 'lodash/camelCase'
```

Alternative approach:
- I tried updating the references to use the lodash module instead; but that broke theme-check-node in CI (see [here](https://github.com/Shopify/theme-tools/actions/runs/16379019530/job/46285940295))

## What's next? Any followup issues?

No follow-up issues identified.

## Before you deploy

- [x] I included a patch bump `changeset`