### PR TITLE
Added doc tag support logic inside snippet tag

### DIFF
--- a/.changeset/hungry-ravens-sneeze.md
+++ b/.changeset/hungry-ravens-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Introducing `doc` tags inside the new `snippet` tag, as well as making the theme check more rigorous with where the `doc` tag is placed

--- a/packages/theme-check-common/src/checks/unsupported-doc-tag/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unsupported-doc-tag/index.spec.ts
@@ -14,7 +14,7 @@ describe('Module: UnsupportedDocTag', () => {
 
     expect(offenses).to.have.length(1);
     expect(offenses[0].message).to.equal(
-      'The `doc` tag can only be used within a snippet or block.',
+      'The `doc` must be placed directly within an inline snippet tag, not nested inside other tags',
     );
   });
 
@@ -41,5 +41,40 @@ describe('Module: UnsupportedDocTag', () => {
     );
 
     expect(offenses).to.be.empty;
+  });
+
+  it('should not report an error when `doc` tag is used inside inline snippet', async () => {
+    const layoutSourceCode = `
+      {% snippet %}
+        ${sourceCode}
+      {% endsnippet %}
+    `;
+
+    const offenses = await runLiquidCheck(
+      UnsupportedDocTag,
+      layoutSourceCode,
+      'file://layout/theme.liquid',
+    );
+
+    expect(offenses).to.be.empty;
+  });
+
+  it('should report an error when `doc` tag is nested inside a block within a snippet file', async () => {
+    const nestedSourceCode = `
+      {% if true %}
+        ${sourceCode}
+      {% endif %}
+    `;
+
+    const offenses = await runLiquidCheck(
+      UnsupportedDocTag,
+      nestedSourceCode,
+      'file://snippets/file.liquid',
+    );
+
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal(
+      'The `doc` tag must be a top-level tag within a snippet/block file',
+    );
   });
 });


### PR DESCRIPTION
## What are you adding in this PR?
Solves [#826](https://github.com/Shopify/developer-tools-team/issues/826)
Updated theme check to support `doc` tag inside of `snippet` tag. This change allows the `doc` tag to be used within inline snippets, in addition to the previously supported snippet and block contexts.

This PR also makes the theme check more rigorous by ensuring the doc tag is either:
- at the top level of a snippet/block file, OR
- a direct child of the snippet tag

The error message has been updated to reflect this new support, and tests have been added to verify that `doc` tags inside inline snippets don't trigger errors.

## What's next? Any followup issues?

Update the theme check docs

## Before you deploy

- [x] This PR includes a new checks or changes the configuration of a check
 - [x] I included a minor bump `changeset`
 - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable.