### PR TITLE
Find+fix echo tags & variable output with no value

### DIFF
--- a/.changeset/hip-scissors-accept.md
+++ b/.changeset/hip-scissors-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Find+fix echo tags & variable output with no value

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleAssignValues.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleAssignValues.ts
@@ -1,6 +1,6 @@
 import { LiquidTag } from '@shopify/liquid-html-parser';
 import { Problem, SourceCodeType } from '../../..';
-import { ensureValidAst, getFirstValueInMarkup, INVALID_SYNTAX_MESSAGE } from './utils';
+import { ensureValidAst, getValuesInMarkup, INVALID_SYNTAX_MESSAGE } from './utils';
 
 export function detectMultipleAssignValues(
   node: LiquidTag,
@@ -42,7 +42,7 @@ export function detectMultipleAssignValues(
     assignmentValue,
   ] = match;
 
-  const firstAssignmentValue = getFirstValueInMarkup(assignmentValue);
+  const firstAssignmentValue = getValuesInMarkup(assignmentValue).at(0)?.value;
 
   if (!firstAssignmentValue) {
     return;

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/utils.spec.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/utils.spec.ts
@@ -1,0 +1,30 @@
+import { expect, describe, it } from 'vitest';
+import { getValuesInMarkup } from './utils';
+
+describe('getValuesInMarkup', () => {
+  it('should return the values in the markup (one value)', () => {
+    const markup = '"123"';
+    const values = getValuesInMarkup(markup);
+    expect(values).toContainEqual({ value: '"123"', index: 0 });
+  });
+
+  it('should return the values in the markup (multiple values)', () => {
+    const markup = '"123" 555 text';
+    const values = getValuesInMarkup(markup);
+    expect(values).toContainEqual({ value: '"123"', index: 0 });
+    expect(values).toContainEqual({ value: '555', index: 6 });
+    expect(values).toContainEqual({ value: 'text', index: 10 });
+  });
+
+  it('should return nothing when no values in the markup', () => {
+    const markup = '';
+    const values = getValuesInMarkup(markup);
+    expect(values).to.have.length(0);
+  });
+
+  it('should return nothing when only spaces in the markup', () => {
+    const markup = '     ';
+    const values = getValuesInMarkup(markup);
+    expect(values).to.have.length(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/utils.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/utils.ts
@@ -12,7 +12,9 @@ export function ensureValidAst(source: string) {
   }
 }
 
-export function getFirstValueInMarkup(markup: string) {
-  const match = markup.match(/"[^"]*"|'[^']*'|\S+/);
-  return match?.at(0);
+export function getValuesInMarkup(markup: string) {
+  return [...markup.matchAll(/"[^"]*"|'[^']*'|\S+/g)].map((match) => ({
+    value: match[0],
+    index: match.index,
+  }));
 }

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.ts
@@ -2,7 +2,7 @@ import { Severity, SourceCodeType, LiquidCheckDefinition } from '../../types';
 import { getOffset, isError } from '../../utils';
 import { detectMultipleAssignValues } from './checks/MultipleAssignValues';
 import { detectInvalidBooleanExpressions } from './checks/InvalidBooleanExpressions';
-import { detectMultipleEchoValues as detectMultipleEchoValues } from './checks/MultipleEchoValues';
+import { detectInvalidEchoValue } from './checks/InvalidEchoValue';
 
 type LineColPosition = {
   line: number;
@@ -50,7 +50,7 @@ export const LiquidHTMLSyntaxError: LiquidCheckDefinition = {
           context.report(problem);
         },
         async LiquidTag(node) {
-          const problem = detectMultipleAssignValues(node) || detectMultipleEchoValues(node);
+          const problem = detectMultipleAssignValues(node) || detectInvalidEchoValue(node);
 
           if (!problem) {
             return;
@@ -59,7 +59,7 @@ export const LiquidHTMLSyntaxError: LiquidCheckDefinition = {
           context.report(problem);
         },
         async LiquidVariableOutput(node) {
-          const problem = detectMultipleEchoValues(node);
+          const problem = detectInvalidEchoValue(node);
 
           if (!problem) {
             return;


### PR DESCRIPTION
## What are you adding in this PR?

Part of https://github.com/Shopify/developer-tools-team/issues/812#issue-3339001872

- Find and fix empty `echo` values
  - If no value is provided but still has filters, just replace it with `blank`
  - If no value is provided and no filters are provided, we can keep it as is

## Tophat
- yarn install
- yarn build
- F5
- Try a few invalid syntax and see auto-fix patches the echo statements:
```
{% echo | upcase %}
{{ | upcase }}
{% liquid echo | upcase %}
```

## Before you deploy

- [x] I included a patch bump `changeset`
