### PR TITLE
Added document linking inside json files

### DIFF
--- a/.changeset/sixty-queens-float.md
+++ b/.changeset/sixty-queens-float.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Added document linking inside json files

--- a/packages/theme-language-server-common/src/json/JSONLanguageService.ts
+++ b/packages/theme-language-server-common/src/json/JSONLanguageService.ts
@@ -144,6 +144,12 @@ export class JSONLanguageService {
     if (!document) return [];
 
     switch (document.type) {
+      case SourceCodeType.JSON: {
+        if (document.ast instanceof Error) return [];
+        const visitor = createJSONDocumentLinksVisitor(document.textDocument, URI.parse(rootUri));
+        return visit(document.ast, visitor);
+      }
+
       case SourceCodeType.LiquidHtml: {
         if (document.ast instanceof Error) return [];
         const textDocument = document.textDocument;

--- a/packages/theme-language-server-common/src/json/documentLinks/DocumentLinksProvider.spec.ts
+++ b/packages/theme-language-server-common/src/json/documentLinks/DocumentLinksProvider.spec.ts
@@ -3,139 +3,221 @@ import { DocumentManager } from '../../documents';
 import { createJSONDocumentLinksVisitor } from './DocumentLinksProvider';
 import { toJSONAST, visit } from '@shopify/theme-check-common';
 import { URI } from 'vscode-uri';
+import { JSONLanguageService } from '../JSONLanguageService';
 
-describe('JSON Document Links in Schema Tags', () => {
+describe('JSON Document Links', () => {
   let documentManager: DocumentManager;
   let rootUri: string;
   let uriString: string;
+  let jsonLanguageService: JSONLanguageService;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     documentManager = new DocumentManager();
-  });
-
-  it('should return document links for block types in schema tags', async () => {
-    uriString = 'file:///path/to/sections/header.liquid';
     rootUri = 'file:///path/to/project';
 
-    const schemaContent = `
-      {
-        "name": "Header",
-        "blocks": [
-          { "type": "logo" },
-          { "type": "navigation" }
-        ]
-      }
-    `;
+    // Create a minimal JSONLanguageService for testing
+    jsonLanguageService = new JSONLanguageService(
+      documentManager,
+      { schemas: async () => [] },
+      async () => ({}),
+      async () => 'theme',
+      async () => [],
+      async () => undefined,
+      async () => rootUri,
+    );
 
-    const liquidContent = `
-      <div>Header content</div>
-      
-      {% schema %}
-      ${schemaContent}
-      {% endschema %}
-    `;
-
-    documentManager.open(uriString, liquidContent, 1);
-
-    const textDocument = documentManager.get(uriString)!.textDocument;
-    const schemaOffset = liquidContent.indexOf(schemaContent);
-
-    const visitor = createJSONDocumentLinksVisitor(textDocument, URI.parse(rootUri), schemaOffset);
-    const ast = toJSONAST(schemaContent);
-
-    if (ast instanceof Error) throw ast;
-    const result = visit(ast, visitor);
-
-    expect(result).toHaveLength(2);
-    expect(result[0].target).toBe('file:///path/to/project/blocks/logo.liquid');
-    expect(result[1].target).toBe('file:///path/to/project/blocks/navigation.liquid');
+    // Initialize the service to resolve the initialized promise
+    await jsonLanguageService.setup({});
   });
 
-  it('should handle section types in schema tags', async () => {
-    uriString = 'file:///path/to/sections/main-collection.liquid';
-    rootUri = 'file:///path/to/project';
+  describe('Schema Tags in Liquid Files', () => {
+    it('should return document links for block types in schema tags', async () => {
+      uriString = 'file:///path/to/sections/header.liquid';
+      rootUri = 'file:///path/to/project';
 
-    const schemaContent = `
-      {
-        "name": "Collection",
-        "blocks": [
-          {
-            "type": "text",
-            "settings": []
+      const schemaContent = `
+        {
+          "name": "Header",
+          "blocks": [
+            { "type": "logo" },
+            { "type": "navigation" }
+          ]
+        }
+      `;
+
+      const liquidContent = `
+        <div>Header content</div>
+        
+        {% schema %}
+        ${schemaContent}
+        {% endschema %}
+      `;
+
+      documentManager.open(uriString, liquidContent, 1);
+
+      const textDocument = documentManager.get(uriString)!.textDocument;
+      const schemaOffset = liquidContent.indexOf(schemaContent);
+
+      const visitor = createJSONDocumentLinksVisitor(
+        textDocument,
+        URI.parse(rootUri),
+        schemaOffset,
+      );
+      const ast = toJSONAST(schemaContent);
+
+      if (ast instanceof Error) throw ast;
+      const result = visit(ast, visitor);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].target).toBe('file:///path/to/project/blocks/logo.liquid');
+      expect(result[1].target).toBe('file:///path/to/project/blocks/navigation.liquid');
+    });
+
+    it('should handle section types in schema tags', async () => {
+      uriString = 'file:///path/to/sections/main-collection.liquid';
+      rootUri = 'file:///path/to/project';
+
+      const schemaContent = `
+        {
+          "name": "Collection",
+          "blocks": [
+            {
+              "type": "text",
+              "settings": []
+            }
+          ],
+          "presets": [
+            {
+              "name": "Default",
+              "blocks": [
+                { "type": "text" }
+              ]
+            }
+          ]
+        }
+      `;
+
+      const liquidContent = `
+        <div>Collection content</div>
+        
+        {% schema %}
+        ${schemaContent}
+        {% endschema %}
+      `;
+
+      documentManager.open(uriString, liquidContent, 1);
+
+      const textDocument = documentManager.get(uriString)!.textDocument;
+      const schemaOffset = liquidContent.indexOf(schemaContent);
+
+      const visitor = createJSONDocumentLinksVisitor(
+        textDocument,
+        URI.parse(rootUri),
+        schemaOffset,
+      );
+      const ast = toJSONAST(schemaContent);
+
+      if (ast instanceof Error) throw ast;
+      const result = visit(ast, visitor);
+
+      // Should find both block type references (in blocks array and in presets)
+      expect(result).toHaveLength(2);
+      expect(result[0].target).toBe('file:///path/to/project/blocks/text.liquid');
+      expect(result[1].target).toBe('file:///path/to/project/blocks/text.liquid');
+    });
+
+    it('should not create links for special block types in schema tags', async () => {
+      uriString = 'file:///path/to/sections/app-blocks.liquid';
+      rootUri = 'file:///path/to/project';
+
+      const schemaContent = `
+        {
+          "name": "App Blocks",
+          "blocks": [
+            { "type": "@app" },
+            { "type": "@theme" },
+            { "type": "custom-block" }
+          ]
+        }
+      `;
+
+      const liquidContent = `
+        <div>App blocks section</div>
+        
+        {% schema %}
+        ${schemaContent}
+        {% endschema %}
+      `;
+
+      documentManager.open(uriString, liquidContent, 1);
+
+      const textDocument = documentManager.get(uriString)!.textDocument;
+      const schemaOffset = liquidContent.indexOf(schemaContent);
+      const visitor = createJSONDocumentLinksVisitor(
+        textDocument,
+        URI.parse(rootUri),
+        schemaOffset,
+      );
+      const ast = toJSONAST(schemaContent);
+
+      if (ast instanceof Error) throw ast;
+      const result = visit(ast, visitor);
+
+      // Should only create link for custom-block, not @app or @theme
+      expect(result).toHaveLength(1);
+      expect(result[0].target).toBe('file:///path/to/project/blocks/custom-block.liquid');
+    });
+  });
+
+  describe('JSON Files', () => {
+    it('should return document links for section types in template JSON files', async () => {
+      uriString = 'file:///path/to/templates/index.json';
+
+      const jsonContent = `{
+        "layout": "theme",
+        "sections": {
+          "header": {
+            "type": "header-section"
+          },
+          "main": {
+            "type": "main-product"
           }
-        ],
-        "presets": [
-          {
-            "name": "Default",
-            "blocks": [
-              { "type": "text" }
-            ]
-          }
-        ]
-      }
-    `;
+        }
+      }`;
 
-    const liquidContent = `
-      <div>Collection content</div>
-      
-      {% schema %}
-      ${schemaContent}
-      {% endschema %}
-    `;
+      documentManager.open(uriString, jsonContent, 1);
 
-    documentManager.open(uriString, liquidContent, 1);
+      const result = await jsonLanguageService.documentLinks({
+        textDocument: { uri: uriString },
+      });
 
-    const textDocument = documentManager.get(uriString)!.textDocument;
-    const schemaOffset = liquidContent.indexOf(schemaContent);
+      expect(result).toHaveLength(2);
+      expect(result[0].target).toBe('file:///path/to/project/sections/header-section.liquid');
+      expect(result[1].target).toBe('file:///path/to/project/sections/main-product.liquid');
+    });
 
-    const visitor = createJSONDocumentLinksVisitor(textDocument, URI.parse(rootUri), schemaOffset);
-    const ast = toJSONAST(schemaContent);
+    it('should return document links for block types in section JSON files', async () => {
+      uriString = 'file:///path/to/sections/settings.json';
 
-    if (ast instanceof Error) throw ast;
-    const result = visit(ast, visitor);
-
-    // Should find both block type references (in blocks array and in presets)
-    expect(result).toHaveLength(2);
-    expect(result[0].target).toBe('file:///path/to/project/blocks/text.liquid');
-    expect(result[1].target).toBe('file:///path/to/project/blocks/text.liquid');
-  });
-
-  it('should not create links for special block types in schema tags', async () => {
-    uriString = 'file:///path/to/sections/app-blocks.liquid';
-    rootUri = 'file:///path/to/project';
-
-    const schemaContent = `
-      {
-        "name": "App Blocks",
+      const jsonContent = `{
+        "name": "Section with blocks",
         "blocks": [
-          { "type": "@app" },
-          { "type": "@theme" },
-          { "type": "custom-block" }
+          { "type": "text" },
+          { "type": "image" },
+          { "type": "@app" }
         ]
-      }
-    `;
+      }`;
 
-    const liquidContent = `
-      <div>App blocks section</div>
-      
-      {% schema %}
-      ${schemaContent}
-      {% endschema %}
-    `;
+      documentManager.open(uriString, jsonContent, 1);
 
-    documentManager.open(uriString, liquidContent, 1);
+      const result = await jsonLanguageService.documentLinks({
+        textDocument: { uri: uriString },
+      });
 
-    const textDocument = documentManager.get(uriString)!.textDocument;
-    const schemaOffset = liquidContent.indexOf(schemaContent);
-
-    const visitor = createJSONDocumentLinksVisitor(textDocument, URI.parse(rootUri), schemaOffset);
-    const ast = toJSONAST(schemaContent);
-
-    if (ast instanceof Error) throw ast;
-    const result = visit(ast, visitor);
-
-    // Should only create link for custom-block, not @app or @theme
-    expect(result).toHaveLength(1);
-    expect(result[0].target).toBe('file:///path/to/project/blocks/custom-block.liquid');
+      expect(result).toHaveLength(2);
+      expect(result[0].target).toBe('file:///path/to/project/blocks/text.liquid');
+      expect(result[1].target).toBe('file:///path/to/project/blocks/image.liquid');
+      // @app should not create a link
+    });
   });
 });

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -509,13 +509,11 @@ export function startServer(
   connection.onDocumentLinks(async (params) => {
     if (hasUnsupportedDocument(params)) return [];
 
-    const document = documentManager.get(params.textDocument.uri);
-    if (!document || document.type !== SourceCodeType.LiquidHtml) return [];
-
     const [liquidLinks, jsonLinks] = await Promise.all([
       documentLinksProvider.documentLinks(params.textDocument.uri),
       jsonLanguageService.documentLinks(params),
     ]);
+
     return [...liquidLinks, ...jsonLinks];
   });
 


### PR DESCRIPTION
## What are you adding in this PR?

Added document linking support inside JSON files. This allow faster navigation and better dev experience.

The implementation:
- Extends the DocumentLinksProvider to handle JSON files in addition to Liquid HTML files
- Creates links for section type references in templates
- Creates links for block type references in section schemas
- Properly ignores special block types like "@app" and "@theme"
- Handles nested structures correctly

## What's next? Any followup issues?

## What did you learn?

Working with document links across different file types requires careful handling of URI paths and proper type checking to ensure the correct linking behavior.

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible