### PR TITLE
Add color_palette setting type for language server support

### DIFF
--- a/.changeset/popular-dryers-swim.md
+++ b/.changeset/popular-dryers-swim.md
@@ -1,0 +1,6 @@
+---
+"@shopify/theme-language-server-common": patch
+"@shopify/theme-check-common": patch
+---
+
+Add support for color_palette input type

--- a/packages/theme-check-common/src/types/schemas/setting.ts
+++ b/packages/theme-check-common/src/types/schemas/setting.ts
@@ -34,6 +34,7 @@ export declare namespace Setting {
     | ColorBackground
     | ColorScheme
     | ColorSchemeGroup
+    | ColorPalette
     | ImagePicker
     | Video
     | VideoUrl
@@ -81,6 +82,7 @@ export declare namespace Setting {
     ColorBackground = 'color_background',
     ColorScheme = 'color_scheme',
     ColorSchemeGroup = 'color_scheme_group',
+    ColorPalette = 'color_palette',
 
     // Media Settings
     ImagePicker = 'image_picker',
@@ -200,6 +202,9 @@ export declare namespace Setting {
     default?: string;
   }
   export interface ColorSchemeGroup extends Base<Type.ColorSchemeGroup> {}
+  export interface ColorPalette extends Base<Type.ColorPalette> {
+    default?: Record<string, string>;
+  }
 
   // Media Settings
   export interface ImagePicker extends Base<Type.ImagePicker> {

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -998,6 +998,9 @@ function settingReturnType(setting: InputSetting): ObjectEntry['return_type'] {
     case 'color_scheme_group':
       return [];
 
+    case 'color_palette':
+      return [{ type: 'string', name: '' }];
+
     case 'font_picker':
       return [{ type: 'font', name: '' }];
 


### PR DESCRIPTION
Add TypeScript type definitions and language server type inference for the new color_palette setting type.

- `packages/theme-check-common/src/types/schemas/setting.ts` — add `ColorPalette` to type union, enum, and interface
- `packages/theme-language-server-common/src/TypeSystem.ts` — add return type case for `color_palette` settings