### PR TITLE
Ignore Jujutsu VFS scheme to prevent fs.readDirectory errors

### DIFF
--- a/.changeset/sweet-turkey-try.md
+++ b/.changeset/sweet-turkey-try.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Added jj to the URI prefixes ignored by hasUnsupportedDocument

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -75,7 +75,9 @@ const hasUnsupportedDocument = (params: any) => {
     'textDocument' in params &&
     'uri' in params.textDocument &&
     typeof params.textDocument.uri === 'string' &&
-    (params.textDocument.uri.startsWith('git:') || params.textDocument.uri.startsWith('output:'))
+    (params.textDocument.uri.startsWith('jj:') ||
+      params.textDocument.uri.startsWith('git:') ||
+      params.textDocument.uri.startsWith('output:'))
   );
 };
 


### PR DESCRIPTION
## What are you adding in this PR?

While trying Jujutsu (jj) in VS Code, I noticed that opening a diff from the Source Control panel triggers an error notification about the unsupported `fs.readDirectory` method.

The extension already ignores VFS schemes used by Git. This PR extends the same logic to also ignore the Jujutsu VFS scheme, preventing the error from being triggered.

## What's next? Any followup issues?

No follow-up planned.
For now, I’m currently using a local build of the Shopify extension to avoid this error notification issue. Hopefully this can be merged so I no longer need to do that 🙂.

## Before you deploy
- [x] I included a patch bump `changeset`
