### PR TITLE
Replace partner slack link with dev community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <div align="center">
 
-🗣 [Slack](https://join.slack.com/t/shopifypartners/shared_invite/zt-sdr2quab-mGkzkttZ2hnVm0~8noSyvw) | 📝 [Changelog](https://github.com/Shopify/theme-tools/blob/main/packages/vscode-extension/CHANGELOG.md)
+🗣 [Dev Community]([https://join.slack.com/t/shopifypartners/shared_invite/zt-sdr2quab-mGkzkttZ2hnVm0~8noSyvw](https://community.shopify.dev)) | 📝 [Changelog](https://github.com/Shopify/theme-tools/blob/main/packages/vscode-extension/CHANGELOG.md)
 
 </div>
 


### PR DESCRIPTION

## What are you adding in this PR?

Replacing the partner slack link in readme with dev community link.

Since Partner Slack is sunset, we should direct to the dev community instead.

## What's next? Any followup issues?

None
