### PR TITLE
Added hover support for inline snippets on `render` tags

### DIFF
--- a/.changeset/moody-mice-learn.md
+++ b/.changeset/moody-mice-learn.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+---
+
+Added hover support for `render` handle and named arguments for inline snippets

--- a/packages/theme-check-common/src/visitor.ts
+++ b/packages/theme-check-common/src/visitor.ts
@@ -1,4 +1,8 @@
-import { NodeTypes as LiquidHtmlNodeTypes } from '@shopify/liquid-html-parser';
+import {
+  NodeTypes as LiquidHtmlNodeTypes,
+  NamedTags,
+  LiquidTagSnippet,
+} from '@shopify/liquid-html-parser';
 import { AST, LiquidHtmlNode, NodeOfType, SourceCodeType, NodeTypes, JSONNode } from './types';
 
 export type VisitorMethod<S extends SourceCodeType, T, R> = (
@@ -153,4 +157,26 @@ export function findJSONNode(
   }
 
   return [current, ancestors];
+}
+
+export function findInlineSnippet(
+  ast: LiquidHtmlNode,
+  snippetName: string,
+): LiquidTagSnippet | null {
+  let foundSnippet: LiquidTagSnippet | null = null;
+
+  visit<SourceCodeType.LiquidHtml, void>(ast, {
+    LiquidTag(node) {
+      if (
+        node.name === NamedTags.snippet &&
+        typeof node.markup !== 'string' &&
+        node.markup.type === 'VariableLookup' &&
+        node.markup.name === snippetName
+      ) {
+        foundSnippet = node as LiquidTagSnippet;
+      }
+    },
+  });
+
+  return foundSnippet;
 }

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -60,6 +60,38 @@ This is a description
       await expect(provider).to.hover(`{% assign asdf = 'snip█pet' %}`, null);
       await expect(provider).to.hover(`{{ 'snip█pet' }}`, null);
     });
+
+    it('should return snippet definition with all parameters for inline snippet', async () => {
+      provider = createProvider(async () => undefined); // No file-based snippets
+
+      const source = `
+        {% snippet inline_product_card %}
+          {% doc %}
+            @param {string} title - The title of the inline product card
+
+            @example
+            {% render inline_product_card, title: 'My Product' %}
+          {% enddoc %}
+          <div>{{ title }}</div>
+        {% endsnippet %}
+        
+        {% render inline_produc█t_card %}
+      `;
+
+      // prettier-ignore
+      const expectedHoverContent = 
+`### inline_product_card
+
+**Parameters:**
+- \`title\`: string - The title of the inline product card
+
+**Examples:**
+\`\`\`liquid
+{% render inline_product_card, title: 'My Product' %}
+\`\`\``;
+
+      await expect(provider).to.hover(source, expectedHoverContent);
+    });
   });
 });
 

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.ts
@@ -1,5 +1,10 @@
 import { NodeTypes } from '@shopify/liquid-html-parser';
-import { LiquidHtmlNode, GetDocDefinitionForURI } from '@shopify/theme-check-common';
+import {
+  LiquidHtmlNode,
+  GetDocDefinitionForURI,
+  findInlineSnippet,
+  extractDocDefinition,
+} from '@shopify/theme-check-common';
 import { Hover, HoverParams } from 'vscode-languageserver';
 import { BaseHoverProvider } from '../BaseHoverProvider';
 import { formatLiquidDocContentMarkdown } from '../../utils/liquidDoc';
@@ -13,26 +18,37 @@ export class RenderSnippetHoverProvider implements BaseHoverProvider {
     params: HoverParams,
   ): Promise<Hover | null> {
     const parentNode = ancestors.at(-1);
-    if (
-      currentNode.type !== NodeTypes.String ||
-      !parentNode ||
-      parentNode.type !== NodeTypes.RenderMarkup
-    ) {
-      return null;
+
+    if (parentNode?.type === NodeTypes.RenderMarkup) {
+      let snippetName: string;
+      let docDefinition;
+
+      if (currentNode.type === NodeTypes.String) {
+        snippetName = currentNode.value;
+        docDefinition = await this.getDocDefinitionForURI(
+          params.textDocument.uri,
+          'snippets',
+          snippetName,
+        );
+      } else if (currentNode.type === NodeTypes.VariableLookup) {
+        snippetName = currentNode.name || '';
+        const rootNode = ancestors[0];
+        const snippetNode = findInlineSnippet(rootNode, snippetName);
+        if (snippetNode) {
+          docDefinition = extractDocDefinition(params.textDocument.uri, snippetNode);
+        }
+      } else {
+        return null;
+      }
+
+      return {
+        contents: {
+          kind: 'markdown',
+          value: formatLiquidDocContentMarkdown(snippetName, docDefinition || undefined),
+        },
+      };
     }
 
-    const snippetName = currentNode.value;
-    const docDefinition = await this.getDocDefinitionForURI(
-      params.textDocument.uri,
-      'snippets',
-      snippetName,
-    );
-
-    return {
-      contents: {
-        kind: 'markdown',
-        value: formatLiquidDocContentMarkdown(snippetName, docDefinition),
-      },
-    };
+    return null;
   }
 }

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
@@ -46,6 +46,67 @@ describe('Module: RenderSnippetParameterHoverProvider', async () => {
       );
     });
   });
+
+  describe('hover on inline snippet parameters', () => {
+    it('should return parameter info for inline snippet', async () => {
+      provider = createProvider(async () => undefined); // No file-based snippets
+
+      const source = `
+        {% snippet product_card %}
+          {% doc %}
+            @param {string} title - The title of the product
+            @param {number} price - The price of the product
+          {% enddoc %}
+          <div>{{ title }}: {{ price }}</div>
+        {% endsnippet %}
+        
+        {% render product_card, ti█tle: 'My Product', price: 99 %}
+      `;
+
+      await expect(provider).to.hover(source, '### `title`: string\n\nThe title of the product');
+    });
+
+    it('should return null if parameter not found in inline snippet doc', async () => {
+      provider = createProvider(async () => undefined);
+
+      const source = `
+        {% snippet product_card %}
+          {% doc %}
+            @param {string} title - The title of the product
+          {% enddoc %}
+          <div>{{ title }}</div>
+        {% endsnippet %}
+        
+        {% render product_card, unknown_para█m: 'value' %}
+      `;
+
+      await expect(provider).to.hover(source, null);
+    });
+
+    it('should handle multiple inline snippets correctly', async () => {
+      provider = createProvider(async () => undefined);
+
+      const source = `
+        {% snippet first_snippet %}
+          {% doc %}
+            @param {string} first_param - First parameter
+          {% enddoc %}
+          <div>{{ first_param }}</div>
+        {% endsnippet %}
+        
+        {% snippet second_snippet %}
+          {% doc %}
+            @param {number} second_param - Second parameter
+          {% enddoc %}
+          <div>{{ second_param }}</div>
+        {% endsnippet %}
+        
+        {% render second_snippet, second_para█m: 42 %}
+      `;
+
+      await expect(provider).to.hover(source, '### `second_param`: number\n\nSecond parameter');
+    });
+  });
 });
 
 const createProvider = (getSnippetDefinition: GetDocDefinitionForURI) => {


### PR DESCRIPTION
## What are you adding in this PR?
Solves [#829](https://github.com/Shopify/developer-tools-team/issues/829)
Added hover support for `render` handle and named arguments for inline snippets.

## What's next? Any followup issues?

- [ x ] I included a minor bump `changeset`
- [ x ] My feature is backward compatible