### PR TITLE
Bump to TS 5

### DIFF
--- a/.changeset/flat-suns-join.md
+++ b/.changeset/flat-suns-join.md
@@ -1,0 +1,16 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+'release-orchestrator': patch
+'@shopify/theme-check-common': patch
+'@shopify/theme-check-node': patch
+'theme-check-vscode': patch
+'@shopify/liquid-html-parser': patch
+'@shopify/theme-check-browser': patch
+'@shopify/theme-check-docs-updater': patch
+'@shopify/theme-graph': patch
+'@shopify/theme-language-server-browser': patch
+'@shopify/theme-language-server-common': patch
+'@shopify/theme-language-server-node': patch
+---
+
+Bump to TypeScript 5

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
-    "typescript": "^4.9.3",
+    "typescript": "^5.9.0",
     "vitest": "^2.1.9",
     "vscode-languageserver-protocol": "^3.17.3",
     "vscode-languageserver-textdocument": "^1.0.8",

--- a/packages/prettier-plugin-liquid/tsconfig.json
+++ b/packages/prettier-plugin-liquid/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["es2020"],
     "outDir": "dist",
     "module": "commonjs",
-    "target": "ES6",
+    "target": "es2020",
     "rootDir": "src",
     "esModuleInterop": true,
     "paths": {

--- a/packages/release-orchestrator/src/steps/getPackageJsonRecord.spec.ts
+++ b/packages/release-orchestrator/src/steps/getPackageJsonRecord.spec.ts
@@ -1,9 +1,9 @@
 import { expect, it, describe, afterEach, afterAll, vi, Mock } from 'vitest';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { getPackageJsonRecord } from './getPackageJsonRecord';
 // import { promisify } from 'node:util';
 
-vi.mock('fs', async () => ({
+vi.mock('fs/promises', async () => ({
   default: { readFile: vi.fn() },
 }));
 

--- a/packages/release-orchestrator/src/utils.ts
+++ b/packages/release-orchestrator/src/utils.ts
@@ -1,11 +1,11 @@
 import { exec } from 'child_process';
 import crypto from 'crypto';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { promisify } from 'node:util';
 import type { RunOptions, StepFunction } from './types';
 
 const execAsync = promisify(exec);
-export const readFile = promisify(fs.readFile);
+export const readFile = fs.readFile;
 
 /**
  * Creates a memoized version of a function.
@@ -54,7 +54,9 @@ export const run = async (cmd: string, runInRepoRoot = true): Promise<string> =>
   const execOptions: RunOptions = runInRepoRoot
     ? { encoding: 'utf-8', cwd: await getRepoRoot() }
     : { encoding: 'utf-8' };
-  const { stdout, stderr } = await execAsync(cmd, execOptions);
+  let { stdout, stderr } = await execAsync(cmd, execOptions);
+  stdout = Buffer.isBuffer(stdout) ? stdout.toString('utf-8') : stdout;
+  stderr = Buffer.isBuffer(stderr) ? stderr.toString('utf-8') : stderr;
   if (stderr) {
     console.error(stderr);
     return stderr.trim();

--- a/packages/theme-check-common/src/index.ts
+++ b/packages/theme-check-common/src/index.ts
@@ -157,7 +157,7 @@ function createContext<T extends SourceCodeType, S extends Schema>(
         end: getPosition(file.source, problem.endIndex),
         fix: problem.fix,
         suggest: problem.suggest,
-      } as Offense<T>);
+      } as Offense<T> as Offense);
     },
     file,
   } as Context<T, S>;

--- a/packages/theme-check-node/src/config/resolve/resolve-config.spec.ts
+++ b/packages/theme-check-node/src/config/resolve/resolve-config.spec.ts
@@ -63,7 +63,7 @@ SomeCheck:
     // mock recommended.yml file
     await fs.writeFile(
       path.join(mockNodeModulePath, 'recommended.yml'),
-      await fs.readFile(path.join(__dirname, '..', 'fixtures', 'node-module-rec.yml')),
+      await fs.readFile(path.join(__dirname, '..', 'fixtures', 'node-module-rec.yml'), 'utf8'),
       'utf8',
     );
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -73,9 +73,9 @@
   "devDependencies": {
     "@shopify/theme-check-docs-updater": "^3.23.0",
     "@types/glob": "^8.0.0",
-    "@types/node": "16.x",
+    "@types/node": "^22",
     "@types/prettier": "^2.4.2",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.104.0",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "@vscode/test-electron": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1350,22 +1350,19 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@16.x":
-  version "16.18.53"
-  resolved "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz"
-  integrity sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==
+"@types/node@*", "@types/node@^22":
+  version "22.18.8"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz#738d9dafa38f6e0c467687c158f8e1ca2d7d8eaa"
+  integrity sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/node@^12.7.1":
   version "12.20.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
-"@types/normalize-package-data@^2.4.0":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.2.tgz#9b0e3e8533fe5024ad32d6637eb9589988b6fdca"
-  integrity sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A==
-
-"@types/normalize-package-data@^2.4.3":
+"@types/normalize-package-data@^2.4.0", "@types/normalize-package-data@^2.4.3":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
@@ -1431,10 +1428,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/vscode@^1.85.0":
-  version "1.94.0"
-  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.94.0.tgz#ccd2111b6ecaba6ad4da19c2d524828fa73ae250"
-  integrity sha512-UyQOIUT0pb14XSqJskYnRwD2aG0QrPVefIfrW1djR+/J4KeFQ0i1+hjZoaAmeNf3Z2jleK+R2hv+EboG/m8ruw==
+"@types/vscode@^1.104.0":
+  version "1.104.0"
+  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.104.0.tgz#6e4d041d1ff5722db72c688518b330fcfb6fc658"
+  integrity sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==
 
 "@types/ws@^8.5.5":
   version "8.5.7"
@@ -7551,10 +7548,10 @@ typed-rest-client@^1.8.4:
     tunnel "0.0.6"
     underscore "^1.12.1"
 
-typescript@^4.9.3:
-  version "4.9.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.9.0:
+  version "5.9.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -7580,6 +7577,11 @@ underscore@^1.12.1:
   version "1.13.6"
   resolved "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unicorn-magic@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## What are you adding in this PR?

Bump to TypeScript version 5.

Only had minor issues,

1. We were pushing to the offenses array typed `Offense[]` an `Offense<T>` and it didn't like that.
2. We were using the `s` regex flag which only works in ES2018+, the compiler didn't catch that before. So we updated the tsconfig for the prettier plugin to target ES2018 as it should. 
3. Some of the node packages started return Buffer | string and we needed to adapt
4. Some of the `@types` were outdated and didn't work in TS 5

Thanks to https://github.com/microsoft/TypeScript/issues/33133#issuecomment-526277334, I was able to debug what was up because tsc was crashing and giving no valuable information

Fixes #1064 

## Before you deploy

<!-- Delete the checklists you don't need -->

No changeset since this is an internal change. 
