### PR TITLE
Added support for render tag completion for inline snippets

### DIFF
--- a/.changeset/flat-geckos-breathe.md
+++ b/.changeset/flat-geckos-breathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Added completion support for inline snippets in the `render` tag

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.spec.ts
@@ -24,11 +24,23 @@ describe('Module: RenderSnippetCompletionProvider', async () => {
 
   it('should complete snippets correctly', async () => {
     await expect(provider).to.complete('{% render "', ['product-card', 'image']);
-    await expect(provider).to.complete('{% render "product', [
+    // VSCode handles filtering
+  });
+
+  it('should complete inline snippets', async () => {
+    const template = `{% snippet my-inline-snippet %}
+  {% echo 'hello' %}
+{% endsnippet %}
+
+{% render m█ %}`;
+
+    await expect(provider).to.complete(template, ['my-inline-snippet']);
+    // VSCode handles filtering
+    await expect(provider).to.complete(template, [
       expect.objectContaining({
         documentation: {
           kind: 'markdown',
-          value: 'snippets/product-card.liquid',
+          value: `Inline snippet "my-inline-snippet"`,
         },
       }),
     ]);

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.ts
@@ -1,7 +1,9 @@
-import { NodeTypes } from '@shopify/liquid-html-parser';
+import { LiquidHtmlNode, LiquidTag, NodeTypes } from '@shopify/liquid-html-parser';
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
 import { LiquidCompletionParams } from '../params';
 import { Provider } from './common';
+import { SourceCodeType, visit, isError } from '@shopify/theme-check-common';
+import { findInlineSnippetAncestor } from '@shopify/theme-check-common/dist/checks/utils';
 
 export type GetSnippetNamesForURI = (uri: string) => Promise<string[]>;
 
@@ -14,21 +16,13 @@ export class RenderSnippetCompletionProvider implements Provider {
     const { node, ancestors } = params.completionContext;
     const parentNode = ancestors.at(-1);
 
-    if (
-      !node ||
-      !parentNode ||
-      node.type !== NodeTypes.String ||
-      parentNode.type !== NodeTypes.RenderMarkup
-    ) {
+    if (!node || !parentNode || parentNode.type !== NodeTypes.RenderMarkup) {
       return [];
     }
 
-    const options = await this.getSnippetNamesForURI(params.textDocument.uri);
-    const partial = node.value;
-
-    return options
-      .filter((option) => option.startsWith(partial))
-      .map(
+    if (node.type === NodeTypes.String) {
+      const fileSnippets = await this.getSnippetNamesForURI(params.textDocument.uri);
+      const fileCompletionItems = fileSnippets.map(
         (option: string): CompletionItem => ({
           label: option,
           kind: CompletionItemKind.Snippet,
@@ -38,5 +32,42 @@ export class RenderSnippetCompletionProvider implements Provider {
           },
         }),
       );
+      return fileCompletionItems;
+    } else if (node.type === NodeTypes.VariableLookup) {
+      const containingSnippet = findInlineSnippetAncestor(ancestors);
+      const containingSnippetName =
+        containingSnippet && typeof containingSnippet.markup !== 'string'
+          ? containingSnippet.markup.name
+          : null;
+
+      const fullAst = params.document.ast;
+      const allInlineSnippets = isError(fullAst) ? [] : getInlineSnippetsNames(fullAst);
+
+      const inlineSnippets = allInlineSnippets.filter((name) => name !== containingSnippetName);
+
+      const inlineCompletionItems = inlineSnippets.map(
+        (option: string): CompletionItem => ({
+          label: option,
+          kind: CompletionItemKind.Snippet,
+          documentation: {
+            kind: 'markdown',
+            value: `Inline snippet "${option}"`,
+          },
+        }),
+      );
+      return inlineCompletionItems;
+    } else {
+      return [];
+    }
   }
+}
+
+function getInlineSnippetsNames(ast: LiquidHtmlNode): string[] {
+  return visit<SourceCodeType.LiquidHtml, string>(ast, {
+    LiquidTag(node: LiquidTag) {
+      if (node.name === 'snippet' && typeof node.markup !== 'string' && node.markup.name) {
+        return node.markup.name;
+      }
+    },
+  });
 }


### PR DESCRIPTION
## What are you adding in this PR?
Solves [#827](https://github.com/Shopify/developer-tools-team/issues/827)
Added completion support for inline snippets in the render tag. Now when using the `{% render %}` tag, the language server will suggest both file-based snippets and inline snippets defined within the same file. Inline snippets are displayed with a helpful documentation note indicating they are "defined in this file".

## What's next? Any followup issues?

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible