### PR TITLE
Reworded error messages for conditional html liquid syntax check

### DIFF
--- a/.changeset/tough-ties-tickle.md
+++ b/.changeset/tough-ties-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Change wording around syntax errors for invalid conditional nodes in Liquid HTML Syntax check


### PR DESCRIPTION
## What are you adding in this PR?

Changing the messages we show in Liquid HTML Syntax Checks when finding errors in conditional nodes.

**For quick reference:**
Cases where the parser ignores anything after the first truthy value with an invalid conditional
`{% if 7 1 > 100 %}hello{% endif %}` will return 
`Syntax is not supported: Expression stops at truthy value '7', and will ignore: '1 > 100'`

Cases where the parser will render a special character after an `if` as false
`{% if > 2 %}hello{% endif %}`
`Syntax is not supported: Conditional cannot start with '>'. Use a variable or value instead`

Cases where we have trailing tokens after a valid conditional
`{% if 6 > 5 'foobar' %}hello{% endif %}`
`Syntax is not supported: Conditional is invalid. Anything after '6 > 5' will be ignored`

Cases where we are using `&&` or `||` instead of `and/or`
`{% if true && false %}hello{% endif %}`
`Syntax is not supported: Expression stops at truthy value 'true', and will ignore: '&& false'. Use 'and'/'or' instead of '&&'/'||' for multiple conditions`


## What's next? Any followup issues?

<!-- Outline follow up tasks with links to issues so they're tracked. -->

## What did you learn?

<!-- Totally optional. But... If you learned something interesting, why not share it? -->

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Check changes -->
- [ ] This PR includes a new checks or changes the configuration of a check
  - [ ] I included a minor bump `changeset`
  - [ ] It's in the `allChecks` array in `src/checks/index.ts`
  - [ ] I ran `yarn build` and committed the updated configuration files
    <!-- It might be that a check doesn't make sense in a theme-app-extension context -->
    <!-- When that happens, the check's config should be updated/overridden in the theme-app-extension config -->
    <!-- see packages/node/configs/theme-app-extension.yml -->
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config
  - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable (link PR here).

<!-- Public API changes, new features -->
- [ ] I included a minor bump `changeset`
- [ ] My feature is backward compatible

<!-- Bug fixes -->
- [ ] I included a patch bump `changeset`
