### PR TITLE
Upgrade Prettier to v3

### DIFF
--- a/.changeset/sweet-needles-fetch.md
+++ b/.changeset/sweet-needles-fetch.md
@@ -1,0 +1,10 @@
+---
+"@shopify/theme-language-server-common": patch
+"@shopify/codemirror-language-client": patch
+"@shopify/prettier-plugin-liquid": patch
+"@shopify/liquid-html-parser": patch
+"@shopify/theme-check-common": patch
+"theme-check-vscode": patch
+---
+
+Upgrade prettier to v3 (internal)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "css-loader": "^6.7.3",
     "html-webpack-plugin": "^5.5.0",
     "jsdom": "^22.1.0",
-    "prettier": "^2.8.4",
+    "prettier": "^3.0.0",
     "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
     "tsconfig-paths-webpack-plugin": "^4.1.0",

--- a/packages/codemirror-language-client/src/LanguageClient.ts
+++ b/packages/codemirror-language-client/src/LanguageClient.ts
@@ -59,7 +59,10 @@ export class LanguageClient extends EventTarget implements AbstractLanguageClien
   private disposables: Disposable[];
   private log: Dependencies['log'];
 
-  constructor(public readonly worker: Worker, dependencies: Dependencies) {
+  constructor(
+    public readonly worker: Worker,
+    dependencies: Dependencies,
+  ) {
     super();
     this.requests = new Map();
     this.requestId = 0;

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -113,38 +113,33 @@ export interface ConcreteBasicNode<T> {
   locEnd: number;
 }
 
-export interface ConcreteLiquidDocParamNode
-  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocParamNode> {
+export interface ConcreteLiquidDocParamNode extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocParamNode> {
   name: 'param';
   paramName: ConcreteLiquidDocParamNameNode;
   paramDescription: ConcreteTextNode | null;
   paramType: ConcreteTextNode | null;
 }
 
-export interface ConcreteLiquidDocParamNameNode
-  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocParamNameNode> {
+export interface ConcreteLiquidDocParamNameNode extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocParamNameNode> {
   name: 'paramName';
   content: ConcreteTextNode;
   required: boolean;
 }
 
-export interface ConcreteLiquidDocDescriptionNode
-  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocDescriptionNode> {
+export interface ConcreteLiquidDocDescriptionNode extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocDescriptionNode> {
   name: 'description';
   content: ConcreteTextNode;
   isImplicit: boolean;
   isInline: boolean;
 }
 
-export interface ConcreteLiquidDocExampleNode
-  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocExampleNode> {
+export interface ConcreteLiquidDocExampleNode extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocExampleNode> {
   name: 'example';
   content: ConcreteTextNode;
   isInline: boolean;
 }
 
-export interface ConcreteLiquidDocPromptNode
-  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocPromptNode> {
+export interface ConcreteLiquidDocPromptNode extends ConcreteBasicNode<ConcreteNodeTypes.LiquidDocPromptNode> {
   name: 'prompt';
   content: ConcreteTextNode;
 }
@@ -170,12 +165,10 @@ export interface ConcreteHtmlRawTag extends ConcreteHtmlNodeBase<ConcreteNodeTyp
   blockEndLocStart: number;
   blockEndLocEnd: number;
 }
-export interface ConcreteHtmlVoidElement
-  extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlVoidElement> {
+export interface ConcreteHtmlVoidElement extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlVoidElement> {
   name: string;
 }
-export interface ConcreteHtmlSelfClosingElement
-  extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlSelfClosingElement> {
+export interface ConcreteHtmlSelfClosingElement extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlSelfClosingElement> {
   name: (ConcreteTextNode | ConcreteLiquidVariableOutput)[];
 }
 export interface ConcreteHtmlTagOpen extends ConcreteHtmlNodeBase<ConcreteNodeTypes.HtmlTagOpen> {
@@ -197,12 +190,9 @@ export type ConcreteAttributeNode =
   | ConcreteAttrUnquoted
   | ConcreteAttrEmpty;
 
-export interface ConcreteAttrSingleQuoted
-  extends ConcreteAttributeNodeBase<ConcreteNodeTypes.AttrSingleQuoted> {}
-export interface ConcreteAttrDoubleQuoted
-  extends ConcreteAttributeNodeBase<ConcreteNodeTypes.AttrDoubleQuoted> {}
-export interface ConcreteAttrUnquoted
-  extends ConcreteAttributeNodeBase<ConcreteNodeTypes.AttrUnquoted> {}
+export interface ConcreteAttrSingleQuoted extends ConcreteAttributeNodeBase<ConcreteNodeTypes.AttrSingleQuoted> {}
+export interface ConcreteAttrDoubleQuoted extends ConcreteAttributeNodeBase<ConcreteNodeTypes.AttrDoubleQuoted> {}
+export interface ConcreteAttrUnquoted extends ConcreteAttributeNodeBase<ConcreteNodeTypes.AttrUnquoted> {}
 export interface ConcreteAttrEmpty extends ConcreteBasicNode<ConcreteNodeTypes.AttrEmpty> {
   name: (ConcreteLiquidVariableOutput | ConcreteTextNode)[];
 }
@@ -219,8 +209,7 @@ interface ConcreteBasicLiquidNode<T> extends ConcreteBasicNode<T> {
   whitespaceEnd: null | '-';
 }
 
-export interface ConcreteLiquidRawTag
-  extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidRawTag> {
+export interface ConcreteLiquidRawTag extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidRawTag> {
   name: string;
   body: string;
   children: (ConcreteTextNode | ConcreteLiquidNode)[];
@@ -244,28 +233,42 @@ export type ConcreteLiquidTagOpenNamed =
   | ConcreteLiquidTagOpenPaginate
   | ConcreteLiquidTagOpenTablerow;
 
-export interface ConcreteLiquidTagOpenNode<Name, Markup>
-  extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTagOpen> {
+export interface ConcreteLiquidTagOpenNode<
+  Name,
+  Markup,
+> extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTagOpen> {
   name: Name;
   markup: Markup;
 }
 
 export interface ConcreteLiquidTagOpenBaseCase extends ConcreteLiquidTagOpenNode<string, string> {}
 
-export interface ConcreteLiquidTagOpenCapture
-  extends ConcreteLiquidTagOpenNode<NamedTags.capture, ConcreteLiquidVariableLookup> {}
+export interface ConcreteLiquidTagOpenCapture extends ConcreteLiquidTagOpenNode<
+  NamedTags.capture,
+  ConcreteLiquidVariableLookup
+> {}
 
-export interface ConcreteLiquidTagOpenCase
-  extends ConcreteLiquidTagOpenNode<NamedTags.case, ConcreteLiquidExpression> {}
-export interface ConcreteLiquidTagWhen
-  extends ConcreteLiquidTagNode<NamedTags.when, ConcreteLiquidExpression[]> {}
+export interface ConcreteLiquidTagOpenCase extends ConcreteLiquidTagOpenNode<
+  NamedTags.case,
+  ConcreteLiquidExpression
+> {}
+export interface ConcreteLiquidTagWhen extends ConcreteLiquidTagNode<
+  NamedTags.when,
+  ConcreteLiquidExpression[]
+> {}
 
-export interface ConcreteLiquidTagOpenIf
-  extends ConcreteLiquidTagOpenNode<NamedTags.if, ConcreteLiquidCondition[]> {}
-export interface ConcreteLiquidTagOpenUnless
-  extends ConcreteLiquidTagOpenNode<NamedTags.unless, ConcreteLiquidCondition[]> {}
-export interface ConcreteLiquidTagElsif
-  extends ConcreteLiquidTagNode<NamedTags.elsif, ConcreteLiquidCondition[]> {}
+export interface ConcreteLiquidTagOpenIf extends ConcreteLiquidTagOpenNode<
+  NamedTags.if,
+  ConcreteLiquidCondition[]
+> {}
+export interface ConcreteLiquidTagOpenUnless extends ConcreteLiquidTagOpenNode<
+  NamedTags.unless,
+  ConcreteLiquidCondition[]
+> {}
+export interface ConcreteLiquidTagElsif extends ConcreteLiquidTagNode<
+  NamedTags.elsif,
+  ConcreteLiquidCondition[]
+> {}
 
 export interface ConcreteLiquidCondition extends ConcreteBasicNode<ConcreteNodeTypes.Condition> {
   relation: 'and' | 'or' | null;
@@ -278,11 +281,15 @@ export interface ConcreteLiquidComparison extends ConcreteBasicNode<ConcreteNode
   right: ConcreteLiquidExpression;
 }
 
-export interface ConcreteLiquidTagOpenForm
-  extends ConcreteLiquidTagOpenNode<NamedTags.form, ConcreteLiquidArgument[]> {}
+export interface ConcreteLiquidTagOpenForm extends ConcreteLiquidTagOpenNode<
+  NamedTags.form,
+  ConcreteLiquidArgument[]
+> {}
 
-export interface ConcreteLiquidTagOpenFor
-  extends ConcreteLiquidTagOpenNode<NamedTags.for, ConcreteLiquidTagForMarkup> {}
+export interface ConcreteLiquidTagOpenFor extends ConcreteLiquidTagOpenNode<
+  NamedTags.for,
+  ConcreteLiquidTagForMarkup
+> {}
 export interface ConcreteLiquidTagForMarkup extends ConcreteBasicNode<ConcreteNodeTypes.ForMarkup> {
   variableName: string;
   collection: ConcreteLiquidExpression;
@@ -290,21 +297,23 @@ export interface ConcreteLiquidTagForMarkup extends ConcreteBasicNode<ConcreteNo
   args: ConcreteLiquidNamedArgument[];
 }
 
-export interface ConcreteLiquidTagOpenTablerow
-  extends ConcreteLiquidTagOpenNode<NamedTags.tablerow, ConcreteLiquidTagForMarkup> {}
+export interface ConcreteLiquidTagOpenTablerow extends ConcreteLiquidTagOpenNode<
+  NamedTags.tablerow,
+  ConcreteLiquidTagForMarkup
+> {}
 
-export interface ConcreteLiquidTagOpenPaginate
-  extends ConcreteLiquidTagOpenNode<NamedTags.paginate, ConcretePaginateMarkup> {}
+export interface ConcreteLiquidTagOpenPaginate extends ConcreteLiquidTagOpenNode<
+  NamedTags.paginate,
+  ConcretePaginateMarkup
+> {}
 
-export interface ConcretePaginateMarkup
-  extends ConcreteBasicNode<ConcreteNodeTypes.PaginateMarkup> {
+export interface ConcretePaginateMarkup extends ConcreteBasicNode<ConcreteNodeTypes.PaginateMarkup> {
   collection: ConcreteLiquidExpression;
   pageSize: ConcreteLiquidExpression;
   args: ConcreteLiquidNamedArgument[] | null;
 }
 
-export interface ConcreteLiquidTagClose
-  extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTagClose> {
+export interface ConcreteLiquidTagClose extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTagClose> {
   name: string;
 }
 
@@ -325,91 +334,109 @@ export type ConcreteLiquidTagNamed =
   | ConcreteLiquidTagSections
   | ConcreteLiquidTagWhen;
 
-export interface ConcreteLiquidTagNode<Name, Markup>
-  extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTag> {
+export interface ConcreteLiquidTagNode<
+  Name,
+  Markup,
+> extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidTag> {
   markup: Markup;
   name: Name;
 }
 
 export interface ConcreteLiquidTagBaseCase extends ConcreteLiquidTagNode<string, string> {}
-export interface ConcreteLiquidTagEcho
-  extends ConcreteLiquidTagNode<NamedTags.echo, ConcreteLiquidVariable> {}
-export interface ConcreteLiquidTagIncrement
-  extends ConcreteLiquidTagNode<NamedTags.increment, ConcreteLiquidVariableLookup> {}
-export interface ConcreteLiquidTagDecrement
-  extends ConcreteLiquidTagNode<NamedTags.decrement, ConcreteLiquidVariableLookup> {}
-export interface ConcreteLiquidTagSection
-  extends ConcreteLiquidTagNode<NamedTags.section, ConcreteStringLiteral> {}
-export interface ConcreteLiquidTagSections
-  extends ConcreteLiquidTagNode<NamedTags.sections, ConcreteStringLiteral> {}
-export interface ConcreteLiquidTagLayout
-  extends ConcreteLiquidTagNode<NamedTags.layout, ConcreteLiquidExpression> {}
+export interface ConcreteLiquidTagEcho extends ConcreteLiquidTagNode<
+  NamedTags.echo,
+  ConcreteLiquidVariable
+> {}
+export interface ConcreteLiquidTagIncrement extends ConcreteLiquidTagNode<
+  NamedTags.increment,
+  ConcreteLiquidVariableLookup
+> {}
+export interface ConcreteLiquidTagDecrement extends ConcreteLiquidTagNode<
+  NamedTags.decrement,
+  ConcreteLiquidVariableLookup
+> {}
+export interface ConcreteLiquidTagSection extends ConcreteLiquidTagNode<
+  NamedTags.section,
+  ConcreteStringLiteral
+> {}
+export interface ConcreteLiquidTagSections extends ConcreteLiquidTagNode<
+  NamedTags.sections,
+  ConcreteStringLiteral
+> {}
+export interface ConcreteLiquidTagLayout extends ConcreteLiquidTagNode<
+  NamedTags.layout,
+  ConcreteLiquidExpression
+> {}
 
-export interface ConcreteLiquidTagLiquid
-  extends ConcreteLiquidTagNode<NamedTags.liquid, ConcreteLiquidLiquidTagNode[]> {}
+export interface ConcreteLiquidTagLiquid extends ConcreteLiquidTagNode<
+  NamedTags.liquid,
+  ConcreteLiquidLiquidTagNode[]
+> {}
 export type ConcreteLiquidLiquidTagNode =
   | ConcreteLiquidTagOpen
   | ConcreteLiquidTagClose
   | ConcreteLiquidTag
   | ConcreteLiquidRawTag;
 
-export interface ConcreteLiquidTagAssign
-  extends ConcreteLiquidTagNode<NamedTags.assign, ConcreteLiquidTagAssignMarkup> {}
-export interface ConcreteLiquidTagAssignMarkup
-  extends ConcreteBasicNode<ConcreteNodeTypes.AssignMarkup> {
+export interface ConcreteLiquidTagAssign extends ConcreteLiquidTagNode<
+  NamedTags.assign,
+  ConcreteLiquidTagAssignMarkup
+> {}
+export interface ConcreteLiquidTagAssignMarkup extends ConcreteBasicNode<ConcreteNodeTypes.AssignMarkup> {
   name: string;
   value: ConcreteLiquidVariable;
 }
 
-export interface ConcreteLiquidTagCycle
-  extends ConcreteLiquidTagNode<NamedTags.cycle, ConcreteLiquidTagCycleMarkup> {}
-export interface ConcreteLiquidTagCycleMarkup
-  extends ConcreteBasicNode<ConcreteNodeTypes.CycleMarkup> {
+export interface ConcreteLiquidTagCycle extends ConcreteLiquidTagNode<
+  NamedTags.cycle,
+  ConcreteLiquidTagCycleMarkup
+> {}
+export interface ConcreteLiquidTagCycleMarkup extends ConcreteBasicNode<ConcreteNodeTypes.CycleMarkup> {
   groupName: ConcreteLiquidExpression | null;
   args: ConcreteLiquidExpression[];
 }
 
-export interface ConcreteLiquidTagContentFor
-  extends ConcreteLiquidTagNode<NamedTags.content_for, ConcreteLiquidTagContentForMarkup> {}
+export interface ConcreteLiquidTagContentFor extends ConcreteLiquidTagNode<
+  NamedTags.content_for,
+  ConcreteLiquidTagContentForMarkup
+> {}
 
-export interface ConcreteLiquidTagRender
-  extends ConcreteLiquidTagNode<NamedTags.render, ConcreteLiquidTagRenderMarkup> {}
-export interface ConcreteLiquidTagInclude
-  extends ConcreteLiquidTagNode<NamedTags.include, ConcreteLiquidTagRenderMarkup> {}
+export interface ConcreteLiquidTagRender extends ConcreteLiquidTagNode<
+  NamedTags.render,
+  ConcreteLiquidTagRenderMarkup
+> {}
+export interface ConcreteLiquidTagInclude extends ConcreteLiquidTagNode<
+  NamedTags.include,
+  ConcreteLiquidTagRenderMarkup
+> {}
 
-export interface ConcreteLiquidTagContentForMarkup
-  extends ConcreteBasicNode<ConcreteNodeTypes.ContentForMarkup> {
+export interface ConcreteLiquidTagContentForMarkup extends ConcreteBasicNode<ConcreteNodeTypes.ContentForMarkup> {
   contentForType: ConcreteStringLiteral;
   args: ConcreteLiquidNamedArgument[];
 }
 
-export interface ConcreteLiquidTagRenderMarkup
-  extends ConcreteBasicNode<ConcreteNodeTypes.RenderMarkup> {
+export interface ConcreteLiquidTagRenderMarkup extends ConcreteBasicNode<ConcreteNodeTypes.RenderMarkup> {
   snippet: ConcreteStringLiteral | ConcreteLiquidVariableLookup;
   variable: ConcreteRenderVariableExpression | null;
   alias: ConcreteRenderAliasExpression | null;
   renderArguments: ConcreteLiquidNamedArgument[];
 }
 
-export interface ConcreteRenderVariableExpression
-  extends ConcreteBasicNode<ConcreteNodeTypes.RenderVariableExpression> {
+export interface ConcreteRenderVariableExpression extends ConcreteBasicNode<ConcreteNodeTypes.RenderVariableExpression> {
   kind: 'for' | 'with';
   name: ConcreteLiquidExpression;
 }
 
-export interface ConcreteRenderAliasExpression
-  extends ConcreteBasicNode<ConcreteNodeTypes.RenderAliasExpression> {
+export interface ConcreteRenderAliasExpression extends ConcreteBasicNode<ConcreteNodeTypes.RenderAliasExpression> {
   value: string;
 }
 
-export interface ConcreteLiquidVariableOutput
-  extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidVariableOutput> {
+export interface ConcreteLiquidVariableOutput extends ConcreteBasicLiquidNode<ConcreteNodeTypes.LiquidVariableOutput> {
   markup: ConcreteLiquidVariable | string;
 }
 
 // The variable is the name + filters, like shopify/liquid.
-export interface ConcreteLiquidVariable
-  extends ConcreteBasicNode<ConcreteNodeTypes.LiquidVariable> {
+export interface ConcreteLiquidVariable extends ConcreteBasicNode<ConcreteNodeTypes.LiquidVariable> {
   expression: ConcreteLiquidExpression;
   filters: ConcreteLiquidFilter[];
   rawSource: string;
@@ -422,8 +449,7 @@ export interface ConcreteLiquidFilter extends ConcreteBasicNode<ConcreteNodeType
 
 export type ConcreteLiquidArgument = ConcreteLiquidExpression | ConcreteLiquidNamedArgument;
 
-export interface ConcreteLiquidNamedArgument
-  extends ConcreteBasicNode<ConcreteNodeTypes.NamedArgument> {
+export interface ConcreteLiquidNamedArgument extends ConcreteBasicNode<ConcreteNodeTypes.NamedArgument> {
   name: string;
   value: ConcreteLiquidExpression;
 }
@@ -439,8 +465,7 @@ export type ConcreteComplexLiquidExpression =
   | ConcreteLiquidBooleanExpression
   | ConcreteLiquidExpression;
 
-export interface ConcreteLiquidBooleanExpression
-  extends ConcreteBasicNode<ConcreteNodeTypes.BooleanExpression> {
+export interface ConcreteLiquidBooleanExpression extends ConcreteBasicNode<ConcreteNodeTypes.BooleanExpression> {
   conditions: ConcreteLiquidCondition[];
 }
 
@@ -463,8 +488,7 @@ export interface ConcreteLiquidRange extends ConcreteBasicNode<ConcreteNodeTypes
   end: ConcreteLiquidExpression;
 }
 
-export interface ConcreteLiquidVariableLookup
-  extends ConcreteBasicNode<ConcreteNodeTypes.VariableLookup> {
+export interface ConcreteLiquidVariableLookup extends ConcreteBasicNode<ConcreteNodeTypes.VariableLookup> {
   name: string | null;
   lookups: ConcreteLiquidExpression[];
 }
@@ -482,8 +506,7 @@ export interface ConcreteTextNode extends ConcreteBasicNode<ConcreteNodeTypes.Te
   value: string;
 }
 
-export interface ConcreteYamlFrontmatterNode
-  extends ConcreteBasicNode<ConcreteNodeTypes.YAMLFrontmatter> {
+export interface ConcreteYamlFrontmatterNode extends ConcreteBasicNode<ConcreteNodeTypes.YAMLFrontmatter> {
   body: string;
 }
 

--- a/packages/liquid-html-parser/src/stage-2-ast.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.ts
@@ -268,12 +268,16 @@ export interface AssignMarkup extends ASTNode<NodeTypes.AssignMarkup> {
 }
 
 /** https://shopify.dev/docs/api/liquid/tags#increment */
-export interface LiquidTagIncrement
-  extends LiquidTagNode<NamedTags.increment, LiquidVariableLookup> {}
+export interface LiquidTagIncrement extends LiquidTagNode<
+  NamedTags.increment,
+  LiquidVariableLookup
+> {}
 
 /** https://shopify.dev/docs/api/liquid/tags#decrement */
-export interface LiquidTagDecrement
-  extends LiquidTagNode<NamedTags.decrement, LiquidVariableLookup> {}
+export interface LiquidTagDecrement extends LiquidTagNode<
+  NamedTags.decrement,
+  LiquidVariableLookup
+> {}
 
 /** https://shopify.dev/docs/api/liquid/tags#capture */
 export interface LiquidTagCapture extends LiquidTagNode<NamedTags.capture, LiquidVariableLookup> {}
@@ -329,12 +333,16 @@ export interface LiquidTagIf extends LiquidTagConditional<NamedTags.if> {}
 export interface LiquidTagUnless extends LiquidTagConditional<NamedTags.unless> {}
 
 /** {% elsif cond %} */
-export interface LiquidBranchElsif
-  extends LiquidBranchNode<NamedTags.elsif, LiquidConditionalExpression> {}
+export interface LiquidBranchElsif extends LiquidBranchNode<
+  NamedTags.elsif,
+  LiquidConditionalExpression
+> {}
 
 // Helper for creating the types of if and unless
-export interface LiquidTagConditional<Name>
-  extends LiquidTagNode<Name, LiquidConditionalExpression> {}
+export interface LiquidTagConditional<Name> extends LiquidTagNode<
+  Name,
+  LiquidConditionalExpression
+> {}
 
 /** The union type of all conditional expression nodes */
 export type LiquidConditionalExpression =
@@ -370,8 +378,10 @@ export interface PaginateMarkup extends ASTNode<NodeTypes.PaginateMarkup> {
 }
 
 /** https://shopify.dev/docs/api/liquid/tags#content_for */
-export interface LiquidTagContentFor
-  extends LiquidTagNode<NamedTags.content_for, ContentForMarkup> {}
+export interface LiquidTagContentFor extends LiquidTagNode<
+  NamedTags.content_for,
+  ContentForMarkup
+> {}
 
 /** https://shopify.dev/docs/api/liquid/tags#render */
 export interface LiquidTagRender extends LiquidTagNode<NamedTags.render, RenderMarkup> {}

--- a/packages/prettier-plugin-liquid/src/printer/print/tag.ts
+++ b/packages/prettier-plugin-liquid/src/printer/print/tag.ts
@@ -195,8 +195,8 @@ function printAttributes(
   const whitespaceBetweenAttributes = forceNotToBreakAttrContent
     ? ' '
     : options.singleAttributePerLine && node.attributes.length > 1
-    ? hardline
-    : line;
+      ? hardline
+      : line;
 
   const attributes = prettierIgnoreAttributes
     ? replaceEndOfLine(
@@ -232,8 +232,8 @@ function printAttributes(
         ? ' '
         : ''
       : isSelfClosing(node)
-      ? line
-      : softline;
+        ? line
+        : softline;
   }
 
   return [
@@ -274,8 +274,8 @@ export function printOpeningTagPrefix(node: LiquidHtmlNode, options: LiquidParse
   return needsToBorrowParentOpeningTagEndMarker(node)
     ? printOpeningTagEndMarker(node.parentNode) // opening tag '>' of parent
     : needsToBorrowPrevClosingTagEndMarker(node)
-    ? printClosingTagEndMarker(node.prev, options) // closing '>' of previous
-    : '';
+      ? printClosingTagEndMarker(node.prev, options) // closing '>' of previous
+      : '';
 }
 
 // Will maybe print the `>` of the node.
@@ -346,8 +346,8 @@ export function printClosingTagSuffix(node: LiquidHtmlNode, options: LiquidParse
   return needsToBorrowParentClosingTagStartMarker(node)
     ? printClosingTagStartMarker(node.parentNode, options)
     : needsToBorrowNextOpeningTagStartMarker(node)
-    ? printOpeningTagStartMarker(node.next)
-    : '';
+      ? printOpeningTagStartMarker(node.next)
+      : '';
 }
 
 export function printClosingTagStartMarker(

--- a/packages/prettier-plugin-liquid/src/printer/utils/node.ts
+++ b/packages/prettier-plugin-liquid/src/printer/utils/node.ts
@@ -298,8 +298,8 @@ function hasLeadingLineBreak(node: LiquidHtmlNode) {
       node.prev
         ? node.prev.position.end
         : (node.parentNode as any).blockStartPosition
-        ? (node.parentNode as any).blockStartPosition.end
-        : (node.parentNode as any).position.start,
+          ? (node.parentNode as any).blockStartPosition.end
+          : (node.parentNode as any).position.start,
       node.position.start,
     )
   );
@@ -315,8 +315,8 @@ function hasTrailingLineBreak(node: LiquidHtmlNode) {
       node.next
         ? node.next.position.start
         : (node.parentNode as any).blockEndPosition
-        ? (node.parentNode as any).blockEndPosition.start
-        : (node.parentNode as any).position.end,
+          ? (node.parentNode as any).blockEndPosition.start
+          : (node.parentNode as any).position.end,
     )
   );
 }

--- a/packages/prettier-plugin-liquid/tsconfig.json
+++ b/packages/prettier-plugin-liquid/tsconfig.json
@@ -8,8 +8,11 @@
     "target": "es2020",
     "rootDir": "src",
     "esModuleInterop": true,
+    "baseUrl": ".",
     "paths": {
-      "@shopify/liquid-html-parser": ["../liquid-html-parser/src"]
+      "@shopify/liquid-html-parser": ["../liquid-html-parser/src"],
+      "prettier": ["../../node_modules/@types/prettier"],
+      "prettier/doc": ["../../node_modules/@types/prettier/doc.d.ts"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/theme-check-common/src/test/MockFileSystem.ts
+++ b/packages/theme-check-common/src/test/MockFileSystem.ts
@@ -11,7 +11,10 @@ interface FileTree {
 export class MockFileSystem implements AbstractFileSystem {
   private rootUri: string;
 
-  constructor(private mockTheme: MockTheme, rootUri = 'file:///') {
+  constructor(
+    private mockTheme: MockTheme,
+    rootUri = 'file:///',
+  ) {
     this.rootUri = normalize(rootUri);
   }
 

--- a/packages/theme-check-common/src/utils/block.ts
+++ b/packages/theme-check-common/src/utils/block.ts
@@ -187,10 +187,10 @@ async function validateBlockTargeting(
       const errorMessage = isStaticBlock
         ? `Could not find a static block of type "${nestedBlock.type}" with id "${blockId}" in "blocks/${parentNode.type}.liquid".`
         : isPrivateBlock
-        ? `Private block type "${nestedBlock.type}" is not allowed in "${parentNode.type}" blocks.`
-        : `Block type "${nestedBlock.type}" is not allowed in "${
-            parentNode.type
-          }" blocks. Allowed types are: ${allowedBlockTypes.join(', ')}.`;
+          ? `Private block type "${nestedBlock.type}" is not allowed in "${parentNode.type}" blocks.`
+          : `Block type "${nestedBlock.type}" is not allowed in "${
+              parentNode.type
+            }" blocks. Allowed types are: ${allowedBlockTypes.join(', ')}.`;
       reportWarning(errorMessage, offset, typeNode, context);
     }
 

--- a/packages/theme-language-server-common/src/TypeSystem.spec.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.spec.ts
@@ -565,9 +565,8 @@ describe('Module: TypeSystem', () => {
 
   describe('metafieldDefinitionsObjectMap', async () => {
     it('should convert metafield definitions into types', async () => {
-      const metafieldObjectMap = await typeSystem.metafieldDefinitionsObjectMap(
-        'file:///any/file.liquid',
-      );
+      const metafieldObjectMap =
+        await typeSystem.metafieldDefinitionsObjectMap('file:///any/file.liquid');
 
       assert(metafieldObjectMap['product_metafields']);
       assert(metafieldObjectMap['product_metafield_custom']);
@@ -575,9 +574,8 @@ describe('Module: TypeSystem', () => {
     });
 
     it('should group metafield definitions by namespace', async () => {
-      const metafieldObjectMap = await typeSystem.metafieldDefinitionsObjectMap(
-        'file:///any/file.liquid',
-      );
+      const metafieldObjectMap =
+        await typeSystem.metafieldDefinitionsObjectMap('file:///any/file.liquid');
       const properties = metafieldObjectMap['product_metafields'].properties;
 
       assert(properties);
@@ -628,9 +626,8 @@ describe('Module: TypeSystem', () => {
     });
 
     it('should have `metafield_x_array` return_type for array of references', async () => {
-      const metafieldObjectMap = await typeSystem.metafieldDefinitionsObjectMap(
-        'file:///any/file.liquid',
-      );
+      const metafieldObjectMap =
+        await typeSystem.metafieldDefinitionsObjectMap('file:///any/file.liquid');
       const relatedProperties = metafieldObjectMap['order_metafield_related'].properties;
 
       assert(relatedProperties);

--- a/packages/theme-language-server-common/src/completions/providers/ContentForBlockTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForBlockTypeCompletionProvider.spec.ts
@@ -17,7 +17,7 @@ describe('Module: ContentForBlockTypeCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
       getThemeBlockNames: async (_rootUri: string, _includePrivate: boolean) => [
         'block-1',
         'block-2',

--- a/packages/theme-language-server-common/src/completions/providers/ContentForCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForCompletionProvider.spec.ts
@@ -17,7 +17,7 @@ describe('Module: ContentForCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ContentForParameterCompletionProvider.spec.ts
@@ -33,7 +33,7 @@ describe('Module: ContentForBlockParameterCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 
@@ -264,7 +264,7 @@ describe('Module: ContentForBlockParameterCompletionProvider', async () => {
           tags: async () => [],
           systemTranslations: async () => ({}),
         },
-        getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+        getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
         getDocDefinitionForURI: async (_uri, _category, _name) => {
           return {
             uri: 'file:///blocks/product-card.liquid',

--- a/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/FilterCompletionProvider.spec.ts
@@ -132,7 +132,7 @@ describe('Module: FilterCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/FilterNamedParameterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/FilterNamedParameterCompletionProvider.spec.ts
@@ -48,7 +48,7 @@ describe('Module: ObjectCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeCompletionProvider.spec.ts
@@ -22,7 +22,7 @@ describe('Module: HtmlAttributeCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/HtmlAttributeValueCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlAttributeValueCompletionProvider.spec.ts
@@ -16,7 +16,7 @@ describe('Module: HtmlAttributeValueCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/HtmlTagCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/HtmlTagCompletionProvider.spec.ts
@@ -20,7 +20,7 @@ describe('Module: HtmlTagCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocParamTypeCompletionProvider.spec.ts
@@ -21,7 +21,7 @@ describe('Module: LiquidDocParamTypeCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidDocTagCompletionProvider.spec.ts
@@ -16,7 +16,7 @@ describe('Module: LiquidDocTagCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/LiquidTagsCompletionProvider.spec.ts
@@ -90,7 +90,7 @@ describe('Module: LiquidTagsCompletionProvider', async () => {
         tags: async () => tags,
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.spec.ts
@@ -76,7 +76,7 @@ describe('Module: ObjectAttributeCompletionProvider', async () => {
         systemTranslations: async () => ({}),
       },
       getThemeSettingsSchemaForURI: settingsProvider,
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetCompletionProvider.spec.ts
@@ -18,7 +18,7 @@ describe('Module: RenderSnippetCompletionProvider', async () => {
       },
       getTranslationsForURI: async (_) => ({}),
       getSnippetNamesForURI: async (_) => ['product-card', 'image'],
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/RenderSnippetParameterCompletionProvider.spec.ts
@@ -61,7 +61,7 @@ describe('Module: RenderSnippetParameterCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
       getDocDefinitionForURI: async (_uri, _type, snippetName) => {
         if (mockSnippetName === snippetName) {
           return mockSnippetDefinition;

--- a/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.spec.ts
@@ -16,7 +16,7 @@ describe('Module: TranslationCompletionProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
       getTranslationsForURI: async (_) => ({
         general: {
           username_html: '<b>username</b>',

--- a/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.ts
@@ -82,7 +82,7 @@ export class TranslationCompletionProvider implements Provider {
 
     return options.map(({ path, translation }): CompletionItem => {
       const params = extractParams(
-        typeof translation === 'string' ? translation : Object.values(translation)[0] ?? '',
+        typeof translation === 'string' ? translation : (Object.values(translation)[0] ?? ''),
       );
       const parameters = paramsString(params);
       return {

--- a/packages/theme-language-server-common/src/formatting/providers/HtmlElementAutoclosingOnTypeFormattingProvider.ts
+++ b/packages/theme-language-server-common/src/formatting/providers/HtmlElementAutoclosingOnTypeFormattingProvider.ts
@@ -52,9 +52,7 @@ const defer = (fn: () => void) => setTimeout(fn, 10);
  *  </div>
  * ```
  */
-export class HtmlElementAutoclosingOnTypeFormattingProvider
-  implements BaseOnTypeFormattingProvider
-{
+export class HtmlElementAutoclosingOnTypeFormattingProvider implements BaseOnTypeFormattingProvider {
   constructor(private setCursorPosition: SetCursorPosition) {}
 
   onTypeFormatting(

--- a/packages/theme-language-server-common/src/hover/providers/ContentForArgumentHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/ContentForArgumentHoverProvider.spec.ts
@@ -64,7 +64,7 @@ const createProvider = (getSnippetDefinition: GetDocDefinitionForURI) => {
       tags: async () => [],
       systemTranslations: async () => ({}),
     },
-    async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     async () => ({}),
     async () => [],
     getSnippetDefinition,

--- a/packages/theme-language-server-common/src/hover/providers/ContentForTypeHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/ContentForTypeHoverProvider.spec.ts
@@ -79,7 +79,7 @@ const createProvider = (getSnippetDefinition: GetDocDefinitionForURI) => {
       tags: async () => [],
       systemTranslations: async () => ({}),
     },
-    async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     async () => ({}),
     async () => [],
     getSnippetDefinition,

--- a/packages/theme-language-server-common/src/hover/providers/HtmlAttributeHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/HtmlAttributeHoverProvider.spec.ts
@@ -16,7 +16,7 @@ describe('Module: HtmlAttributeHoverProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     );
   });
 

--- a/packages/theme-language-server-common/src/hover/providers/HtmlAttributeValueHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/HtmlAttributeValueHoverProvider.spec.ts
@@ -16,7 +16,7 @@ describe('Module: HtmlAttributeHoverProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     );
   });
 

--- a/packages/theme-language-server-common/src/hover/providers/HtmlTagHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/HtmlTagHoverProvider.spec.ts
@@ -16,7 +16,7 @@ describe('Module: HtmlTagHoverProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     );
   });
 

--- a/packages/theme-language-server-common/src/hover/providers/LiquidDocTagHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidDocTagHoverProvider.spec.ts
@@ -18,7 +18,7 @@ describe('Module: RenderSnippetParameterHoverProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     );
   });
 

--- a/packages/theme-language-server-common/src/hover/providers/LiquidFilterArgumentHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidFilterArgumentHoverProvider.spec.ts
@@ -32,7 +32,7 @@ describe('Module: LiquidFilterArgumentHoverProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     );
   });
 

--- a/packages/theme-language-server-common/src/hover/providers/LiquidFilterHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidFilterHoverProvider.spec.ts
@@ -23,7 +23,7 @@ describe('Module: LiquidFilterHoverProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     );
   });
 

--- a/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidObjectAttributeHoverProvider.spec.ts
@@ -56,7 +56,7 @@ describe('Module: LiquidObjectAttributeHoverProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     );
   });
 

--- a/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/LiquidTagHoverProvider.spec.ts
@@ -19,7 +19,7 @@ describe('Module: LiquidTagHoverProvider', async () => {
         ],
         systemTranslations: async () => ({}),
       },
-      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     );
   });
 

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetHoverProvider.spec.ts
@@ -73,7 +73,7 @@ const createProvider = (getSnippetDefinition: GetDocDefinitionForURI) => {
       tags: async () => [],
       systemTranslations: async () => ({}),
     },
-    async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     async () => ({}),
     async () => [],
     getSnippetDefinition,

--- a/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/RenderSnippetParameterHoverProvider.spec.ts
@@ -58,7 +58,7 @@ const createProvider = (getSnippetDefinition: GetDocDefinitionForURI) => {
       tags: async () => [],
       systemTranslations: async () => ({}),
     },
-    async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+    async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     async () => ({}),
     async () => [],
     getSnippetDefinition,

--- a/packages/theme-language-server-common/src/hover/providers/TranslationHoverProvider.spec.ts
+++ b/packages/theme-language-server-common/src/hover/providers/TranslationHoverProvider.spec.ts
@@ -16,7 +16,7 @@ describe('Module: TranslationHoverProvider', async () => {
         tags: async () => [],
         systemTranslations: async () => ({}),
       },
-      async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
       async () => ({
         general: {
           password: 'password',

--- a/packages/theme-language-server-common/src/progress.ts
+++ b/packages/theme-language-server-common/src/progress.ts
@@ -20,7 +20,10 @@ export interface IProgress {
  * await progress.end('Finished');
  */
 export class Progress {
-  constructor(private connection: Connection, private progressToken: string) {}
+  constructor(
+    private connection: Connection,
+    private progressToken: string,
+  ) {}
 
   static create(
     connection: Connection | undefined,

--- a/packages/theme-language-server-common/src/server/Configuration.ts
+++ b/packages/theme-language-server-common/src/server/Configuration.ts
@@ -24,7 +24,10 @@ export class Configuration {
   [CHECK_ON_CHANGE]: boolean = true;
   [PRELOAD_ON_BOOT]: boolean = true;
 
-  constructor(private connection: Connection, private capabilities: ClientCapabilities) {
+  constructor(
+    private connection: Connection,
+    private capabilities: ClientCapabilities,
+  ) {
     this.connection = connection;
     this.capabilities = capabilities;
   }

--- a/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
+++ b/packages/theme-language-server-common/src/test/CompletionItemsAssertion.spec.ts
@@ -18,7 +18,7 @@ describe('Module: CompletionItemsAssertion', () => {
         tags: async () => [{ name: 'render' }],
         systemTranslations: async () => ({}),
       },
-      getMetafieldDefinitions: async (_rootUri: string) => ({} as MetafieldDefinitionMap),
+      getMetafieldDefinitions: async (_rootUri: string) => ({}) as MetafieldDefinitionMap,
     });
   });
 

--- a/packages/vscode-extension/webpack.config.js
+++ b/packages/vscode-extension/webpack.config.js
@@ -90,7 +90,7 @@ const desktopConfig = {
           to: 'data',
         },
         {
-          from: path.resolve(__dirname, '../../node_modules/prettier'),
+          from: path.resolve(__dirname, '../../node_modules/prettier2'),
           to: 'prettier',
           globOptions: {
             ignore: ['**/esm/**'],
@@ -110,6 +110,9 @@ const browserClientConfig = {
   },
   resolve: {
     ...baseConfig.resolve,
+    alias: {
+      prettier: path.resolve(__dirname, '../../node_modules/prettier2'),
+    },
   },
   output: {
     path: path.resolve(__dirname, 'dist', 'browser'),
@@ -142,6 +145,12 @@ const browserServerConfig = async () => {
     ...baseConfig,
     target: 'webworker',
     entry: { server: './src/browser/server.ts', },
+    resolve: {
+      ...baseConfig.resolve,
+      alias: {
+        prettier: path.resolve(__dirname, '../../node_modules/prettier2'),
+      },
+    },
     output: {
       path: path.resolve(__dirname, 'dist', 'browser'),
       filename: '[name].js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,7 +1375,7 @@
 
 "@types/prettier@^2.4.2":
   version "2.7.3"
-  resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz"
+  resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
   integrity sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==
 
 "@types/qs@*":
@@ -6430,10 +6430,15 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz"
   integrity sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==
 
-prettier@^2.6.2, prettier@^2.7.1, prettier@^2.8.4:
+prettier@^2.6.2, prettier@^2.7.1:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+prettier@^3.0.0:
+  version "3.8.1"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz#edf48977cf991558f4fcbd8a3ba6015ba2a3a173"
+  integrity sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What are you adding in this PR?

Upgrade Prettier from v2.8.4 to v3.0.0. This update includes formatting changes across multiple files, primarily affecting interface declarations and conditional expressions. The changes are mostly related to line breaks and indentation.  
  
## Why?

Because ohm-js/wasm is making us newer features of ESM that prettier 2 doesn't support. 

## Before you deploy

- [x] I included a patch bump `changeset`

`/aside` Claude did the work but I did 🎩 and had it fix a couple of typing issues over a couple of loops. 