### PR TITLE
fix: use createRequire for node_modules resolution in VSCode extension

### DIFF
--- a/.changeset/fix-vscode-node-modules-resolution.md
+++ b/.changeset/fix-vscode-node-modules-resolution.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': patch
+---
+
+Fix VSCode extension failing to resolve custom check packages from node_modules (e.g. `extends: '@acme/theme-check-extension/recommended.yml'`). The extension server is webpack-bundled, so `require.resolve` was being handled by webpack instead of Node.js, returning a module ID rather than a file path. Now uses `createRequire` from `node:module` to get real Node.js resolution.

--- a/packages/theme-check-node/src/config/resolve/read-yaml.ts
+++ b/packages/theme-check-node/src/config/resolve/read-yaml.ts
@@ -179,7 +179,7 @@ function resolvePath(
   // returns a numeric module ID instead of a file path. createRequire creates
   // a real Node.js require function that resolves from the given directory,
   // traversing ancestor node_modules automatically.
-  const req = createRequire(path.join(root, '__placeholder.js'));
+  const req = createRequire(path.join(root, '__placeholder'));
   return realpathSync(req.resolve(pathLike));
 }
 

--- a/packages/theme-check-node/src/config/resolve/read-yaml.ts
+++ b/packages/theme-check-node/src/config/resolve/read-yaml.ts
@@ -1,6 +1,7 @@
 import { CheckSettings, Modes, Severity } from '@shopify/theme-check-common';
 import { realpathSync } from 'node:fs';
 import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { parse } from 'yaml';
 import { AbsolutePath } from '../../temp';
@@ -172,7 +173,14 @@ function resolvePath(
     return path.resolve(root, pathLike);
   }
 
-  return realpathSync(require.resolve(pathLike, { paths: getAncestorNodeModules(root)! }));
+  // Use createRequire to get the real Node.js require rather than webpack's
+  // substitute. When the VSCode extension server is bundled, `require.resolve`
+  // becomes webpack's version which doesn't support the `paths` option and
+  // returns a numeric module ID instead of a file path. createRequire creates
+  // a real Node.js require function that resolves from the given directory,
+  // traversing ancestor node_modules automatically.
+  const req = createRequire(path.join(root, '__placeholder.js'));
+  return realpathSync(req.resolve(pathLike));
 }
 
 /**
@@ -236,16 +244,4 @@ function isString(thing: unknown): thing is string {
 
 function asArray<T>(thing: T | T[]): T[] {
   return Array.isArray(thing) ? thing : [thing];
-}
-
-function getAncestorNodeModules(dir: string): string[] {
-  const root = path.parse(dir).root;
-  const nodeModulesPaths: string[] = [];
-
-  while (dir !== root) {
-    nodeModulesPaths.push(path.join(dir, 'node_modules'));
-    dir = path.dirname(dir);
-  }
-
-  return nodeModulesPaths;
 }


### PR DESCRIPTION
## Summary

- Fixes the VSCode extension failing to resolve custom theme check packages (e.g. `@grafikr/theme-check-extension/recommended.yml`) from `node_modules`, while the CLI works fine.
- The root cause: the extension's language server is bundled by webpack, which replaces `require` with its own module system. webpack's `require.resolve` ignores the `paths` option and returns a numeric module ID instead of a real file path.
- The fix uses `createRequire` from `node:module` to create a proper Node.js require function that bypasses webpack's substitution. Node.js's native resolution already traverses ancestor `node_modules` directories, so the `getAncestorNodeModules` helper is no longer needed.

## Test plan

- [x] Confirm existing `read-yaml.spec.ts` tests pass (the node_module resolution test at line 105 exercises this exact code path)
- [x] Manually test by opening a Shopify theme project in VS Code that uses a custom `extends` package in `.theme-check.yml`, verify no "Cannot find module" errors

Closes #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)