### PR TITLE
Find/fix multiple `echo` values

### DIFF
--- a/.changeset/yellow-pears-fetch.md
+++ b/.changeset/yellow-pears-fetch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Find/fix multiple `echo` values

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleAssignValues.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleAssignValues.ts
@@ -1,6 +1,6 @@
 import { LiquidTag } from '@shopify/liquid-html-parser';
 import { Problem, SourceCodeType } from '../../..';
-import { ensureValidAst, INVALID_SYNTAX_MESSAGE } from './utils';
+import { ensureValidAst, getFirstValueInMarkup, INVALID_SYNTAX_MESSAGE } from './utils';
 
 export function detectMultipleAssignValues(
   node: LiquidTag,
@@ -42,9 +42,7 @@ export function detectMultipleAssignValues(
     assignmentValue,
   ] = match;
 
-  // Only capture the first item in the value section
-  const firstValueMatch = assignmentValue.match(/"[^"]*"|'[^']*'|\S+/);
-  const firstAssignmentValue = firstValueMatch ? firstValueMatch[0] : null;
+  const firstAssignmentValue = getFirstValueInMarkup(assignmentValue);
 
   if (!firstAssignmentValue) {
     return;

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleEchoValues.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleEchoValues.ts
@@ -1,0 +1,68 @@
+import { LiquidTag, LiquidVariableOutput, NodeTypes } from '@shopify/liquid-html-parser';
+import { Problem, SourceCodeType } from '../../..';
+import { ensureValidAst, getFirstValueInMarkup, INVALID_SYNTAX_MESSAGE } from './utils';
+
+export function detectMultipleEchoValues(
+  node: LiquidTag | LiquidVariableOutput,
+): Problem<SourceCodeType.LiquidHtml> | undefined {
+  // We've broken it up into two groups:
+  // 1. The variable(s)
+  // 2. The filter section (non-captured)
+  const ECHO_MARKUP_REGEX = /([^|]*)(?:\s*\|\s*.*)?$/m;
+
+  if (node.type === NodeTypes.LiquidTag && node.name !== 'echo') {
+    return;
+  }
+
+  const markup = node.markup;
+
+  if (typeof markup !== 'string') {
+    return;
+  }
+
+  const match = markup.match(ECHO_MARKUP_REGEX);
+  if (!match) {
+    return;
+  }
+
+  const [, echoValue] = match;
+
+  const firstEchoValue = getFirstValueInMarkup(echoValue);
+
+  if (!firstEchoValue) {
+    return;
+  }
+
+  const removalIndices = (source: string) => {
+    const offset = source.indexOf(markup);
+
+    return {
+      startIndex: offset + firstEchoValue.length,
+      endIndex: offset + echoValue.trimEnd().length,
+    };
+  };
+
+  const tagSource = node.source.slice(node.position.start, node.position.end);
+  const { startIndex: tagSourceRemovalStartIndex, endIndex: tagSourceRemovalEndIndex } =
+    removalIndices(tagSource);
+
+  if (
+    !ensureValidAst(
+      tagSource.slice(0, tagSourceRemovalStartIndex) + tagSource.slice(tagSourceRemovalEndIndex),
+    )
+  ) {
+    // If the new AST is invalid, we don't want to auto-fix it
+    return;
+  }
+
+  const { startIndex, endIndex } = removalIndices(node.source);
+
+  return {
+    message: INVALID_SYNTAX_MESSAGE,
+    startIndex,
+    endIndex,
+    fix: (corrector) => {
+      corrector.replace(startIndex, endIndex, '');
+    },
+  };
+}

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/utils.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/utils.ts
@@ -11,3 +11,8 @@ export function ensureValidAst(source: string) {
     return false;
   }
 }
+
+export function getFirstValueInMarkup(markup: string) {
+  const match = markup.match(/"[^"]*"|'[^']*'|\S+/);
+  return match?.at(0);
+}

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.ts
@@ -2,6 +2,7 @@ import { Severity, SourceCodeType, LiquidCheckDefinition } from '../../types';
 import { getOffset, isError } from '../../utils';
 import { detectMultipleAssignValues } from './checks/MultipleAssignValues';
 import { detectInvalidBooleanExpressions } from './checks/InvalidBooleanExpressions';
+import { detectMultipleEchoValues as detectMultipleEchoValues } from './checks/MultipleEchoValues';
 
 type LineColPosition = {
   line: number;
@@ -49,7 +50,16 @@ export const LiquidHTMLSyntaxError: LiquidCheckDefinition = {
           context.report(problem);
         },
         async LiquidTag(node) {
-          const problem = detectMultipleAssignValues(node);
+          const problem = detectMultipleAssignValues(node) || detectMultipleEchoValues(node);
+
+          if (!problem) {
+            return;
+          }
+
+          context.report(problem);
+        },
+        async LiquidVariableOutput(node) {
+          const problem = detectMultipleEchoValues(node);
 
           if (!problem) {
             return;


### PR DESCRIPTION
## What are you adding in this PR?

Part of https://github.com/Shopify/developer-tools-team/issues/812#issue-3339001872

- Find and fix bad use of `echo` where multiple values are provided
  - fix should remove all values past the first one (since that's what the Liquid gem does)
  - the fix will be strict parsable
  - also supports liquid output version of "echoing" `{{ }}`

## Tophat
- yarn install
- yarn build
- F5
- Try a few invalid syntax and see auto-fix erases the bad part of echos:
```
{% echo var1 var2 %}
{{ output1 output2 }}
{% echo var1 var2 | upcase %}
{{ output1 output2 | upcase }}
```
<img width="324" height="116" alt="image" src="https://github.com/user-attachments/assets/629e2822-0556-401a-b185-334cfabcfb73" />



## Before you deploy

- [x] I included a patch bump `changeset`
