### PR TITLE
add tabstops to translations variables

### DIFF
--- a/.changeset/breezy-sheep-repair.md
+++ b/.changeset/breezy-sheep-repair.md
@@ -1,0 +1,5 @@
+---
+"@shopify/theme-language-server-common": patch
+---
+
+add tabstops to translations variables

--- a/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.spec.ts
+++ b/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.spec.ts
@@ -1,4 +1,5 @@
 import { describe, beforeEach, it, expect } from 'vitest';
+import { InsertTextFormat } from 'vscode-languageserver';
 import { DocumentManager } from '../../documents';
 import { CompletionsProvider } from '../CompletionsProvider';
 import { MetafieldDefinitionMap } from '@shopify/theme-check-common';
@@ -59,6 +60,20 @@ describe('Module: TranslationCompletionProvider', async () => {
         }),
       }),
       '"general.comments" | t',
+    ]);
+  });
+
+  it('should add snippet tab stops for translation variables', async () => {
+    await expect(provider).to.complete('{{ "general.comments█" }}', [
+      '"general.username_html" | t',
+      '"general.password" | t',
+      expect.objectContaining({
+        label: '"general.comments" | t',
+        insertTextFormat: InsertTextFormat.Snippet,
+        textEdit: expect.objectContaining({
+          newText: expect.stringContaining('count: ${1:count}'),
+        }),
+      }),
     ]);
   });
 });

--- a/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/TranslationCompletionProvider.ts
@@ -1,10 +1,16 @@
 import { LiquidHtmlNode, NodeTypes } from '@shopify/liquid-html-parser';
-import { CompletionItem, CompletionItemKind, Range, TextEdit } from 'vscode-languageserver';
+import {
+  CompletionItem,
+  CompletionItemKind,
+  InsertTextFormat,
+  Range,
+  TextEdit,
+} from 'vscode-languageserver';
 import { DocumentManager } from '../../documents';
 import {
   GetTranslationsForURI,
   extractParams,
-  paramsString,
+  paramsWithTabstops,
   renderTranslation,
   translationOptions,
 } from '../../translations';
@@ -84,11 +90,12 @@ export class TranslationCompletionProvider implements Provider {
       const params = extractParams(
         typeof translation === 'string' ? translation : (Object.values(translation)[0] ?? ''),
       );
-      const parameters = paramsString(params);
+      const parameters = paramsWithTabstops(params);
       return {
         label: quote + path.join('.') + quote + ' | t', // don't want the count here because it feels noisy(?)
         insertText: path.join('.').slice(insertTextStartIndex), // for editors that don't support textEdit
         kind: CompletionItemKind.Field,
+        insertTextFormat: parameters ? InsertTextFormat.Snippet : InsertTextFormat.PlainText,
         textEdit: TextEdit.replace(
           replaceRange,
           path.join('.') + postFix + (shouldAppendTranslateFilter ? parameters : ''),

--- a/packages/theme-language-server-common/src/translations.ts
+++ b/packages/theme-language-server-common/src/translations.ts
@@ -81,3 +81,8 @@ export function paramsString(params: string[]) {
   if (params.length === 0) return '';
   return `: ` + params.map((param) => `${param}: ${param}`).join(', ');
 }
+
+export function paramsWithTabstops(params: string[]) {
+  if (params.length === 0) return '';
+  return ': ' + params.map((param, index) => `${param}: \${${index + 1}:${param}}`).join(', ');
+}


### PR DESCRIPTION
## What are you adding in this PR?
This fix adds tabstops to all the translation completions-- after selecting the autocomplete label from the dropdown, and pressing `tab`, the editor will now highlight the variable text to be filled by the user and the user will be able to type directly into this space, then `tab` forward and write text over the next variable (if there are multiple variables).
This will only work for translations that have variables.

I wrote a new function in `translations.ts` that creates the string with the Snippet syntax.  There are Plain Text strings and Snippet strings, the previously used function returned PlainText and the tabstops behavior is only available on a Snippet.

The function gets called in the TranslationCompletionProvider and the insertTextFormat flag also gets set to Snippet now, so the editor knows to interpret the string as Snippet and surface the tabstops behavior to the user. 

The existing spec file passes with my change and I added a new test to verify the new behavior

Fixes #537 
## How to Tophat
Off of main (old behavior): To trigger the translation key autocomplete with variables, go to any .liquid file and type:
`{{ 'search.res`
and pause for autocomplete to pop up. Select `search.results_for_html` and accept it, then notice that the variables are not highlighted and must be selected manually to be typed over (screenshots are in the linked ticket)
To see the new behavior, pull down my branch, function F5 to open the Extension Development instance in any theme and repeat the process.  Now you should see the variables highlighted, with the ability to tab to each one and type over. 
Here is a screen recording of the correct, tophatted behavior:

https://github.com/user-attachments/assets/212da252-4ad7-48dd-bd4e-f63bba067183

## What did you learn?

I learned about the block element  █ .
in the context of the tests in the spec file, the block element is used by the test framework to mock the cursor position so the test knows when to trigger the autocomplete functionality and must be used when testing autocomplete behavior (which my change falls under) but isn't needed to test things like the dropdown labels being present or the documentation pop-up. 

## Before you deploy
<!-- Public API changes, new features -->
- [x] I included a patch `changeset`
- [x] My feature is backward compatible

