### PR TITLE
Allow boolean expressions in schema tag

### DIFF
--- a/.changeset/seven-suits-tan.md
+++ b/.changeset/seven-suits-tan.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Allow boolean expressions in schema tag

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/InvalidBooleanExpression.spec.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/InvalidBooleanExpression.spec.ts
@@ -12,6 +12,17 @@ describe('detectTrailingAssignValue', async () => {
     }
   });
 
+  it('should not report when the boolean expression is in a schema tag', async () => {
+    const sourceCode = `{% schema %}
+      {
+        "visible_if": "{{ this > that }}"
+      }
+    {% endschema %}`;
+
+    const offenses = await runLiquidCheck(LiquidHTMLSyntaxError, sourceCode);
+    expect(offenses).to.have.length(0);
+  });
+
   it('should report all use of boolean expressions', async () => {
     const testCases = [
       [`{% assign foo = something == else %}`, '{% assign foo = something %}'],

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/InvalidBooleanExpressions.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/InvalidBooleanExpressions.ts
@@ -1,4 +1,4 @@
-import { NodeTypes } from '@shopify/liquid-html-parser';
+import { NamedTags, NodeTypes } from '@shopify/liquid-html-parser';
 import { Check, Context, SourceCodeType } from '../../..';
 import { INVALID_SYNTAX_MESSAGE } from './utils';
 
@@ -6,8 +6,17 @@ export function detectInvalidBooleanExpressions(
   context: Context<SourceCodeType.LiquidHtml>,
 ): Check<SourceCodeType.LiquidHtml> {
   return {
-    async BooleanExpression(node) {
+    async BooleanExpression(node, ancestors) {
       const condition = node.condition;
+
+      // We are okay with boolean expressions in schema tags (specifically for visible_if)
+      if (
+        ancestors.some(
+          (ancestor) => ancestor.type === NodeTypes.LiquidRawTag && ancestor.name === 'schema',
+        )
+      ) {
+        return;
+      }
 
       if (
         condition.type !== NodeTypes.Comparison &&

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/InvalidBooleanExpressions.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/InvalidBooleanExpressions.ts
@@ -1,42 +1,36 @@
-import { NamedTags, NodeTypes } from '@shopify/liquid-html-parser';
-import { Check, Context, SourceCodeType } from '../../..';
+import { LiquidBooleanExpression, LiquidHtmlNode, NodeTypes } from '@shopify/liquid-html-parser';
+import { Problem, SourceCodeType } from '../../..';
 import { INVALID_SYNTAX_MESSAGE } from './utils';
 
 export function detectInvalidBooleanExpressions(
-  context: Context<SourceCodeType.LiquidHtml>,
-): Check<SourceCodeType.LiquidHtml> {
+  node: LiquidBooleanExpression,
+  ancestors: LiquidHtmlNode[],
+): Problem<SourceCodeType.LiquidHtml> | undefined {
+  const condition = node.condition;
+
+  // We are okay with boolean expressions in schema tags (specifically for visible_if)
+  if (
+    ancestors.some(
+      (ancestor) => ancestor.type === NodeTypes.LiquidRawTag && ancestor.name === 'schema',
+    )
+  ) {
+    return;
+  }
+
+  if (condition.type !== NodeTypes.Comparison && condition.type !== NodeTypes.LogicalExpression) {
+    return;
+  }
+
   return {
-    async BooleanExpression(node, ancestors) {
-      const condition = node.condition;
-
-      // We are okay with boolean expressions in schema tags (specifically for visible_if)
-      if (
-        ancestors.some(
-          (ancestor) => ancestor.type === NodeTypes.LiquidRawTag && ancestor.name === 'schema',
-        )
-      ) {
-        return;
-      }
-
-      if (
-        condition.type !== NodeTypes.Comparison &&
-        condition.type !== NodeTypes.LogicalExpression
-      ) {
-        return;
-      }
-
-      context.report({
-        message: INVALID_SYNTAX_MESSAGE,
-        startIndex: node.position.start,
-        endIndex: node.position.end,
-        fix: (corrector) => {
-          corrector.replace(
-            node.position.start,
-            node.position.end,
-            node.source.slice(condition.left.position.start, condition.left.position.end),
-          );
-        },
-      });
+    message: INVALID_SYNTAX_MESSAGE,
+    startIndex: node.position.start,
+    endIndex: node.position.end,
+    fix: (corrector) => {
+      corrector.replace(
+        node.position.start,
+        node.position.end,
+        node.source.slice(condition.left.position.start, condition.left.position.end),
+      );
     },
   };
 }

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleAssignValues.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleAssignValues.ts
@@ -1,9 +1,10 @@
-import { Check, Context, SourceCodeType } from '../../..';
+import { LiquidTag } from '@shopify/liquid-html-parser';
+import { Problem, SourceCodeType } from '../../..';
 import { ensureValidAst, INVALID_SYNTAX_MESSAGE } from './utils';
 
 export function detectMultipleAssignValues(
-  context: Context<SourceCodeType.LiquidHtml>,
-): Check<SourceCodeType.LiquidHtml> {
+  node: LiquidTag,
+): Problem<SourceCodeType.LiquidHtml> | undefined {
   // Using a regex to match the markup like we do in Shopify/liquid
   // https://github.com/Shopify/liquid/blob/9bb7fbf123e6e2bd61e00189b1c83159f375d3f3/lib/liquid/tags/assign.rb#L21
   //
@@ -14,84 +15,79 @@ export function detectMultipleAssignValues(
   // 4. The filter section (non-captured)
   const ASSIGN_MARKUP_REGEX = /([^=]+)(=\s*)([^|]+)(?:\s*\|\s*.*)?$/m;
 
+  if (node.name !== 'assign') {
+    return;
+  }
+
+  const markup = node.markup;
+
+  if (typeof markup !== 'string') {
+    return;
+  }
+
+  const match = markup.match(ASSIGN_MARKUP_REGEX);
+  if (!match) {
+    return;
+  }
+
+  // If we have a markup 'foo    =    "123" something | upcase: 123', we have the following groups
+  const [
+    // 'foo    =    "123" something | upcase: 123'
+    _fullMatch,
+    // 'foo    '
+    assignmentVariable,
+    // '=    '
+    assignmentOperator,
+    // '"123" something'
+    assignmentValue,
+  ] = match;
+
+  // Only capture the first item in the value section
+  const firstValueMatch = assignmentValue.match(/"[^"]*"|'[^']*'|\S+/);
+  const firstAssignmentValue = firstValueMatch ? firstValueMatch[0] : null;
+
+  if (!firstAssignmentValue) {
+    return;
+  }
+
+  const removalIndices = (source: string) => {
+    const offset = source.indexOf(markup);
+
+    return {
+      startIndex:
+        offset +
+        assignmentVariable.length +
+        assignmentOperator.length +
+        firstAssignmentValue.length,
+      endIndex:
+        offset +
+        assignmentVariable.length +
+        assignmentOperator.length +
+        assignmentValue.trimEnd().length,
+    };
+  };
+
+  const tagSource = node.source.slice(node.position.start, node.position.end);
+  const { startIndex: tagSourceRemovalStartIndex, endIndex: tagSourceRemovalEndIndex } =
+    removalIndices(tagSource);
+
+  if (
+    !ensureValidAst(
+      tagSource.slice(0, tagSourceRemovalStartIndex) + tagSource.slice(tagSourceRemovalEndIndex),
+    )
+  ) {
+    // If the new AST is invalid, we don't want to auto-fix it
+    return;
+  }
+
+  const { startIndex, endIndex } = removalIndices(node.source);
+
   return {
-    async LiquidTag(node) {
-      if (node.name !== 'assign') {
-        return;
-      }
-
-      const markup = node.markup;
-
-      if (typeof markup !== 'string') {
-        return;
-      }
-
-      const match = markup.match(ASSIGN_MARKUP_REGEX);
-      if (!match) {
-        return;
-      }
-
-      // If we have a markup 'foo    =    "123" something | upcase: 123', we have the following groups
-      const [
-        // 'foo    =    "123" something | upcase: 123'
-        _fullMatch,
-        // 'foo    '
-        assignmentVariable,
-        // '=    '
-        assignmentOperator,
-        // '"123" something'
-        assignmentValue,
-      ] = match;
-
-      // Only capture the first item in the value section
-      const firstValueMatch = assignmentValue.match(/"[^"]*"|'[^']*'|\S+/);
-      const firstAssignmentValue = firstValueMatch ? firstValueMatch[0] : null;
-
-      if (!firstAssignmentValue) {
-        return;
-      }
-
-      const removalIndices = (source: string) => {
-        const offset = source.indexOf(markup);
-
-        return {
-          startIndex:
-            offset +
-            assignmentVariable.length +
-            assignmentOperator.length +
-            firstAssignmentValue.length,
-          endIndex:
-            offset +
-            assignmentVariable.length +
-            assignmentOperator.length +
-            assignmentValue.trimEnd().length,
-        };
-      };
-
-      const tagSource = node.source.slice(node.position.start, node.position.end);
-      const { startIndex: tagSourceRemovalStartIndex, endIndex: tagSourceRemovalEndIndex } =
-        removalIndices(tagSource);
-
-      if (
-        !ensureValidAst(
-          tagSource.slice(0, tagSourceRemovalStartIndex) +
-            tagSource.slice(tagSourceRemovalEndIndex),
-        )
-      ) {
-        // If the new AST is invalid, we don't want to auto-fix it
-        return;
-      }
-
-      const { startIndex, endIndex } = removalIndices(node.source);
-
-      context.report({
-        message: INVALID_SYNTAX_MESSAGE,
-        startIndex,
-        endIndex,
-        fix: (corrector) => {
-          corrector.replace(startIndex, endIndex, '');
-        },
-      });
+    message: INVALID_SYNTAX_MESSAGE,
+    startIndex,
+    endIndex,
+    fix: (corrector) => {
+      corrector.replace(startIndex, endIndex, '');
     },
   };
 }

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.ts
@@ -39,8 +39,24 @@ export const LiquidHTMLSyntaxError: LiquidCheckDefinition = {
     const ast = context.file.ast;
     if (!isError(ast)) {
       return {
-        ...detectInvalidBooleanExpressions(context),
-        ...detectMultipleAssignValues(context),
+        async BooleanExpression(node, ancestors) {
+          const problem = detectInvalidBooleanExpressions(node, ancestors);
+
+          if (!problem) {
+            return;
+          }
+
+          context.report(problem);
+        },
+        async LiquidTag(node) {
+          const problem = detectMultipleAssignValues(node);
+
+          if (!problem) {
+            return;
+          }
+
+          context.report(problem);
+        },
       };
     }
 


### PR DESCRIPTION
PR reviewers: Please view in ignored white-space mode

## What are you adding in this PR?

Commit 1:
- When we added restriction of boolean expressions in our liquid files, i over-corrected and also restricted it in schema tags
- This ensures we don't report its use in visible_if in schemas

Commit 2:
- just refactoring some files so that we can support multiple issues within the same tag
  - The only model would NOT allow you to add another `LiquidTag` check because `detectMultipleAssignValues` already declared it

## Tophat

This should not produce a theme-check error:

```
{% schema %}
      {
        "visible_if": "{{ this > that }}"
      }
{% endschema %}
```

This should still produce a theme-check error:

```
{{ this > that }}
```


## Before you deploy

- [x] I included a patch bump `changeset`
