### PR TITLE
Updated the undefined-object theme check to skip over inline-snippets

### DIFF
--- a/.changeset/sweet-steaks-greet.md
+++ b/.changeset/sweet-steaks-greet.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Updated the `Undefined-object` theme check to skip over the new `snippet` tags

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -459,4 +459,18 @@ describe('Module: UndefinedObject', () => {
     assert(offenses.length == 0);
     expect(offenses).to.be.empty;
   });
+
+  it('should not report an offense for inline snippet names in snippet and render tags', async () => {
+    const sourceCode = `
+      {% snippet my_inline_snippet %}
+        {% echo 'hello' %}
+      {% endsnippet %}
+
+      {% render my_inline_snippet %}
+    `;
+
+    const offenses = await runLiquidCheck(UndefinedObject, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
 });

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -7,6 +7,7 @@ import {
   LiquidTagDecrement,
   LiquidTagFor,
   LiquidTagIncrement,
+  LiquidTagSnippet,
   LiquidTagTablerow,
   LiquidVariableLookup,
   NamedTags,
@@ -16,7 +17,7 @@ import {
 import { LiquidCheckDefinition, Severity, SourceCodeType, ThemeDocset } from '../../types';
 import { isError, last } from '../../utils';
 import { hasLiquidDoc } from '../../liquid-doc/liquidDoc';
-import { isWithinRawTagThatDoesNotParseItsContents } from '../utils';
+import { isWithinRawTagThatDoesNotParseItsContents, findInlineSnippetAncestor } from '../utils';
 
 type Scope = { start?: number; end?: number };
 
@@ -38,13 +39,14 @@ export const UndefinedObject: LiquidCheckDefinition = {
   create(context) {
     const relativePath = context.toRelativePath(context.file.uri);
     const ast = context.file.ast;
+    const isSnippetFile = relativePath.startsWith('snippets/');
 
     if (isError(ast)) return {};
 
     /**
      * Skip this check when a snippet does not have the presence of doc tags.
      */
-    if (relativePath.startsWith('snippets/') && !hasLiquidDoc(ast)) return {};
+    if (isSnippetFile && !hasLiquidDoc(ast)) return {};
 
     /**
      * Skip this check when definitions for global objects are unavailable.
@@ -56,7 +58,9 @@ export const UndefinedObject: LiquidCheckDefinition = {
     const themeDocset = context.themeDocset;
     const scopedVariables: Map<string, Scope[]> = new Map();
     const fileScopedVariables: Set<string> = new Set();
-    const variables: LiquidVariableLookup[] = [];
+    const variables: Array<{ node: LiquidVariableLookup; inlineSnippet: LiquidTag | null }> = [];
+    const inlineSnippetsWithDocTags: Set<number> = new Set();
+    let snippetFileHasDocTag = false;
 
     function indexVariableScope(variableName: string | null, scope: Scope) {
       if (!variableName) return;
@@ -66,9 +70,27 @@ export const UndefinedObject: LiquidCheckDefinition = {
     }
 
     return {
-      async LiquidDocParamNode(node: LiquidDocParamNode) {
+      async LiquidRawTag(node, ancestors) {
+        if (!isSnippetFile || node.name !== 'doc') return;
+
+        const parent = last(ancestors);
+        if (isLiquidTag(parent) && isLiquidTagSnippet(parent)) {
+          inlineSnippetsWithDocTags.add(parent.position.start);
+        } else {
+          snippetFileHasDocTag = true;
+        }
+      },
+
+      async LiquidDocParamNode(node: LiquidDocParamNode, ancestors: LiquidHtmlNode[]) {
         const paramName = node.paramName?.value;
-        if (paramName) {
+        if (!paramName) return;
+        const snippetAncestor = findInlineSnippetAncestor(ancestors);
+        if (snippetAncestor) {
+          indexVariableScope(paramName, {
+            start: snippetAncestor.blockStartPosition.end,
+            end: snippetAncestor.blockEndPosition?.start,
+          });
+        } else {
           fileScopedVariables.add(paramName);
         }
       },
@@ -134,6 +156,10 @@ export const UndefinedObject: LiquidCheckDefinition = {
             end: node.blockEndPosition?.start,
           });
         }
+
+        if (isLiquidTagSnippet(node) && node.markup.name) {
+          fileScopedVariables.add(node.markup.name);
+        }
       },
 
       async VariableLookup(node, ancestors) {
@@ -142,11 +168,10 @@ export const UndefinedObject: LiquidCheckDefinition = {
         const parent = last(ancestors);
         if (isLiquidTag(parent) && isLiquidTagCapture(parent)) return;
 
-        if (parent?.type === NodeTypes.RenderMarkup && parent.snippet === node) return;
+        if (isLiquidTag(parent) && isLiquidTagSnippet(parent)) return;
 
-        if (isLiquidTag(parent) && parent.name === 'snippet' && parent.markup === node) return;
-
-        variables.push(node);
+        const inlineSnippet = findInlineSnippetAncestor(ancestors);
+        variables.push({ node, inlineSnippet });
       },
 
       async onCodePathEnd() {
@@ -154,8 +179,21 @@ export const UndefinedObject: LiquidCheckDefinition = {
 
         objects.forEach((obj) => fileScopedVariables.add(obj.name));
 
-        variables.forEach((variable) => {
+        variables.forEach(({ node: variable, inlineSnippet }) => {
           if (!variable.name) return;
+
+          // For snippet files: only check variables if they're in a scope with a doc tag.
+          if (isSnippetFile) {
+            if (inlineSnippet) {
+              if (!inlineSnippetsWithDocTags.has(inlineSnippet.position.start)) {
+                return;
+              }
+            } else {
+              if (!snippetFileHasDocTag) {
+                return;
+              }
+            }
+          }
 
           const isVariableDefined = isDefined(
             variable.name,
@@ -270,6 +308,10 @@ function isLiquidTag(node?: LiquidHtmlNode): node is LiquidTag {
 
 function isLiquidTagCapture(node: LiquidTag): node is LiquidTagCapture {
   return node.name === NamedTags.capture;
+}
+
+function isLiquidTagSnippet(node: LiquidTag): node is LiquidTagSnippet {
+  return node.name === NamedTags.snippet;
 }
 
 function isLiquidTagAssign(node: LiquidTag): node is LiquidTagAssign {

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -142,6 +142,10 @@ export const UndefinedObject: LiquidCheckDefinition = {
         const parent = last(ancestors);
         if (isLiquidTag(parent) && isLiquidTagCapture(parent)) return;
 
+        if (parent?.type === NodeTypes.RenderMarkup && parent.snippet === node) return;
+
+        if (isLiquidTag(parent) && parent.name === 'snippet' && parent.markup === node) return;
+
         variables.push(node);
       },
 

--- a/packages/theme-check-common/src/checks/utils.ts
+++ b/packages/theme-check-common/src/checks/utils.ts
@@ -13,6 +13,7 @@ import {
   LiquidTagTablerow,
   LiquidTag,
   LoopNamedTags,
+  NamedTags,
 } from '@shopify/liquid-html-parser';
 import { LiquidHtmlNodeOfType as NodeOfType } from '../types';
 
@@ -102,6 +103,16 @@ export function isLoopScopedVariable(variableName: string, ancestors: LiquidHtml
 
 export function isLoopLiquidTag(tag: LiquidTag): tag is LiquidTagFor | LiquidTagTablerow {
   return LoopNamedTags.includes(tag.name as any);
+}
+
+export function findInlineSnippetAncestor(ancestors: LiquidHtmlNode[]) {
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    const ancestor = ancestors[i];
+    if (ancestor.type === NodeTypes.LiquidTag && ancestor.name === NamedTags.snippet) {
+      return ancestor;
+    }
+  }
+  return null;
 }
 
 const RawTagsThatDoNotParseTheirContents = ['raw', 'stylesheet', 'javascript', 'schema'];


### PR DESCRIPTION
## What are you adding in this PR?

Disabled the "Undefined Object" theme check for the new `snippet` tag to prevent false positives.
This change also includes making the check scope-aware based on inline snippets' doc tag parameters.

## Behaviour before change:

![image.png](https://app.graphite.dev/user-attachments/assets/3ebbbee8-6b98-4c1f-bf4a-79a3ec249a68.png)

![image.png](https://app.graphite.dev/user-attachments/assets/54f5b3c3-2085-4d14-8a05-4a138a0e99fd.png)

## Behaviour after change:

![image.png](https://app.graphite.dev/user-attachments/assets/b9579d4a-78a0-4fac-b8d2-bd3265515dd6.png)

![image.png](https://app.graphite.dev/user-attachments/assets/9853f5c6-e7b1-4fbb-b2ac-a7534df44367.png)

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible