### PR TITLE
Start extension whenever liquid files are detected in repo

### DIFF
--- a/.changeset/unlucky-donkeys-itch.md
+++ b/.changeset/unlucky-donkeys-itch.md
@@ -1,0 +1,5 @@
+---
+'theme-check-vscode': patch
+---
+
+[Bugfix] Start extension whenever liquid files are detected in repo

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -89,7 +89,8 @@
     "vscode-test": "^1.3.0"
   },
   "activationEvents": [
-    "workspaceContains:**/.theme-check.yml"
+    "workspaceContains:**/.theme-check.yml",
+    "workspaceContains:**/*.liquid"
   ],
   "main": "./dist/node/extension.js",
   "browser": "./dist/browser/extension.js",


### PR DESCRIPTION
- Whenever you open `.json`, `.css.liquid`, `.js.liquid` or any file that isn't `.liquid` file in a theme first, theme-checks do not run
- The startup of the extension relies on either a liquid file opening OR the repo containing `.theme-check.yml`
- In most cases, themes have the `.theme-check.yml` file, but in VSC for Admin, they do not. So this bug is quite annoying when you only deal with `.json` files.

## What are you adding in this PR?

- This change will ensure if the repo contains any ".liquid" file, it will start the extension

## Alternative approach

- I also tried to `onLanguage:json` approach in `activationEvents`, but this would start our extension on other repos that have "normal" jsons and not theme-specific json files

i.e
```
  "activationEvents": [
    "workspaceContains:**/.theme-check.yml",
    "onLanguage:jsonc"
  ],
```

More docs [here](https://code.visualstudio.com/api/references/activation-events#onLanguage)

## Tophat

Recreating the error:
- Open a theme repo in VSCode
- Open config/settings_schema.json and change the `font_picker` default to be "helvetica_n4"
- Close all files and reload the window
- Open config/settings_schema.json and notice there is no theme-check warning under "helvetica_n4"
- Open a liquid file in the repo
- Open config/settings_schema.json again and notice there is a theme-check warning under "helvetica_n4"

Fix:
- Run this branch of theme-tools in VSCode
- Press F5
- Open the same theme repo above and see that opening config/settings_schema.json first will still show the error

## Before you deploy

- [x] I included a patch bump `changeset`
