### PR TITLE
Add change log for 'Update liquid paginate by max limit rule from 50 to 250'

### DIFF
--- a/.changeset/polite-ladybugs-try.md
+++ b/.changeset/polite-ladybugs-try.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': patch
+'@shopify/theme-check-node': patch
+---
+
+Update liquid paginate max limit rule from 50 to 250


### PR DESCRIPTION
Adding missing changeset from https://github.com/Shopify/theme-tools/pull/1007