### PR TITLE
Remove extra NPM_TOKEN configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
   VSCE_PAT: ${{ secrets.VSCE_PAT }}
   OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   npm_config_registry: "https://registry.npmjs.org"
 


### PR DESCRIPTION
We don't use the NPM_TOKEN value for releasing anymore and actively remove it from the publishing step. There's some theory that this being set at the environment level could be causing some disruption to the publishing step (since it's currently failing).

We aren't using this variable for anything else in this workflow so it's safe to remove.