### PR TITLE
Added orphaned file theme check

### DIFF
--- a/.changeset/nine-experts-peel.md
+++ b/.changeset/nine-experts-peel.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+'@shopify/theme-graph': minor
+---
+
+Added a new OrphanedSnippet theme check to discover and warn if a snippet isn't referenced anywhere

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -30,6 +30,7 @@ import { MissingAsset } from './missing-asset';
 import { MissingContentForArguments } from './missing-content-for-arguments';
 import { MissingRenderSnippetArguments } from './missing-render-snippet-arguments';
 import { MissingTemplate } from './missing-template';
+import { OrphanedSnippet } from './orphaned-snippet';
 import { PaginationSize } from './pagination-size';
 import { ParserBlockingScript } from './parser-blocking-script';
 import { SchemaPresetsBlockOrder } from './schema-presets-block-order';
@@ -98,6 +99,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   MissingRenderSnippetArguments,
   MissingTemplate,
   AppBlockMissingSchema,
+  OrphanedSnippet,
   PaginationSize,
   ParserBlockingScript,
   SchemaPresetsBlockOrder,

--- a/packages/theme-check-common/src/checks/orphaned-snippet/index.spec.ts
+++ b/packages/theme-check-common/src/checks/orphaned-snippet/index.spec.ts
@@ -1,0 +1,58 @@
+import { expect, describe, it } from 'vitest';
+import { OrphanedSnippet } from './index';
+import { runLiquidCheck } from '../../test';
+
+describe('Module: OrphanedSnippet', () => {
+  describe('when the snippet is not referenced by any files', () => {
+    it('should report a warning', async () => {
+      const sourceCode = `<div>Orphaned content</div>`;
+
+      const offenses = await runLiquidCheck(
+        OrphanedSnippet,
+        sourceCode,
+        'snippets/orphaned.liquid',
+        {
+          getReferences: async (uri) => [],
+        },
+      );
+
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).toBe('This snippet is not referenced by any other files');
+    });
+  });
+
+  describe('when the snippet is referenced by other files', () => {
+    it('should not report a warning', async () => {
+      const sourceCode = `<div>Referenced snippet</div>`;
+
+      const offenses = await runLiquidCheck(
+        OrphanedSnippet,
+        sourceCode,
+        'snippets/product-card.liquid',
+        {
+          getReferences: async (uri) => [
+            {
+              source: { uri: 'templates/product.liquid' },
+              target: { uri: 'snippets/product-card.liquid' },
+              type: 'direct',
+            },
+          ],
+        },
+      );
+
+      expect(offenses).toHaveLength(0);
+    });
+  });
+
+  describe('when checking non-snippet files', () => {
+    it('should not report warnings for templates', async () => {
+      const sourceCode = `{% section 'header' %}`;
+
+      const offenses = await runLiquidCheck(OrphanedSnippet, sourceCode, 'templates/index.liquid', {
+        getReferences: async (uri) => [],
+      });
+
+      expect(offenses).toHaveLength(0);
+    });
+  });
+});

--- a/packages/theme-check-common/src/checks/orphaned-snippet/index.ts
+++ b/packages/theme-check-common/src/checks/orphaned-snippet/index.ts
@@ -1,0 +1,43 @@
+import { isSnippet } from '../../to-schema';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+
+export const OrphanedSnippet: LiquidCheckDefinition = {
+  meta: {
+    code: 'OrphanedSnippet',
+    name: 'Prevent orphaned snippets',
+    docs: {
+      description: 'This check exists to prevent orphaned snippets in themes.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/orphaned-snippet',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    return {
+      async onCodePathEnd() {
+        const { getReferences } = context;
+
+        if (!getReferences) {
+          return;
+        }
+
+        const fileUri = context.file.uri;
+        if (isSnippet(fileUri)) {
+          const references = await getReferences(fileUri);
+
+          if (references.length === 0) {
+            context.report({
+              message: `This snippet is not referenced by any other files`,
+              startIndex: 0,
+              endIndex: 1,
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -306,6 +306,44 @@ export type Translations = {
   [k in string]: string | Translations;
 };
 
+/**
+ * A reference is a link between two modules.
+ *
+ * @example
+ *
+ * It could be a specific range that points to a whole file
+ * {
+ *   source: { uri: 'file:///templates/index.json', range: [167, 190] },
+ *   target: 'file:///sections/custom-section.liquid'
+ * }
+ *
+ * It could be a specific range that points to a specific range
+ * {
+ *   // e.g. `<parent-component></parent-component>`
+ *   source: { uri: 'file:///snippets/parent.liquid', range: [167, 190] },
+ *
+ *   // e.g. window.customElements.define('parent-component', ParentComponent);
+ *   target: { uri: 'file:///assets/theme.js', range: [0, undefined] }
+ * }
+ */
+export type Reference = {
+  source: Location;
+  target: Location;
+
+  type:
+    | 'direct' // explicit dependency, e.g. {% render 'child' %}
+    | 'indirect' // indirect dependency, e.g. "blocks": [{ "type": "@theme" }]
+    | 'preset'; // preset dependency
+};
+
+export type Range = [start: number, end: number]; // represents a range in the source code
+export type Location = {
+  /** The URI of the module */
+  uri: UriString;
+  /** Optional range inside that module */
+  range?: Range;
+};
+
 export interface Dependencies {
   /** The file system abstraction used to read files. */
   fs: AbstractFileSystem;

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -386,6 +386,12 @@ export interface Dependencies {
    * Used in theme-checks for cross-file checks rather that going through fs.
    */
   getDocDefinition?: (relativePath: string) => Promise<DocDefinition | undefined>;
+
+  /**
+   * Get references to a file (which files reference this file)
+   * Returns an empty array if no files reference this file
+   */
+  getReferences?: (uri: string) => Promise<Reference[]>;
 }
 
 export type ValidateJSON = (

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -101,6 +101,9 @@ MissingTemplate:
   enabled: true
   severity: 0
   ignoreMissing: []
+OrphanedSnippet:
+  enabled: true
+  severity: 1
 PaginationSize:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -79,6 +79,9 @@ MissingTemplate:
   enabled: true
   severity: 0
   ignoreMissing: []
+OrphanedSnippet:
+  enabled: true
+  severity: 1
 PaginationSize:
   enabled: true
   severity: 1

--- a/packages/theme-graph/src/types.ts
+++ b/packages/theme-graph/src/types.ts
@@ -3,6 +3,9 @@ import {
   LiquidSourceCode,
   Dependencies as ThemeCheckDependencies,
   UriString,
+  Reference,
+  Location,
+  Range,
 } from '@shopify/theme-check-common';
 import { Program } from 'acorn';
 
@@ -196,43 +199,7 @@ export interface JsSourceCode {
   ast: Program | Error;
 }
 
-/**
- * A reference is a link between two modules.
- *
- * @example
- *
- * It could be a specific range that points to a whole file
- * {
- *   source: { uri: 'file:///templates/index.json', range: [167, 190] },
- *   target: 'file:///sections/custom-section.liquid'
- * }
- *
- * It could be a specific range that points to a specific range
- * {
- *   // e.g. `<parent-component></parent-component>`
- *   source: { uri: 'file:///snippets/parent.liquid', range: [167, 190] },
- *
- *   // e.g. window.customElements.define('parent-component', ParentComponent);
- *   target: { uri: 'file:///assets/theme.js', range: [0, undefined] }
- * }
- */
-export type Reference = {
-  source: Location;
-  target: Location;
-
-  type:
-    | 'direct' // explicit dependency, e.g. {% render 'child' %}
-    | 'indirect' // indirect dependency, e.g. "blocks": [{ "type": "@theme" }]
-    | 'preset'; // preset dependency
-};
-
-export type Range = [start: number, end: number]; // represents a range in the source code
-export type Location = {
-  /** The URI of the module */
-  uri: UriString;
-  /** Optional range inside that module */
-  range?: Range;
-};
+export { Reference, Range, Location };
 
 export type Void = void | Void[]; /** e.g. product-element, */
 

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -4,6 +4,7 @@ import {
   makeFileExists,
   Offense,
   path,
+  Reference,
   SectionSchema,
   Severity,
   SourceCodeType,
@@ -15,6 +16,7 @@ import { AugmentedSourceCode, DocumentManager } from '../documents';
 import { Dependencies } from '../types';
 import { DiagnosticsManager } from './DiagnosticsManager';
 import { offenseSeverity } from './offenseToDiagnostic';
+import { ThemeGraphManager } from '../server/ThemeGraphManager';
 
 export function makeRunChecks(
   documentManager: DocumentManager,
@@ -26,10 +28,11 @@ export function makeRunChecks(
     jsonValidationSet,
     getMetafieldDefinitions,
     cssLanguageService,
+    themeGraphManager,
   }: Pick<
     Dependencies,
     'fs' | 'loadConfig' | 'themeDocset' | 'jsonValidationSet' | 'getMetafieldDefinitions'
-  > & { cssLanguageService?: CSSLanguageService },
+  > & { cssLanguageService?: CSSLanguageService; themeGraphManager?: ThemeGraphManager },
 ) {
   return async function runChecks(triggerURIs: string[]): Promise<void> {
     // This function takes an array of triggerURIs so that we can correctly
@@ -63,6 +66,11 @@ export function makeRunChecks(
         themeDocset,
         jsonValidationSet,
         getMetafieldDefinitions,
+
+        async getReferences(uri: string): Promise<Reference[]> {
+          if (!themeGraphManager) return [];
+          return themeGraphManager.getReferences(uri);
+        },
 
         // TODO should do something for app blocks?
         async getBlockSchema(name) {

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -182,6 +182,7 @@ export function startServer(
       jsonValidationSet,
       getMetafieldDefinitions,
       cssLanguageService,
+      themeGraphManager,
     }),
     100,
   );


### PR DESCRIPTION
## What are you adding in this PR?

This PR adds a new `OrphanedSnippet` check to detect snippet files that are not referenced by any other files in the theme. This helps identify unused snippets that can be safely removed.

The implementation includes:
- A new `OrphanedSnippet` check with comprehensive tests
- Integration with the theme graph system to detect file references
- Moved `Reference` type definitions to `theme-check-common`, avoiding circular dependencies in order to support the check
- Updated configuration files to enable the check by default

The check reports a warning when it finds snippet files that aren't referenced anywhere else in the theme, helping developers maintain cleaner codebases by identifying unused files.

## What's next? Any followup issues?

## Before you deploy

- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] It's in the `allChecks` array in `src/checks/index.ts`
  - [x] I ran `yarn build` and committed the updated configuration files
  - [ ] If applicable, I've updated the `theme-app-extension.yml` config
  - [x] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (link PR here).