### PR TITLE
Added document links inside schema tags

### DIFF
--- a/.changeset/lazy-seas-collect.md
+++ b/.changeset/lazy-seas-collect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Added document linking inside schema tags, which enhances developer experience

--- a/packages/theme-language-server-common/src/json/JSONLanguageService.spec.ts
+++ b/packages/theme-language-server-common/src/json/JSONLanguageService.spec.ts
@@ -120,6 +120,7 @@ describe('Module: JSONLanguageService', () => {
       (uri: string) => Promise.resolve(uri.includes('tae') ? 'app' : 'theme'),
       () => Promise.resolve([]),
       async () => undefined,
+      async () => 'file:///test-root',
     );
 
     await jsonLanguageService.setup({

--- a/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/json/completions/providers/BlockTypeCompletionProvider.spec.ts
@@ -64,6 +64,7 @@ describe('Unit: BlockTypeCompletionProvider', () => {
       async () => 'theme',
       async () => blockNames,
       async () => undefined,
+      async () => 'file:///test-root',
     );
 
     await jsonLanguageService.setup({

--- a/packages/theme-language-server-common/src/json/documentLinks/DocumentLinksProvider.spec.ts
+++ b/packages/theme-language-server-common/src/json/documentLinks/DocumentLinksProvider.spec.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DocumentManager } from '../../documents';
+import { createJSONDocumentLinksVisitor } from './DocumentLinksProvider';
+import { toJSONAST, visit } from '@shopify/theme-check-common';
+import { URI } from 'vscode-uri';
+
+describe('JSON Document Links in Schema Tags', () => {
+  let documentManager: DocumentManager;
+  let rootUri: string;
+  let uriString: string;
+
+  beforeEach(() => {
+    documentManager = new DocumentManager();
+  });
+
+  it('should return document links for block types in schema tags', async () => {
+    uriString = 'file:///path/to/sections/header.liquid';
+    rootUri = 'file:///path/to/project';
+
+    const schemaContent = `
+      {
+        "name": "Header",
+        "blocks": [
+          { "type": "logo" },
+          { "type": "navigation" }
+        ]
+      }
+    `;
+
+    const liquidContent = `
+      <div>Header content</div>
+      
+      {% schema %}
+      ${schemaContent}
+      {% endschema %}
+    `;
+
+    documentManager.open(uriString, liquidContent, 1);
+
+    const textDocument = documentManager.get(uriString)!.textDocument;
+    const schemaOffset = liquidContent.indexOf(schemaContent);
+
+    const visitor = createJSONDocumentLinksVisitor(textDocument, URI.parse(rootUri), schemaOffset);
+    const ast = toJSONAST(schemaContent);
+
+    if (ast instanceof Error) throw ast;
+    const result = visit(ast, visitor);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].target).toBe('file:///path/to/project/blocks/logo.liquid');
+    expect(result[1].target).toBe('file:///path/to/project/blocks/navigation.liquid');
+  });
+
+  it('should handle section types in schema tags', async () => {
+    uriString = 'file:///path/to/sections/main-collection.liquid';
+    rootUri = 'file:///path/to/project';
+
+    const schemaContent = `
+      {
+        "name": "Collection",
+        "blocks": [
+          {
+            "type": "text",
+            "settings": []
+          }
+        ],
+        "presets": [
+          {
+            "name": "Default",
+            "blocks": [
+              { "type": "text" }
+            ]
+          }
+        ]
+      }
+    `;
+
+    const liquidContent = `
+      <div>Collection content</div>
+      
+      {% schema %}
+      ${schemaContent}
+      {% endschema %}
+    `;
+
+    documentManager.open(uriString, liquidContent, 1);
+
+    const textDocument = documentManager.get(uriString)!.textDocument;
+    const schemaOffset = liquidContent.indexOf(schemaContent);
+
+    const visitor = createJSONDocumentLinksVisitor(textDocument, URI.parse(rootUri), schemaOffset);
+    const ast = toJSONAST(schemaContent);
+
+    if (ast instanceof Error) throw ast;
+    const result = visit(ast, visitor);
+
+    // Should find both block type references (in blocks array and in presets)
+    expect(result).toHaveLength(2);
+    expect(result[0].target).toBe('file:///path/to/project/blocks/text.liquid');
+    expect(result[1].target).toBe('file:///path/to/project/blocks/text.liquid');
+  });
+
+  it('should not create links for special block types in schema tags', async () => {
+    uriString = 'file:///path/to/sections/app-blocks.liquid';
+    rootUri = 'file:///path/to/project';
+
+    const schemaContent = `
+      {
+        "name": "App Blocks",
+        "blocks": [
+          { "type": "@app" },
+          { "type": "@theme" },
+          { "type": "custom-block" }
+        ]
+      }
+    `;
+
+    const liquidContent = `
+      <div>App blocks section</div>
+      
+      {% schema %}
+      ${schemaContent}
+      {% endschema %}
+    `;
+
+    documentManager.open(uriString, liquidContent, 1);
+
+    const textDocument = documentManager.get(uriString)!.textDocument;
+    const schemaOffset = liquidContent.indexOf(schemaContent);
+
+    const visitor = createJSONDocumentLinksVisitor(textDocument, URI.parse(rootUri), schemaOffset);
+    const ast = toJSONAST(schemaContent);
+
+    if (ast instanceof Error) throw ast;
+    const result = visit(ast, visitor);
+
+    // Should only create link for custom-block, not @app or @theme
+    expect(result).toHaveLength(1);
+    expect(result[0].target).toBe('file:///path/to/project/blocks/custom-block.liquid');
+  });
+});

--- a/packages/theme-language-server-common/src/json/documentLinks/DocumentLinksProvider.ts
+++ b/packages/theme-language-server-common/src/json/documentLinks/DocumentLinksProvider.ts
@@ -1,0 +1,61 @@
+import { JSONNode, SourceCodeType } from '@shopify/theme-check-common';
+import { DocumentLink, Range } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI, Utils } from 'vscode-uri';
+import { Visitor } from '@shopify/theme-check-common';
+
+export function createJSONDocumentLinksVisitor(
+  textDocument: TextDocument,
+  root: URI,
+  offset: number = 0,
+): Visitor<SourceCodeType.JSON, DocumentLink> {
+  const visitor: Visitor<SourceCodeType.JSON, DocumentLink> = {
+    Property(node, ancestors) {
+      const origin = jsonPropertyOriginDirectory(ancestors);
+
+      if (!origin) return;
+
+      if (
+        !(
+          node.key.value === 'type' &&
+          node.value.type === 'Literal' &&
+          typeof node.value.value === 'string'
+        )
+      ) {
+        return;
+      }
+
+      if (origin === 'blocks' && ['@app', '@theme'].includes(node.value.value)) {
+        return;
+      }
+
+      return DocumentLink.create(
+        range(textDocument, node.value, offset),
+        Utils.resolvePath(root, origin, node.value.value + '.liquid').toString(),
+      );
+    },
+  };
+  return visitor;
+}
+
+function range(textDocument: TextDocument, node: JSONNode, offset: number): Range {
+  // +1 and -1 to exclude the quotes
+  const start = textDocument.positionAt(offset + node.loc.start.offset + 1);
+  const end = textDocument.positionAt(offset + node.loc.end.offset - 1);
+  return Range.create(start, end);
+}
+
+function jsonPropertyOriginDirectory(ancestors: JSONNode[]): 'sections' | 'blocks' | undefined {
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    const ancestor = ancestors[i];
+    if (ancestor.type === 'Property') {
+      if (ancestor.key.value === 'blocks') {
+        return 'blocks';
+      }
+      if (ancestor.key.value === 'sections') {
+        return 'sections';
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/theme-language-server-common/src/json/test/test-helpers.ts
+++ b/packages/theme-language-server-common/src/json/test/test-helpers.ts
@@ -63,5 +63,6 @@ export function mockJSONLanguageService(
       }
       return doc.getSchema();
     },
+    async () => rootUri,
   );
 }


### PR DESCRIPTION
## What are you adding in this PR?

Added document links support for schema tags in Liquid files. This enhancement allows navigation from schema tags within Liquid files to referenced blocks.

The implementation includes:
- A new `JsonDocumentLinksProvider` class for handling JSON document links
- Integration with the existing `DocumentLinksProvider` to support schema tags
- Special handling for block types (ignoring special types like `@app` and `@theme`)

## What's next? Any followup issues?

- Implement theme graph in DocumentLinks as described [here](https://github.com/Shopify/theme-tools/issues/968)

## What did you learn?

- Implementing a visitor in an AST
- It was an interesting challenge when it came to implementing a visitor inside the current visitor. 

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible