### PR TITLE
Added doc tag support logic inside snippet tag

### DIFF
--- a/packages/theme-check-common/src/checks/unsupported-doc-tag/index.ts
+++ b/packages/theme-check-common/src/checks/unsupported-doc-tag/index.ts
@@ -1,6 +1,7 @@
 import { isSnippet, isBlock } from '../../to-schema';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 import { filePathSupportsLiquidDoc } from '../../liquid-doc/utils';
+import { LiquidRawTag, NodeTypes, LiquidHtmlNode } from '@shopify/liquid-html-parser';
 
 export const UnsupportedDocTag: LiquidCheckDefinition = {
   meta: {
@@ -19,18 +20,30 @@ export const UnsupportedDocTag: LiquidCheckDefinition = {
 
   create(context) {
     const docTagName = 'doc';
-
-    if (filePathSupportsLiquidDoc(context.file.uri)) {
-      return {};
-    }
+    const snippetTagName = 'snippet';
 
     return {
-      async LiquidRawTag(node) {
+      async LiquidRawTag(node: LiquidRawTag, ancestors: LiquidHtmlNode[]) {
         if (node.name !== docTagName) {
           return;
         }
+
+        const isInSnippetOrBlockFile = filePathSupportsLiquidDoc(context.file.uri);
+        const immediateParent = ancestors.at(-1);
+        const isTopLevelInFile = immediateParent?.type === NodeTypes.Document;
+        const isDirectChildOfSnippetTag =
+          immediateParent?.type === NodeTypes.LiquidTag && immediateParent.name === snippetTagName;
+
+        if ((isInSnippetOrBlockFile && isTopLevelInFile) || isDirectChildOfSnippetTag) {
+          return;
+        }
+
+        const message = isInSnippetOrBlockFile
+          ? `The \`${docTagName}\` tag cannot be nested inside any Liquid tags in a snippet or block file`
+          : `The \`${docTagName}\` must be placed directly within an inline snippet tag, not nested inside other tags`;
+
         context.report({
-          message: `The \`${docTagName}\` tag can only be used within a snippet or block.`,
+          message,
           startIndex: node.position.start,
           endIndex: node.position.end,
           suggest: [


### PR DESCRIPTION
## What are you adding in this PR?
Solves [#826](https://github.com/Shopify/developer-tools-team/issues/826)
Updated theme check to support `doc` tag inside of `snippet` tag. This change allows the `doc` tag to be used within inline snippets, in addition to the previously supported snippet and block contexts.

This PR also makes the theme check more rigorous by ensuring the doc tag is either:
- at the top level of a snippet/block file, OR
- a direct child of the snippet tag

The error message has been updated to reflect this new support, and tests have been added to verify that `doc` tags inside inline snippets don't trigger errors.

## What's next? Any followup issues?

Update the theme check docs

## Before you deploy

- [x] This PR includes a new checks or changes the configuration of a check
 - [x] I included a minor bump `changeset`
 - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable.