### PR TITLE
Update our parsing rules to support boolean expressions

### DIFF
--- a/.changeset/rotten-llamas-promise.md
+++ b/.changeset/rotten-llamas-promise.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/prettier-plugin-liquid': minor
+'@shopify/liquid-html-parser': minor
+'@shopify/theme-check-common': minor
+---
+
+Detect and fix use of boolean expressions

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -237,7 +237,7 @@ Liquid <: Helpers {
   // because we'd otherwise positively match the following string
   // instead of falling back to the other rule:
   // {{ 'string' | some_filter }}
-  liquidVariable<delim> = liquidExpression<delim> liquidFilter<delim>* space* &delim
+  liquidVariable<delim> = liquidComplexExpression<delim> liquidFilter<delim>* space* &delim
 
   liquidExpression<delim> =
     | liquidString<delim>
@@ -245,6 +245,18 @@ Liquid <: Helpers {
     | liquidLiteral
     | liquidRange<delim>
     | liquidVariableLookup<delim>
+
+  liquidComplexExpression<delim> =
+    | liquidBooleanExpression<delim>
+    | liquidExpression<delim>
+
+  liquidBooleanExpression<delim> = booleanExpressionCondition<delim> listOf<booleanExpressionSubsequentCondition<delim>, conditionSeparator>
+
+  // This might over-capture things since the conditions below can contain any `liquidExpression`s.
+  // We will need to clean this up in CST. If we restrict the conditions to only contain comparisons and
+  // variable lookups, we can't support "truthy" expressions like `{{ some_var and 'this' }}`
+  booleanExpressionSubsequentCondition<delim> = space* logicalOperator space* (comparison<delim> | liquidExpression<delim>) space*
+  booleanExpressionCondition<delim> = comparison<delim> | liquidExpression<delim>
 
   liquidString<delim> = liquidSingleQuotedString<delim> | liquidDoubleQuotedString<delim>
   liquidSingleQuotedString<delim> = "'" anyExceptStar<("'"| delim)> "'"

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -30,6 +30,55 @@ describe('Unit: Stage 2 (AST)', () => {
         }
       });
 
+      it('should parse comparisons as LiquidVariable > BooleanExpression > Comparison', () => {
+        [
+          { expression: `1 == 1` },
+          { expression: `1 != 1` },
+          { expression: `1 > 1` },
+          { expression: `1 < 1` },
+          { expression: `1 >= 1` },
+          { expression: `1 <= 1` },
+        ].forEach(({ expression }) => {
+          for (const { toAST, expectPath, expectPosition } of testCases) {
+            ast = toAST(`{{ ${expression} }}`);
+            expectPath(ast, 'children.0').to.exist;
+            expectPath(ast, 'children.0.type').to.eql('LiquidVariableOutput');
+            expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+            expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
+            expectPath(ast, 'children.0.markup.expression.type').to.eql('BooleanExpression');
+            expectPath(ast, 'children.0.markup.expression.condition.type').to.eql('Comparison');
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.expression');
+          }
+        });
+      });
+
+      it('should parse logical operations as LiquidVariable > BooleanExpression > LogicalExpression', () => {
+        [
+          { expression: `1 == 1 and 2 == 2` },
+          { expression: `1 == 1 or 2 == 2` },
+          { expression: `1 == 1 and 2 == 2 or 3 == 3` },
+          { expression: `1 == 1 and some_variable or 3 == 3` },
+          { expression: `some_var and 'raw string'` },
+        ].forEach(({ expression }) => {
+          for (const { toAST, expectPath, expectPosition } of testCases) {
+            ast = toAST(`{{ ${expression} }}`);
+            expectPath(ast, 'children.0').to.exist;
+            expectPath(ast, 'children.0.type').to.eql('LiquidVariableOutput');
+            expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+            expectPath(ast, 'children.0.markup.rawSource').to.eql(expression);
+            expectPath(ast, 'children.0.markup.expression.type').to.eql('BooleanExpression');
+            expectPath(ast, 'children.0.markup.expression.condition.type').to.eql(
+              'LogicalExpression',
+            );
+            expectPosition(ast, 'children.0');
+            expectPosition(ast, 'children.0.markup');
+            expectPosition(ast, 'children.0.markup.expression');
+          }
+        });
+      });
+
       it('should parse strings as LiquidVariable > String', () => {
         [
           { expression: `"string o' string"`, value: `string o' string`, single: false },

--- a/packages/liquid-html-parser/src/types.ts
+++ b/packages/liquid-html-parser/src/types.ts
@@ -29,6 +29,7 @@ export enum NodeTypes {
   LiquidFilter = 'LiquidFilter',
   NamedArgument = 'NamedArgument',
   LiquidLiteral = 'LiquidLiteral',
+  BooleanExpression = 'BooleanExpression',
   String = 'String',
   Number = 'Number',
   Range = 'Range',

--- a/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
+++ b/packages/prettier-plugin-liquid/src/printer/preprocess/augment-with-css-properties.ts
@@ -115,6 +115,7 @@ function getCssDisplay(node: AugmentedNode<WithSiblings>, options: LiquidParserO
     case NodeTypes.LiquidFilter:
     case NodeTypes.NamedArgument:
     case NodeTypes.LiquidLiteral:
+    case NodeTypes.BooleanExpression:
     case NodeTypes.String:
     case NodeTypes.Number:
     case NodeTypes.Range:
@@ -225,6 +226,7 @@ function getNodeCssStyleWhiteSpace(
     case NodeTypes.LiquidFilter:
     case NodeTypes.NamedArgument:
     case NodeTypes.LiquidLiteral:
+    case NodeTypes.BooleanExpression:
     case NodeTypes.String:
     case NodeTypes.Number:
     case NodeTypes.Range:

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -506,6 +506,10 @@ function printNode(
       return ['---', hardline, node.body, '---'];
     }
 
+    case NodeTypes.BooleanExpression: {
+      return path.call((p: any) => print(p), 'condition');
+    }
+
     case NodeTypes.String: {
       const preferredQuote = options.liquidSingleQuote ? `'` : `"`;
       const valueHasQuotes = node.value.includes(preferredQuote);

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -1,5 +1,6 @@
 import {
   AssignMarkup,
+  ComplexLiquidExpression,
   LiquidDocParamNode,
   LiquidExpression,
   LiquidHtmlNode,
@@ -46,7 +47,7 @@ export class TypeSystem {
   ) {}
 
   async inferType(
-    thing: Identifier | LiquidExpression | LiquidVariable | AssignMarkup,
+    thing: Identifier | ComplexLiquidExpression | LiquidVariable | AssignMarkup,
     partialAst: LiquidHtmlNode,
     uri: string,
   ): Promise<PseudoType | ArrayType> {
@@ -595,7 +596,7 @@ function resolveTypeRangeType(
 }
 
 function inferType(
-  thing: Identifier | LiquidExpression | LiquidVariable | AssignMarkup,
+  thing: Identifier | ComplexLiquidExpression | LiquidVariable | AssignMarkup,
   symbolsTable: SymbolsTable,
   objectMap: ObjectMap,
   filtersMap: FiltersMap,
@@ -614,6 +615,10 @@ function inferType(
     }
 
     case NodeTypes.LiquidLiteral: {
+      return 'boolean';
+    }
+
+    case NodeTypes.BooleanExpression: {
       return 'boolean';
     }
 

--- a/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
+++ b/packages/theme-language-server-common/src/completions/params/LiquidCompletionParams.ts
@@ -404,6 +404,7 @@ function findCurrentNode(
       // That's the current node.
       case NodeTypes.TextNode:
       case NodeTypes.LiquidLiteral:
+      case NodeTypes.BooleanExpression:
       case NodeTypes.String:
       case NodeTypes.Number:
       case NodeTypes.LiquidDocParamNode:


### PR DESCRIPTION
Part of https://github.com/Shopify/developer-tools-team/issues/807

## What are you adding in this PR?

- Update parser so we can detect boolean expressions in theme code
- Auto-fix boolean expressions when used in assigns, echos, liquid output tag `{{ .. }}`
- When you hover over a variable that's been assigned a boolean expression, we will identify it as a boolean (even though it isn't supported)

## What's next? Any followup issues?

- Find and fix more issues where we allow invalid syntax when we shouldn't

## Tophat

Main feature
- Run this branch
- `yarn install`
- `yarn build`
- F5
- Open a theme
- Create a liquid file with some boolean expressions (see below)
- Run fix and the latter portion of the logical expression or conditional expression be erased
  - If there are multiple expressions, remove all but the first expression

```
{% # liquid output %}
{{ 'example1' == var }}
{{ 'example1' == 'example2' }}
{{ var == 'example2' }}
{{ var1 == var2 }}

{% # echos %}
{% echo 'example1' == var %}
{% echo 'example1' == 'example2' %}
{% echo var == 'example1' %}
{% echo var1 == var2 %}

{% # assigns %}
{% assign var3 = 'example1' == var %}
{% assign var4 = 'example1' == 'example2' %}
{% assign var5 = var == 'example2' %}
{% assign var6 = var1 == var2 %}

{% # Checking inside a liquid block %}
{% liquid
  assign var7 = true
  assign var7 = true == true
  assign var7 = what == '123'
  assign var7 = this and that == 8

  echo true
  echo true == true
  echo what == '123'
  echo this and that == 8

  echo a == b and c == d
  echo sand and c or do
  echo 'test' or 'something' > 5
%}

{% # This is not considered a boolean expression - and we won't be fixing them since they are supported today %}
{% if something > 5 %}{% endif %}
{% if a and b %}{% endif %}
```

Side features
- Hover over a variable with a boolean expression, and it should say it's a boolean
<img width="356" height="95" alt="image" src="https://github.com/user-attachments/assets/0f3b992f-c85d-43d1-b4ff-e508eee29f22" />


## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
