### PR TITLE
Fix OIDC Trusted Publishing workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,7 @@
     ["theme-check-vscode"]
   ],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch"
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,6 @@ jobs:
         run: echo "version=$(jq -r .version packages/vscode-extension/package.json)" >> $GITHUB_OUTPUT
 
       - name: Test OIDC Token
-        if: steps.version.outputs.NEXT_VERSION
         run: |
           TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm" | jq -r '.value')
@@ -75,7 +74,6 @@ jobs:
           version: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: '' # Empty string forces OIDC
           NPM_CONFIG_PROVENANCE: true
 
       - name: VS Code Marketplace publish


### PR DESCRIPTION
## Summary

- Remove broken `if` condition on the "Test OIDC Token" step that referenced a non-existent step ID (`version`), causing the OIDC sanity check to silently never run
- Remove unnecessary `NPM_TOKEN: ''` override from the changesets step env (the workflow-level `NPM_TOKEN` was already removed in a prior commit)
- Align changeset config `access` from `restricted` to `public` to match actual publish behavior (all 12 publishable packages already declare `publishConfig.access: "public"`)

## Context

The recent switch to OIDC Trusted Publishing successfully publishes 9/11 packages. The 2 remaining failures (`@shopify/codemirror-language-client` and `@shopify/theme-graph`) are caused by missing npm-side Trusted Publishing configuration, which is being handled separately.