### PR TITLE
Bump ohm-js to v17

### DIFF
--- a/.changeset/fair-mayflies-shop.md
+++ b/.changeset/fair-mayflies-shop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+Bump ohm-js to v17

--- a/packages/liquid-html-parser/package.json
+++ b/packages/liquid-html-parser/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "line-column": "^1.0.2",
-    "ohm-js": "^16.3.0"
+    "ohm-js": "^17.0.0"
   },
   "devDependencies": {
     "@types/line-column": "^1.0.0"

--- a/packages/liquid-html-parser/src/grammar.ts
+++ b/packages/liquid-html-parser/src/grammar.ts
@@ -1,14 +1,14 @@
-import ohm from 'ohm-js';
+import { grammars, Grammar } from 'ohm-js';
 
-export const liquidHtmlGrammars = ohm.grammars(require('../grammar/liquid-html.ohm.js'));
+export const liquidHtmlGrammars = grammars(require('../grammar/liquid-html.ohm.js'));
 
 export const TextNodeGrammar = liquidHtmlGrammars['Helpers'];
 export const LiquidDocGrammar = liquidHtmlGrammars['LiquidDoc'];
 
 export interface LiquidGrammars {
-  Liquid: ohm.Grammar;
-  LiquidHTML: ohm.Grammar;
-  LiquidStatement: ohm.Grammar;
+  Liquid: Grammar;
+  LiquidHTML: Grammar;
+  LiquidStatement: Grammar;
 }
 
 export const strictGrammars: LiquidGrammars = {

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -1500,7 +1500,7 @@ describe('Unit: Stage 1 (CST)', () => {
 {% doc %}
   @description content with @-like characters: @@test
 
-  @example 
+  @example
   content with stuff and there is the potential for an "@" character
 
   @prompt

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -599,14 +599,7 @@ function toCST<T>(
     TextNode: textNode,
     orderedListOf: 0,
 
-    listOf: 0,
     empty: () => null,
-    emptyListOf: () => [],
-    nonemptyListOf(first: any, _sep: any, rest: any) {
-      const self = this as any;
-      return [first.toAST(self.args.mapping)].concat(rest.toAST(self.args.mapping));
-    },
-
     nonemptyOrderedListOf: 0,
     nonemptyOrderedListOfBoth(nonemptyListOfA: Node, _sep: Node, nonemptyListOfB: Node) {
       const self = this as any;

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -31,7 +31,7 @@
  */
 
 import { Parser } from 'prettier';
-import ohm, { Node } from 'ohm-js';
+import { Grammar, Node } from 'ohm-js';
 import { toAST } from 'ohm-js/extras';
 import {
   LiquidDocGrammar,
@@ -568,7 +568,7 @@ export function toLiquidCST(
 function toCST<T>(
   source: string /* the original file */,
   grammars: LiquidGrammars,
-  grammar: ohm.Grammar,
+  grammar: Grammar,
   cstMappings: ('HelperMappings' | 'LiquidMappings' | 'LiquidHTMLMappings' | 'LiquidStatement')[],
   matchingSource: string = source /* for subtree parsing */,
   offset: number = 0 /* for subtree parsing location offsets */,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,10 +5690,10 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-ohm-js@^16.3.0:
-  version "16.6.0"
-  resolved "https://registry.npmjs.org/ohm-js/-/ohm-js-16.6.0.tgz"
-  integrity sha512-X9P4koSGa7swgVQ0gt71UCYtkAQGOjciJPJAz74kDxWt8nXbH5HrDOQG6qBDH7SR40ktNv4x61BwpTDE9q4lRA==
+ohm-js@^17.0.0:
+  version "17.2.1"
+  resolved "https://registry.npmjs.org/ohm-js/-/ohm-js-17.2.1.tgz#77d7d4910134c9e3c7a1b068a878499c68edf92f"
+  integrity sha512-4cXF0G09fAYU9z61kTfkNbKK1Kz/sGEZ5NbVWHoe9Qi7VB7y+Spwk051CpUTfUENdlIr+vt8tMV4/LosTE2cDQ==
 
 on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"


### PR DESCRIPTION
## What are you adding in this PR?

Bump ohm-js to v17 for easier diffing with WASM build

[Changelog for reference](https://github.com/ohmjs/ohm/blob/main/packages/ohm-js/CHANGELOG.md)

## Before you deploy

- [x] I included a patch bump `changeset`
