### PR TITLE
valid-schema-translations theme check

### DIFF
--- a/.changeset/loud-hotels-teach.md
+++ b/.changeset/loud-hotels-teach.md
@@ -1,0 +1,6 @@
+---
+"@shopify/theme-check-common": minor
+"@shopify/theme-check-node": minor
+---
+
+New theme check to ensure translation values inside of `schema` tag are valid

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -59,6 +59,7 @@ import { ValidLocalBlocks } from './valid-local-blocks';
 import { ValidRenderSnippetArgumentTypes } from './valid-render-snippet-argument-types';
 import { ValidSchema } from './valid-schema';
 import { ValidSchemaName } from './valid-schema-name';
+import { ValidSchemaTranslations } from './valid-schema-translations';
 import { ValidSettingsKey } from './valid-settings-key';
 import { ValidStaticBlockType } from './valid-static-block-type';
 import { ValidVisibleIf, ValidVisibleIfSettingsSchema } from './valid-visible-if';
@@ -133,6 +134,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   ValidVisibleIfSettingsSchema,
   VariableName,
   ValidSchemaName,
+  ValidSchemaTranslations,
 ];
 
 /**

--- a/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-name/index.spec.ts
@@ -69,26 +69,6 @@ describe('Module: ValidSchemaName', () => {
     expect(offenses).toHaveLength(0);
   });
 
-  it('reports an offense with schema name translation is missing', async () => {
-    const offenses = await check(
-      {
-        'locales/en.default.schema.json': '{ "another_translation_key": "Another translation"}',
-        'sections/file.liquid': `
-          {% schema %}
-            {
-              "name": "t:my_translation_key"
-            }
-          {% endschema %}`,
-      },
-      [ValidSchemaName],
-    );
-
-    expect(offenses).toHaveLength(1);
-    expect(offenses[0].message).toEqual(
-      "'t:my_translation_key' does not have a matching entry in 'locales/en.default.schema.json'",
-    );
-  });
-
   it('reports an offense with schema name translation that exists and is over 25 chars long', async () => {
     const offenses = await check(
       {

--- a/packages/theme-check-common/src/checks/valid-schema-name/index.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-name/index.ts
@@ -47,14 +47,6 @@ export const ValidSchemaName: LiquidCheckDefinition = {
           const defaultTranslations = await context.getDefaultSchemaTranslations();
           const translation = deepGet(defaultTranslations, key.split('.'));
 
-          if (translation === undefined) {
-            context.report({
-              message: `'${name}' does not have a matching entry in 'locales/${defaultLocale}.default.schema.json'`,
-              startIndex,
-              endIndex,
-            });
-          }
-
           if (translation !== undefined && translation.length > MAX_SCHEMA_NAME_LENGTH) {
             context.report({
               message: `Schema name '${translation}' from 'locales/${defaultLocale}.default.schema.json' is too long (max 25 characters)`,

--- a/packages/theme-check-common/src/checks/valid-schema-translations/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-translations/index.spec.ts
@@ -1,0 +1,178 @@
+import { expect, describe, it } from 'vitest';
+import { highlightedOffenses, check } from '../../test';
+import { ValidSchemaTranslations } from './index';
+
+describe('Module: ValidSchemaTranslations', () => {
+  it('reports no offense when schema has no translation keys', async () => {
+    const offenses = await check(
+      {
+        'locales/en.default.schema.json': '{}',
+        'sections/file.liquid': `
+          {% schema %}
+            {
+              "name": "My Section",
+              "settings": [
+                {
+                  "type": "text",
+                  "id": "title",
+                  "label": "Title"
+                }
+              ]
+            }
+          {% endschema %}`,
+      },
+      [ValidSchemaTranslations],
+    );
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports no offense when all translation keys exist', async () => {
+    const offenses = await check(
+      {
+        'locales/en.default.schema.json': JSON.stringify({
+          sections: {
+            header: {
+              name: 'Header',
+              settings: {
+                title: {
+                  label: 'Title',
+                  info: 'Enter a title',
+                },
+              },
+            },
+          },
+        }),
+        'sections/file.liquid': `
+          {% schema %}
+            {
+              "name": "t:sections.header.name",
+              "settings": [
+                {
+                  "type": "text",
+                  "id": "title",
+                  "label": "t:sections.header.settings.title.label",
+                  "info": "t:sections.header.settings.title.info"
+                }
+              ]
+            }
+          {% endschema %}`,
+      },
+      [ValidSchemaTranslations],
+    );
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports an offense when a translation key is missing', async () => {
+    const themeFiles = {
+      'locales/en.default.schema.json': JSON.stringify({
+        sections: {
+          header: {
+            name: 'Header',
+          },
+        },
+      }),
+      'sections/file.liquid': `
+          {% schema %}
+            {
+              "name": "t:sections.header.missing_key"
+            }
+          {% endschema %}`,
+    };
+
+    const offenses = await check(themeFiles, [ValidSchemaTranslations]);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual(
+      "'t:sections.header.missing_key' does not have a matching entry in 'locales/en.default.schema.json'",
+    );
+
+    const highlights = highlightedOffenses(themeFiles, offenses);
+    expect(highlights).toHaveLength(1);
+    expect(highlights[0]).toBe('"t:sections.header.missing_key"');
+  });
+
+  it('reports multiple offenses when multiple translation keys are missing', async () => {
+    const offenses = await check(
+      {
+        'locales/en.default.schema.json': JSON.stringify({
+          sections: {
+            header: {
+              name: 'Header',
+            },
+          },
+        }),
+        'sections/file.liquid': `
+          {% schema %}
+            {
+              "name": "t:sections.header.name",
+              "settings": [
+                {
+                  "type": "text",
+                  "id": "title",
+                  "label": "t:sections.header.settings.title.label",
+                  "info": "t:sections.header.settings.title.info"
+                }
+              ]
+            }
+          {% endschema %}`,
+      },
+      [ValidSchemaTranslations],
+    );
+
+    expect(offenses).toHaveLength(2);
+    expect(offenses[0].message).toEqual(
+      "'t:sections.header.settings.title.label' does not have a matching entry in 'locales/en.default.schema.json'",
+    );
+    expect(offenses[1].message).toEqual(
+      "'t:sections.header.settings.title.info' does not have a matching entry in 'locales/en.default.schema.json'",
+    );
+  });
+
+  it('reports offense for missing translation in nested arrays', async () => {
+    const themeFiles = {
+      'locales/en.default.schema.json': JSON.stringify({
+        sections: {
+          header: {
+            name: 'Header',
+          },
+        },
+      }),
+      'sections/file.liquid': `
+          {% schema %}
+            {
+              "name": "t:sections.header.name",
+              "blocks": [
+                {
+                  "type": "text",
+                  "name": "t:sections.header.blocks.text.name"
+                }
+              ]
+            }
+          {% endschema %}`,
+    };
+
+    const offenses = await check(themeFiles, [ValidSchemaTranslations]);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual(
+      "'t:sections.header.blocks.text.name' does not have a matching entry in 'locales/en.default.schema.json'",
+    );
+  });
+
+  it('reports no offense when schema is invalid JSON', async () => {
+    const offenses = await check(
+      {
+        'locales/en.default.schema.json': '{}',
+        'sections/file.liquid': `
+          {% schema %}
+            { invalid json }
+          {% endschema %}`,
+      },
+      [ValidSchemaTranslations],
+    );
+
+    expect(offenses).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/valid-schema-translations/index.ts
+++ b/packages/theme-check-common/src/checks/valid-schema-translations/index.ts
@@ -1,0 +1,97 @@
+import { getLocEnd, getLocStart } from '../../json';
+import { getSchema } from '../../to-schema';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { deepGet } from '../../utils';
+import { JSONNode, LiteralNode } from '../../jsonc/types';
+
+export const ValidSchemaTranslations: LiquidCheckDefinition = {
+  meta: {
+    code: 'ValidSchemaTranslations',
+    name: 'Reports missing translation keys in schema',
+    docs: {
+      description:
+        'This check ensures all translation keys (t:) in schema have matching entries in the default schema translations file.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-schema-translations',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    return {
+      async LiquidRawTag(node) {
+        if (node.name !== 'schema' || node.body.kind !== 'json') {
+          return;
+        }
+
+        const offset = node.blockStartPosition.end;
+        const schema = await getSchema(context);
+        const { ast } = schema ?? {};
+        if (!ast || ast instanceof Error) return;
+
+        const defaultLocale = await context.getDefaultLocale();
+        const defaultTranslations = await context.getDefaultSchemaTranslations();
+
+        // Find all string values that start with 't:' and check if they have translations
+        const translationNodes = findTranslationKeys(ast);
+
+        for (const { value, node: literalNode } of translationNodes) {
+          const key = value.replace('t:', '');
+          const translation = deepGet(defaultTranslations, key.split('.'));
+
+          if (translation === undefined) {
+            const startIndex = offset + getLocStart(literalNode);
+            const endIndex = offset + getLocEnd(literalNode);
+
+            context.report({
+              message: `'${value}' does not have a matching entry in 'locales/${defaultLocale}.default.schema.json'`,
+              startIndex,
+              endIndex,
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+/**
+ * Recursively find all string literal nodes that start with 't:' (translation keys)
+ */
+function findTranslationKeys(node: JSONNode): { value: string; node: LiteralNode }[] {
+  const results: { value: string; node: LiteralNode }[] = [];
+
+  switch (node.type) {
+    case 'Literal': {
+      if (typeof node.value === 'string' && node.value.startsWith('t:')) {
+        results.push({ value: node.value, node });
+      }
+      break;
+    }
+
+    case 'Object': {
+      for (const property of node.children) {
+        results.push(...findTranslationKeys(property.value));
+      }
+      break;
+    }
+
+    case 'Array': {
+      for (const child of node.children) {
+        results.push(...findTranslationKeys(child));
+      }
+      break;
+    }
+
+    case 'Property':
+    case 'Identifier': {
+      // Keys don't contain translation values
+      break;
+    }
+  }
+
+  return results;
+}

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -193,6 +193,9 @@ ValidSchema:
 ValidSchemaName:
   enabled: true
   severity: 0
+ValidSchemaTranslations:
+  enabled: true
+  severity: 0
 ValidSettingsKey:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -171,6 +171,9 @@ ValidSchema:
 ValidSchemaName:
   enabled: true
   severity: 0
+ValidSchemaTranslations:
+  enabled: true
+  severity: 0
 ValidSettingsKey:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?

Part of https://github.com/Shopify/theme-tools/issues/942

Added a new theme check called `ValidSchemaTranslations` that ensures all translation keys (t:) in schema have matching entries in the default schema translations file. This check supersedes the existing `ValidSchemaName` which only checked the `schema.name` value (along with a few more things).

The PR:

- Creates a new check that recursively finds all string values starting with 't:' in schema JSON
- Verifies each translation key has a corresponding entry in the translations file
- Reports error messages for missing translations
- Moves the translation existence check from `ValidSchemaName` to this new dedicated check

## Tophat

Here is a schema you can test out the new theme-check (assuming you don't have `t:general.headerfoo` in your `en.default.schema.json`

```
{% schema %}
{
  "name": "t:general.headerfoo",
  "default": {
    "text": "t:general.headerfoo",
    "select": "option",
    "radio": "option",
  },
  "settings": [
    {
      "type": "text",
      "id": "text",
      "label": "t:general.headerfoo",
    },
    {
      "type": "select",
      "id": "select",
      "label": "t:general.headerfoo",
      "options": [
        {
          "group": "Select Group 1",
          "label": "t:general.headerfoo",
          "value": "option",
        },
        {
          "group": "Select Group 1",
          "label": "Option 2",
          "value": "option2",
        },
      ]
    },
    {
      "type": "radio",
      "id": "radio",
      "label": "Radio",
      "options": [
        {
          "label": "Option",
          "value": "option",
        }
      ],
    }
  ],
  "presets": [
    {
      "name": "Alok Section",
      "category": "t:general.headerfoo",
      "settings": {
        "text": "t:general.headerfoo",
        "select": "option",
        "radio": "option",
      }
    }
  ]
}
{% endschema %}
```

## What's next? Any followup issues?

- Updating shopify-dev so that we have it documented

## Before you deploy

- [x] This PR includes a new checks or changes the configuration of a check
    - [x] I included a minor bump `changeset`
    - [x] It's in the `allChecks` array in `src/checks/index.ts`
    - [x] I ran `yarn build` and committed the updated configuration files
    - [ ] I've made a PR to update the [shopify.dev theme check docs](https://github.com/Shopify/shopify-dev/tree/main/content/storefronts/themes/tools/theme-check/checks) if applicable.
        - I will do so after this PR since we aren't cutting a release for this theme-check yet