### PR TITLE
Support code completion for inline snippet render arguments

### DIFF
--- a/.changeset/eleven-melons-compete.md
+++ b/.changeset/eleven-melons-compete.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Support code completion for inline snippet render arguments


### PR DESCRIPTION
- closes https://github.com/Shopify/developer-tools-team/issues/828

## What are you adding in this PR?

While rendering an inline snippet that contains a doc tag we should be offered argument completion suggestions 

<img width="451" height="283" alt="inline-snippets-arg-completion" src="https://github.com/user-attachments/assets/7d95fb54-23af-4fdb-9b93-50c4dd9002b1" />

<details><summary>Demo</summary>

https://github.com/user-attachments/assets/154d911d-1669-4265-ba20-5f1b79e57ac0

</details> 

## How to test

Pull down the branch `gh pr checkout 1075` 

- Completion options defined a snippets doc tag should display as expected
- Only unused options should display
- Options from nested snippet doc tags should not be offered, only the current scope

> Notes: Since this branch isn't based off of the doc tags branch red squiggles will show up on snippets, but render completion should work as expected. VSCode displays param definitions, Cursor does not

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

