### PR TITLE
Add translation key Go-to-definition support 

### DIFF
--- a/.changeset/quiet-spoons-occur.md
+++ b/.changeset/quiet-spoons-occur.md
@@ -1,0 +1,7 @@
+---
+'@shopify/theme-language-server-common': minor
+'theme-check-vscode': minor
+'@shopify/theme-check-common': patch
+---
+
+Add translation key go-to-definition support

--- a/packages/theme-check-common/src/context-utils.ts
+++ b/packages/theme-check-common/src/context-utils.ts
@@ -33,6 +33,11 @@ export const makeFileSize = (fs: AbstractFileSystem) =>
     }
   };
 
+export const makeGetDefaultLocaleFileUri = (fs: AbstractFileSystem) =>
+  async function getDefaultLocaleFileUri(rootUri: string, postfix = '.default.json') {
+    return getDefaultLocaleFile(fs, rootUri, postfix);
+  };
+
 export const makeGetDefaultLocale = getDefaultLocaleFactoryFactory('.default.json');
 export const makeGetDefaultSchemaLocale = getDefaultLocaleFactoryFactory('.default.schema.json');
 function getDefaultLocaleFactoryFactory(postfix = '.default.json') {

--- a/packages/theme-language-server-common/src/definitions/BaseDefinitionProvider.ts
+++ b/packages/theme-language-server-common/src/definitions/BaseDefinitionProvider.ts
@@ -1,0 +1,10 @@
+import { LiquidHtmlNode } from '@shopify/liquid-html-parser';
+import { DefinitionParams, DefinitionLink } from 'vscode-languageserver-protocol';
+
+export interface BaseDefinitionProvider {
+  definitions(
+    params: DefinitionParams,
+    node: LiquidHtmlNode,
+    ancestors: LiquidHtmlNode[],
+  ): Promise<DefinitionLink[]>;
+}

--- a/packages/theme-language-server-common/src/definitions/DefinitionProvider.ts
+++ b/packages/theme-language-server-common/src/definitions/DefinitionProvider.ts
@@ -1,0 +1,42 @@
+import { findCurrentNode, SourceCodeType } from '@shopify/theme-check-common';
+import { DefinitionLink, DefinitionParams } from 'vscode-languageserver';
+
+import { AugmentedJsonSourceCode, DocumentManager } from '../documents';
+import { BaseDefinitionProvider } from './BaseDefinitionProvider';
+import { TranslationStringDefinitionProvider } from './providers/TranslationStringDefinitionProvider';
+
+export class DefinitionProvider {
+  private providers: BaseDefinitionProvider[];
+
+  constructor(
+    private documentManager: DocumentManager,
+    getDefaultLocaleSourceCode: (uri: string) => Promise<AugmentedJsonSourceCode | null>,
+  ) {
+    this.providers = [
+      new TranslationStringDefinitionProvider(documentManager, getDefaultLocaleSourceCode),
+    ];
+  }
+
+  async definitions(params: DefinitionParams): Promise<DefinitionLink[] | null> {
+    const sourceCode = this.documentManager.get(params.textDocument.uri);
+    if (
+      !sourceCode ||
+      sourceCode.type !== SourceCodeType.LiquidHtml ||
+      sourceCode.ast instanceof Error
+    ) {
+      return null;
+    }
+
+    const { textDocument } = sourceCode;
+    const [node, ancestors] = findCurrentNode(
+      sourceCode.ast,
+      textDocument.offsetAt(params.position),
+    );
+
+    const results: DefinitionLink[] = await Promise.all(
+      this.providers.map((provider) => provider.definitions(params, node, ancestors)),
+    ).then((res) => res.flat());
+
+    return results.length > 0 ? results : null;
+  }
+}

--- a/packages/theme-language-server-common/src/definitions/providers/TranslationStringDefinitionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/definitions/providers/TranslationStringDefinitionProvider.spec.ts
@@ -1,0 +1,73 @@
+import { JSONSourceCode, SourceCodeType, toSourceCode } from '@shopify/theme-check-common';
+import { assert, beforeEach, describe, expect, it } from 'vitest';
+import { DefinitionParams, LocationLink } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { AugmentedJsonSourceCode, DocumentManager } from '../../documents';
+import { DefinitionProvider } from '../DefinitionProvider';
+
+describe('Module: TranslationStringDefinitionProvider', () => {
+  let provider: DefinitionProvider;
+  let documentManager: DocumentManager;
+  let mockGetDefaultLocaleSourceCode: (uri: string) => Promise<any>;
+
+  beforeEach(() => {
+    documentManager = new DocumentManager();
+
+    const translationFileContents = JSON.stringify(
+      {
+        hello: {
+          world: 'Hello World',
+        },
+      },
+      null,
+      2,
+    );
+
+    const uri = 'file:///locales/en.default.json';
+    const sourceCode = toSourceCode(uri, translationFileContents) as JSONSourceCode;
+    mockGetDefaultLocaleSourceCode = async (_uri: string): Promise<AugmentedJsonSourceCode> => {
+      const textDocument = TextDocument.create(uri, sourceCode.type, 1, sourceCode.source);
+      return {
+        ...sourceCode,
+        textDocument,
+      };
+    };
+
+    provider = new DefinitionProvider(documentManager, mockGetDefaultLocaleSourceCode);
+  });
+
+  it('finds the definition of existing translation keys', async () => {
+    documentManager.open('file:///test.liquid', '{{ "hello.world" | t }}', 1);
+    const params: DefinitionParams = {
+      textDocument: { uri: 'file:///test.liquid' },
+      position: { line: 0, character: 5 }, // Position within "hello.world"
+    };
+
+    const result = await provider.definitions(params);
+
+    assert(result);
+    expect(result).toHaveLength(1);
+    assert(LocationLink.is(result[0]));
+    expect(result[0]).toMatchObject({
+      targetUri: 'file:///locales/en.default.json',
+      targetRange: {
+        start: { line: 2, character: expect.any(Number) },
+        end: { line: 2, character: expect.any(Number) },
+      },
+    });
+  });
+
+  it('returns null for non-existent translation key', async () => {
+    const liquidContent = '{{ "unknown.key" | t }}';
+    documentManager.open('file:///templates/products.liquid', liquidContent, 1);
+
+    const params: DefinitionParams = {
+      textDocument: { uri: 'file:///templates/products.liquid' },
+      position: { line: 0, character: 7 }, // Position within "unknown.key"
+    };
+
+    const result = await provider.definitions(params);
+
+    assert(result === null);
+  });
+});

--- a/packages/theme-language-server-common/src/definitions/providers/TranslationStringDefinitionProvider.ts
+++ b/packages/theme-language-server-common/src/definitions/providers/TranslationStringDefinitionProvider.ts
@@ -1,0 +1,72 @@
+import { LiquidHtmlNode, NodeTypes } from '@shopify/liquid-html-parser';
+import { SourceCodeType, nodeAtPath } from '@shopify/theme-check-common';
+import {
+  DefinitionParams,
+  DefinitionLink,
+  Range,
+  LocationLink,
+} from 'vscode-languageserver-protocol';
+import { DocumentManager, AugmentedJsonSourceCode } from '../../documents';
+import { BaseDefinitionProvider } from '../BaseDefinitionProvider';
+
+export class TranslationStringDefinitionProvider implements BaseDefinitionProvider {
+  constructor(
+    private documentManager: DocumentManager,
+    private getDefaultLocaleSourceCode: (uri: string) => Promise<AugmentedJsonSourceCode | null>,
+  ) {}
+
+  async definitions(
+    params: DefinitionParams,
+    node: LiquidHtmlNode,
+    ancestors: LiquidHtmlNode[],
+  ): Promise<DefinitionLink[]> {
+    const doc = this.documentManager.get(params.textDocument.uri)?.textDocument;
+    if (!doc) return [];
+
+    // We want {{ node | t }}
+    if (node.type !== NodeTypes.String) return [];
+    const parent = ancestors.at(-1);
+    if (!parent || parent.type !== NodeTypes.LiquidVariable) return [];
+
+    // Making sure node is the expression
+    if (parent.expression !== node) return [];
+
+    // We're looking for {{ '...' | t }} or {{ '...' | translate }}
+    if (parent.filters.length === 0 || !['t', 'translate'].includes(parent.filters[0].name)) {
+      return [];
+    }
+
+    // Now we need to find the location of the translation in the translation file
+    const defaultLocaleFile = await this.getDefaultLocaleSourceCode(params.textDocument.uri);
+    if (
+      !defaultLocaleFile ||
+      defaultLocaleFile.type !== SourceCodeType.JSON ||
+      defaultLocaleFile.ast instanceof Error
+    ) {
+      return [];
+    }
+
+    const translationKey = node.value;
+    const translationNode = nodeAtPath(defaultLocaleFile.ast, translationKey.split('.'));
+
+    if (!translationNode) return [];
+
+    const targetRange = Range.create(
+      defaultLocaleFile.textDocument.positionAt(translationNode.loc.start.offset),
+      defaultLocaleFile.textDocument.positionAt(translationNode.loc.end.offset),
+    );
+    const originRange = Range.create(
+      doc.positionAt(node.position.start),
+      doc.positionAt(node.position.end),
+    );
+
+    return [
+      LocationLink.create(
+        defaultLocaleFile.textDocument.uri,
+        targetRange,
+        targetRange,
+        originRange,
+      ),
+    ];
+  }
+}


### PR DESCRIPTION
## What are you adding in this PR?

- **Add translation key go-to-definition support**

https://github.com/user-attachments/assets/29a9d9c9-36f0-42fc-a4eb-a3b08ead308c


Fixes #563

## What's next? Any followup issues?

- Add schema translation key go-to-definition support
- Add global theme setting go-to-definition support
- Add block setting go-to-definition support
- Add section setting go-to-definition support

## What did you learn?

- Definition != Declaration. Declaration is for things like `file.h` in C. Though they work exactly the same.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Bug fixes -->
- [x] I included a `changeset`
