### PR TITLE
Fix syntax check for tags where multiple instances of same error occur

### DIFF
--- a/.changeset/weak-rules-notice.md
+++ b/.changeset/weak-rules-notice.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fix syntax check for tags where multiple instances of same error occur

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/InvalidEchoValue.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/InvalidEchoValue.ts
@@ -48,8 +48,8 @@ export function detectInvalidEchoValue(
     };
   }
 
-  const removalIndices = (source: string) => {
-    const offset = source.indexOf(markup);
+  const removalIndices = (source: string, startingIndex: number) => {
+    const offset = source.indexOf(markup, startingIndex);
 
     return {
       startIndex: offset + firstEchoValue.length,
@@ -57,20 +57,17 @@ export function detectInvalidEchoValue(
     };
   };
 
-  const tagSource = node.source.slice(node.position.start, node.position.end);
-  const { startIndex: tagSourceRemovalStartIndex, endIndex: tagSourceRemovalEndIndex } =
-    removalIndices(tagSource);
+  const { startIndex, endIndex } = removalIndices(node.source, node.position.start);
 
   if (
     !ensureValidAst(
-      tagSource.slice(0, tagSourceRemovalStartIndex) + tagSource.slice(tagSourceRemovalEndIndex),
+      node.source.slice(node.position.start, startIndex) +
+        node.source.slice(endIndex, node.position.end),
     )
   ) {
     // If the new AST is invalid, we don't want to auto-fix it
     return;
   }
-
-  const { startIndex, endIndex } = removalIndices(node.source);
 
   return {
     message: INVALID_SYNTAX_MESSAGE,

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleAssignValues.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/checks/MultipleAssignValues.ts
@@ -48,8 +48,8 @@ export function detectMultipleAssignValues(
     return;
   }
 
-  const removalIndices = (source: string) => {
-    const offset = source.indexOf(markup);
+  const removalIndices = (source: string, startingIndex: number) => {
+    const offset = source.indexOf(markup, startingIndex);
 
     return {
       startIndex:
@@ -65,20 +65,17 @@ export function detectMultipleAssignValues(
     };
   };
 
-  const tagSource = node.source.slice(node.position.start, node.position.end);
-  const { startIndex: tagSourceRemovalStartIndex, endIndex: tagSourceRemovalEndIndex } =
-    removalIndices(tagSource);
+  const { startIndex, endIndex } = removalIndices(node.source, node.position.start);
 
   if (
     !ensureValidAst(
-      tagSource.slice(0, tagSourceRemovalStartIndex) + tagSource.slice(tagSourceRemovalEndIndex),
+      node.source.slice(node.position.start, startIndex) +
+        node.source.slice(endIndex, node.position.end),
     )
   ) {
     // If the new AST is invalid, we don't want to auto-fix it
     return;
   }
-
-  const { startIndex, endIndex } = removalIndices(node.source);
 
   return {
     message: INVALID_SYNTAX_MESSAGE,


### PR DESCRIPTION
## What are you adding in this PR?

- Found a bug in our liquid syntax error check where the offset values were off when multiple instances of the same error appeared
- e.g.
```
{% assign foo = 123 555 %}
{% assign foo = 123 555 %}
```
- The first tag would always be patched and the second one would be ignored since we were searching for the same markup without an index offset

## Tophat

1. Run the code and try the following liquid content
```
{% assign wa = 222 wat %}
{% assign wa = 222 wat %}

{% echo hello moo %}
{% echo hello moo %}
```
2. You should see an error on all 4 of those liquid tags
3. Select a random one to fix using VScode autofix, and ensure only that one gets affected
4. Select to fix all instances of the error, and each one should get updated

## Before you deploy

- [x] I included a patch bump `changeset`
