### PR TITLE
Fix RemoteAsset false positives for hash URLs and variable lookups

### DIFF
--- a/.changeset/fix-remote-asset-false-positives.md
+++ b/.changeset/fix-remote-asset-false-positives.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fix RemoteAsset false positives for hash URLs and variable-based attribute values


### PR DESCRIPTION
## Summary

Fixes #995, Fixes #982

This PR fixes two false positive issues in the `RemoteAsset` check:

1. **Hash URLs** (`#anchor`, `#section`) were incorrectly flagged as remote assets
2. **Variable-based URLs** (like `video_source.url`) were incorrectly flagged when static analysis can't determine what's in the variable

## Changes

- Add `isHashUrl()` helper to detect hash-only URLs and skip linting them
- Add `startsWithVariableLookup()` check to skip linting when attribute values start with a `VariableLookup` (since we can't statically know what's in variables)
- Add comprehensive test cases for both patterns

## Test plan

- [x] Added unit tests for hash URL patterns
- [x] Added unit tests for variable lookup patterns
- [x] Existing tests continue to pass