### PR TITLE
Add ValidScopedCSSClass theme check

### DIFF
--- a/.changeset/rude-poems-yell.md
+++ b/.changeset/rude-poems-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-graph': patch
+---
+
+[internal] Moving @shopify/theme-check-node to being a dev-dependency of the package

--- a/.changeset/small-items-marry.md
+++ b/.changeset/small-items-marry.md
@@ -1,0 +1,14 @@
+---
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Introduce new theme-check to detect invalid CSS class usage in HTML
+
+`ValidScopedCSSClass` detects invalid CSS classes in HTML if it deems them being out of scope.
+A CSS class is in-scope if it matches any of the following:
+- The CSS class is declared in `assets/*.css` file
+- The CSS class is declared in the file's `stylesheet` tag
+- The CSS class is declared in a *direct* ancestor's `stylesheet` tag
+- The CSS class is declared in a snippet file's `stylesheet` tag that is rendered by this file or its direct ancestor (recursive)

--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -32,11 +32,15 @@
     "line-column": "^1.0.2",
     "lodash": "^4.17.23",
     "minimatch": "^10.2.1",
+    "postcss": "^8.5.9",
+    "postcss-safe-parser": "^7.0.1",
+    "postcss-selector-parser": "^7.1.1",
     "vscode-json-languageservice": "^5.3.10",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {
     "@types/line-column": "^1.0.0",
-    "@types/lodash": "^4.17.20"
+    "@types/lodash": "^4.17.20",
+    "@types/postcss-safe-parser": "^5.0.4"
   }
 }

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -52,6 +52,7 @@ import { UnusedDocParam } from './unused-doc-param';
 import { ValidContentForArguments } from './valid-content-for-arguments';
 import { ValidContentForArgumentTypes } from './valid-content-for-argument-types';
 import { ValidBlockTarget } from './valid-block-target';
+import { ValidScopedCSSClass } from './valid-scoped-css-class';
 import { ValidHTMLTranslation } from './valid-html-translation';
 import { ValidJSON } from './valid-json';
 import { ValidDocParamTypes } from './valid-doc-param-types';
@@ -123,6 +124,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   ValidHTMLTranslation,
   ValidContentForArguments,
   ValidContentForArgumentTypes,
+  ValidScopedCSSClass,
   ValidJSON,
   ValidDocParamTypes,
   ValidLocalBlocks,

--- a/packages/theme-check-common/src/checks/valid-scoped-css-class/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-scoped-css-class/index.spec.ts
@@ -1,0 +1,781 @@
+import { expect, describe, it } from 'vitest';
+import { ValidScopedCSSClass } from './index';
+import { check, runLiquidCheck } from '../../test';
+
+describe('Module: ValidScopedCSSClass', () => {
+  const noDeps = {
+    getReferences: async () => [] as any[],
+    getDependencies: async () => [] as any[],
+  };
+
+  describe('local stylesheet scope', () => {
+    it('reports no offense when a class is defined in the local stylesheet', async () => {
+      const sourceCode = `
+        {% stylesheet %}
+          .my-class { color: red; }
+        {% endstylesheet %}
+        <div class="my-class">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('does not report when a class is not defined anywhere in the theme', async () => {
+      const sourceCode = `
+        {% stylesheet %}
+          .defined-class { color: red; }
+        {% endstylesheet %}
+        <div class="external-class">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('reports an offense when a class exists in the theme but is out of scope', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .local-class { color: red; }
+            {% endstylesheet %}
+            <div class="other-class">Hello</div>
+          `,
+          'snippets/other.liquid': `
+            {% stylesheet %}
+              .other-class { color: blue; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        noDeps,
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(1);
+      expect(sectionOffenses[0].message).toBe(
+        "CSS class 'other-class' may be defined outside the scope of this file.",
+      );
+    });
+
+    it('reports only out-of-scope theme classes, ignores unknown classes', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .a { color: red; }
+              .c { color: blue; }
+            {% endstylesheet %}
+            <div class="a b c external">Hello</div>
+          `,
+          'snippets/other.liquid': `
+            {% stylesheet %}
+              .b { font-size: 14px; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        noDeps,
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(1);
+      expect(sectionOffenses[0].message).toBe(
+        "CSS class 'b' may be defined outside the scope of this file.",
+      );
+    });
+
+    it('handles multiple stylesheet tags', async () => {
+      const sourceCode = `
+        {% stylesheet %}
+          .from-first { color: red; }
+        {% endstylesheet %}
+        {% stylesheet %}
+          .from-second { color: blue; }
+        {% endstylesheet %}
+        <div class="from-first from-second">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('does not report when a class is in scope even if also defined out of scope', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .shared-class { color: red; }
+            {% endstylesheet %}
+            <div class="shared-class">Hello</div>
+          `,
+          'snippets/unrelated.liquid': `
+            {% stylesheet %}
+              .shared-class { color: blue; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        noDeps,
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(0);
+    });
+  });
+
+  describe('dynamic class attributes', () => {
+    it('skips dynamic Liquid output in class attribute values', async () => {
+      const sourceCode = `
+        {% stylesheet %}
+          .static { color: red; }
+        {% endstylesheet %}
+        <div class="static {{ dynamic_var }}">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('checks static parts and skips dynamic parts in mixed attributes', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .static { color: red; }
+            {% endstylesheet %}
+            <div class="static out-of-scope {{ dynamic }}">Hello</div>
+          `,
+          'snippets/other.liquid': `
+            {% stylesheet %}
+              .out-of-scope { color: blue; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        noDeps,
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(1);
+      expect(sectionOffenses[0].message).toBe(
+        "CSS class 'out-of-scope' may be defined outside the scope of this file.",
+      );
+    });
+
+    it('does not report partial tokens glued to Liquid nodes', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .static { color: red; }
+            {% endstylesheet %}
+            <div class="btn-{{ size }} static">Hello</div>
+          `,
+          'snippets/other.liquid': `
+            {% stylesheet %}
+              .btn- { color: blue; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        noDeps,
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(0);
+    });
+  });
+
+  describe('CSS class extraction edge cases', () => {
+    it('extracts classes from complex selectors', async () => {
+      const sourceCode = `
+        {% stylesheet %}
+          .parent > .child { color: red; }
+          .a + .b ~ .c { color: blue; }
+        {% endstylesheet %}
+        <div class="parent child a b c">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('extracts classes from pseudo-class selectors', async () => {
+      const sourceCode = `
+        {% stylesheet %}
+          .btn:hover { color: red; }
+          .link::before { content: ''; }
+        {% endstylesheet %}
+        <div class="btn link">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('extracts classes from media queries', async () => {
+      const sourceCode = `
+        {% stylesheet %}
+          @media (min-width: 768px) {
+            .responsive { display: block; }
+          }
+        {% endstylesheet %}
+        <div class="responsive">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('does not extract classes from CSS comments', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              /* .commented-out { color: red; } */
+              .real { color: blue; }
+            {% endstylesheet %}
+            <div class="commented-out real">Hello</div>
+          `,
+          'snippets/other.liquid': `
+            {% stylesheet %}
+              .commented-out { color: green; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        noDeps,
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(1);
+      expect(sectionOffenses[0].message).toBe(
+        "CSS class 'commented-out' may be defined outside the scope of this file.",
+      );
+    });
+  });
+
+  describe('HTML element types', () => {
+    it('checks void elements', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .valid { color: red; }
+            {% endstylesheet %}
+            <input class="invalid">
+          `,
+          'snippets/other.liquid': `
+            {% stylesheet %}
+              .invalid { color: blue; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        noDeps,
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(1);
+      expect(sectionOffenses[0].message).toBe(
+        "CSS class 'invalid' may be defined outside the scope of this file.",
+      );
+    });
+
+    it('checks self-closing elements', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .valid { color: red; }
+            {% endstylesheet %}
+            <img class="invalid" />
+          `,
+          'snippets/other.liquid': `
+            {% stylesheet %}
+              .invalid { color: blue; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        noDeps,
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(1);
+      expect(sectionOffenses[0].message).toBe(
+        "CSS class 'invalid' may be defined outside the scope of this file.",
+      );
+    });
+
+    it('checks SVG elements and their children', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .valid { color: red; }
+            {% endstylesheet %}
+            <svg class="out-of-scope">
+              <rect class="out-of-scope" />
+              <g class="out-of-scope"></g>
+            </svg>
+          `,
+          'snippets/other.liquid': `
+            {% stylesheet %}
+              .out-of-scope { color: blue; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        noDeps,
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(3);
+      expect(sectionOffenses.every((o) => o.message.includes('out-of-scope'))).toBe(true);
+    });
+  });
+
+  describe('empty and whitespace class attributes', () => {
+    it('does not report for empty class attribute', async () => {
+      const sourceCode = `
+        {% stylesheet %}
+          .a { color: red; }
+        {% endstylesheet %}
+        <div class="">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+  });
+
+  describe('ancestor stylesheet scope', () => {
+    it('considers classes from an ancestor file as in scope', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .parent-class { color: red; }
+            {% endstylesheet %}
+            {% render 'child' %}
+          `,
+          'snippets/child.liquid': `
+            <div class="parent-class">Hello</div>
+          `,
+        },
+        [ValidScopedCSSClass],
+        {
+          getReferences: async (uri: string) => {
+            if (uri.endsWith('snippets/child.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/child.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            return [];
+          },
+          getDependencies: async (uri: string) => {
+            if (uri.endsWith('sections/section.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/child.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            return [];
+          },
+        },
+      );
+
+      const snippetOffenses = offenses.filter((o) => o.uri.endsWith('snippets/child.liquid'));
+      expect(snippetOffenses).toHaveLength(0);
+    });
+
+    it('follows grandparent ancestors via direct references', async () => {
+      const offenses = await check(
+        {
+          'layout/theme.liquid': `
+            {% stylesheet %}
+              .layout-class { color: red; }
+            {% endstylesheet %}
+            {% sections 'main' %}
+          `,
+          'sections/section.liquid': `
+            {% render 'snippet' %}
+          `,
+          'snippets/snippet.liquid': `
+            <div class="layout-class">Hello</div>
+          `,
+        },
+        [ValidScopedCSSClass],
+        {
+          getReferences: async (uri: string) => {
+            if (uri.endsWith('snippets/snippet.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/snippet.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            if (uri.endsWith('sections/section.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///layout/theme.liquid' },
+                  target: { uri: 'file:///sections/section.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            return [];
+          },
+          getDependencies: async (uri: string) => {
+            if (uri.endsWith('layout/theme.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///layout/theme.liquid' },
+                  target: { uri: 'file:///sections/section.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            if (uri.endsWith('sections/section.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/snippet.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            return [];
+          },
+        },
+      );
+
+      const snippetOffenses = offenses.filter((o) => o.uri.endsWith('snippets/snippet.liquid'));
+      expect(snippetOffenses).toHaveLength(0);
+    });
+
+    it('does not consider indirect references as ancestors', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% stylesheet %}
+              .parent-class { color: red; }
+            {% endstylesheet %}
+          `,
+          'snippets/child.liquid': `
+            {% stylesheet %}
+              .local-class { color: blue; }
+            {% endstylesheet %}
+            <div class="local-class parent-class">Hello</div>
+          `,
+        },
+        [ValidScopedCSSClass],
+        {
+          getReferences: async (uri: string) => {
+            if (uri.endsWith('snippets/child.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/child.liquid' },
+                  type: 'indirect' as const,
+                },
+              ];
+            }
+            return [];
+          },
+          getDependencies: async () => [],
+        },
+      );
+
+      const snippetOffenses = offenses.filter((o) => o.uri.endsWith('snippets/child.liquid'));
+      expect(snippetOffenses).toHaveLength(1);
+      expect(snippetOffenses[0].message).toBe(
+        "CSS class 'parent-class' may be defined outside the scope of this file.",
+      );
+    });
+  });
+
+  describe('rendered snippet scope', () => {
+    it('considers classes from a rendered snippet as in scope', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% render 'styles' %}
+            <div class="snippet-class">Hello</div>
+          `,
+          'snippets/styles.liquid': `
+            {% stylesheet %}
+              .snippet-class { color: red; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        {
+          getReferences: async () => [],
+          getDependencies: async (uri: string) => {
+            if (uri.endsWith('sections/section.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/styles.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            return [];
+          },
+        },
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(0);
+    });
+
+    it('considers classes from snippet descendants (recursive)', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% render 'outer' %}
+            <div class="deep-class">Hello</div>
+          `,
+          'snippets/outer.liquid': `
+            {% render 'inner' %}
+          `,
+          'snippets/inner.liquid': `
+            {% stylesheet %}
+              .deep-class { color: red; }
+            {% endstylesheet %}
+          `,
+        },
+        [ValidScopedCSSClass],
+        {
+          getReferences: async () => [],
+          getDependencies: async (uri: string) => {
+            if (uri.endsWith('sections/section.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/outer.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            if (uri.endsWith('snippets/outer.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///snippets/outer.liquid' },
+                  target: { uri: 'file:///snippets/inner.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            return [];
+          },
+        },
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(0);
+    });
+
+    it('considers classes from snippets rendered by ancestors', async () => {
+      const offenses = await check(
+        {
+          'sections/section.liquid': `
+            {% render 'styles' %}
+            {% render 'child' %}
+          `,
+          'snippets/styles.liquid': `
+            {% stylesheet %}
+              .style-class { color: red; }
+            {% endstylesheet %}
+          `,
+          'snippets/child.liquid': `
+            <div class="style-class">Hello</div>
+          `,
+        },
+        [ValidScopedCSSClass],
+        {
+          getReferences: async (uri: string) => {
+            if (uri.endsWith('snippets/child.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/child.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            return [];
+          },
+          getDependencies: async (uri: string) => {
+            if (uri.endsWith('sections/section.liquid')) {
+              return [
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/styles.liquid' },
+                  type: 'direct' as const,
+                },
+                {
+                  source: { uri: 'file:///sections/section.liquid' },
+                  target: { uri: 'file:///snippets/child.liquid' },
+                  type: 'direct' as const,
+                },
+              ];
+            }
+            return [];
+          },
+        },
+      );
+
+      const childOffenses = offenses.filter((o) => o.uri.endsWith('snippets/child.liquid'));
+      expect(childOffenses).toHaveLength(0);
+    });
+  });
+
+  describe('CSS asset file scope', () => {
+    it('considers classes from .css files in the assets folder', async () => {
+      const offenses = await check(
+        {
+          'assets/theme.css': `.asset-class { color: red; }`,
+          'sections/section.liquid': `
+            <div class="asset-class">Hello</div>
+          `,
+        },
+        [ValidScopedCSSClass],
+        {
+          getReferences: async () => [],
+          getDependencies: async () => [],
+        },
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(0);
+    });
+
+    it('considers classes from multiple .css asset files', async () => {
+      const offenses = await check(
+        {
+          'assets/base.css': `.base-class { color: red; }`,
+          'assets/components.css': `.component-class { color: blue; }`,
+          'sections/section.liquid': `
+            <div class="base-class component-class">Hello</div>
+          `,
+        },
+        [ValidScopedCSSClass],
+        {
+          getReferences: async () => [],
+          getDependencies: async () => [],
+        },
+      );
+
+      const sectionOffenses = offenses.filter((o) => o.uri.endsWith('sections/section.liquid'));
+      expect(sectionOffenses).toHaveLength(0);
+    });
+  });
+
+  describe('graceful degradation', () => {
+    it('reports no offenses when getReferences is unavailable', async () => {
+      const sourceCode = `
+        <div class="undefined-class">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        {},
+      );
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('reports no offenses when getDependencies is unavailable', async () => {
+      const sourceCode = `
+        <div class="undefined-class">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        { getReferences: async () => [] },
+      );
+      expect(offenses).toHaveLength(0);
+    });
+  });
+
+  describe('no classes defined anywhere', () => {
+    it('reports no offenses when no CSS classes are defined in scope', async () => {
+      const sourceCode = `
+        <div class="some-class">Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+  });
+
+  describe('no class usage', () => {
+    it('reports no offenses when there are no class attributes', async () => {
+      const sourceCode = `
+        {% stylesheet %}
+          .some-class { color: red; }
+        {% endstylesheet %}
+        <div>Hello</div>
+      `;
+      const offenses = await runLiquidCheck(
+        ValidScopedCSSClass,
+        sourceCode,
+        'sections/section.liquid',
+        noDeps,
+      );
+      expect(offenses).toHaveLength(0);
+    });
+  });
+});

--- a/packages/theme-check-common/src/checks/valid-scoped-css-class/index.ts
+++ b/packages/theme-check-common/src/checks/valid-scoped-css-class/index.ts
@@ -1,0 +1,189 @@
+import {
+  LiquidRawTag,
+  HtmlElement,
+  HtmlRawNode,
+  HtmlVoidElement,
+  HtmlSelfClosingElement,
+} from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { AbstractFileSystem } from '../../AbstractFileSystem';
+import { recursiveReadDirectory } from '../../context-utils';
+import {
+  extractCSSClassNames,
+  collectUsedClasses,
+  collectUsedClassesFromSvg,
+} from '../../utils/styles';
+import {
+  getAncestorUris,
+  getAllSnippetDescendantUris,
+  getRenderedSnippetUris,
+} from '../../utils/traversal';
+
+/** Collect CSS classes from all .css files in the assets directory via getCSSClassesForURI. */
+async function getAssetCSSClasses(
+  fs: AbstractFileSystem,
+  toUri: (relativePath: string) => string,
+  getCSSClassesForURI: (uri: string) => Promise<Set<string>>,
+): Promise<Set<string>> {
+  const classes = new Set<string>();
+  try {
+    const assetsUri = toUri('assets');
+    const files = await fs.readDirectory(assetsUri);
+    const cssFileUris = files.filter(([uri]) => uri.endsWith('.css')).map(([uri]) => uri);
+    const results = await Promise.all(cssFileUris.map((uri) => getCSSClassesForURI(uri)));
+    for (const fileClasses of results) {
+      for (const cls of fileClasses) classes.add(cls);
+    }
+  } catch {
+    // assets directory might not exist
+  }
+  return classes;
+}
+
+/** Collect ALL CSS classes defined anywhere in the theme via getCSSClassesForURI. */
+async function getAllThemeCSSClasses(
+  fs: AbstractFileSystem,
+  toUri: (relativePath: string) => string,
+  getCSSClassesForURI: (uri: string) => Promise<Set<string>>,
+): Promise<Set<string>> {
+  const allClasses = new Set<string>();
+
+  // Collect from CSS asset files
+  const assetClasses = await getAssetCSSClasses(fs, toUri, getCSSClassesForURI);
+  for (const cls of assetClasses) allClasses.add(cls);
+
+  // Collect from all liquid files' stylesheet tags
+  try {
+    const rootUri = toUri('');
+    const liquidFiles = await recursiveReadDirectory(fs, rootUri, ([uri]) =>
+      uri.endsWith('.liquid'),
+    );
+    const results = await Promise.all(liquidFiles.map((uri) => getCSSClassesForURI(uri)));
+    for (const classes of results) {
+      for (const cls of classes) allClasses.add(cls);
+    }
+  } catch {
+    // root directory read failure
+  }
+
+  return allClasses;
+}
+
+export const ValidScopedCSSClass: LiquidCheckDefinition = {
+  meta: {
+    code: 'ValidScopedCSSClass',
+    name: 'Validates CSS classes used in class attributes are defined in an in-scope stylesheet',
+    docs: {
+      description:
+        'Reports CSS classes used in HTML class attributes that are not defined in any in-scope stylesheet tag or CSS asset file.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-scoped-css-class',
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    const localCSSClasses = new Set<string>();
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+
+    return {
+      async LiquidRawTag(node: LiquidRawTag) {
+        if (node.name === 'stylesheet') {
+          for (const cls of extractCSSClassNames(node.body.value)) {
+            localCSSClasses.add(cls);
+          }
+        }
+      },
+
+      async HtmlElement(node: HtmlElement) {
+        collectUsedClasses(node.attributes, usedClasses);
+      },
+
+      async HtmlVoidElement(node: HtmlVoidElement) {
+        collectUsedClasses(node.attributes, usedClasses);
+      },
+
+      async HtmlSelfClosingElement(node: HtmlSelfClosingElement) {
+        collectUsedClasses(node.attributes, usedClasses);
+      },
+
+      async HtmlRawNode(node: HtmlRawNode) {
+        if (node.name === 'svg') {
+          collectUsedClassesFromSvg(
+            node.attributes,
+            node.body.value,
+            node.body.position.start,
+            usedClasses,
+          );
+        }
+      },
+
+      async onCodePathEnd() {
+        if (usedClasses.length === 0) return;
+
+        const { getReferences, getDependencies, getCSSClassesForURI, fs, toUri } = context;
+        if (!getReferences || !getDependencies || !getCSSClassesForURI) return;
+
+        // Start with local CSS classes
+        const inScopeClasses = new Set(localCSSClasses);
+
+        // 1. Extract CSS classes from all .css files in the assets folder
+        const assetClasses = await getAssetCSSClasses(fs, toUri, getCSSClassesForURI);
+        for (const cls of assetClasses) {
+          inScopeClasses.add(cls);
+        }
+
+        // 2. Get all ancestors (following direct references upward)
+        const ancestors = await getAncestorUris(context.file.uri, getReferences);
+
+        // 3. Extract CSS classes from ancestor stylesheet tags
+        const ancestorClassResults = await Promise.all(
+          ancestors.map((uri) => getCSSClassesForURI(uri)),
+        );
+        for (const classes of ancestorClassResults) {
+          for (const cls of classes) inScopeClasses.add(cls);
+        }
+
+        // 4. Collect rendered snippets from this file and all ancestors
+        const filesToCheck = [context.file.uri, ...ancestors];
+        const allRenderedSnippetUris: string[] = [];
+        for (const fileUri of filesToCheck) {
+          const snippetUris = await getRenderedSnippetUris(fileUri, getDependencies);
+          allRenderedSnippetUris.push(...snippetUris);
+        }
+
+        // 5. BFS through snippet descendants to find all reachable snippets
+        const allSnippetUris = await getAllSnippetDescendantUris(
+          allRenderedSnippetUris,
+          getDependencies,
+        );
+
+        // 6. Extract CSS classes from all reachable snippet stylesheet tags
+        const snippetClassResults = await Promise.all(
+          allSnippetUris.map((uri) => getCSSClassesForURI(uri)),
+        );
+        for (const classes of snippetClassResults) {
+          for (const cls of classes) inScopeClasses.add(cls);
+        }
+
+        // 7. Collect ALL CSS classes defined anywhere in the theme
+        const allThemeClasses = await getAllThemeCSSClasses(fs, toUri, getCSSClassesForURI);
+
+        // 8. Only report classes that ARE defined somewhere in the theme but not in scope.
+        //    Classes not defined anywhere (e.g. from CDNs, utility frameworks) are silently ignored.
+        for (const { className, startIndex, endIndex } of usedClasses) {
+          if (allThemeClasses.has(className) && !inScopeClasses.has(className)) {
+            context.report({
+              message: `CSS class '${className}' may be defined outside the scope of this file.`,
+              startIndex,
+              endIndex,
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/index.ts
+++ b/packages/theme-check-common/src/index.ts
@@ -56,6 +56,8 @@ export * from './utils/indexBy';
 export * from './utils/memo';
 export * from './utils/types';
 export * from './utils/object';
+export * from './utils/styles';
+export * from './utils/traversal';
 export * from './visitor';
 export * from './liquid-doc/liquidDoc';
 export { getBlockName } from './liquid-doc/arguments';

--- a/packages/theme-check-common/src/test/test-helper.ts
+++ b/packages/theme-check-common/src/test/test-helper.ts
@@ -8,6 +8,8 @@ import {
   check as coreCheck,
   createCorrector,
   Dependencies,
+  extractCSSClassesFromAssetUri,
+  extractCSSClassesFromLiquidUri,
   extractDocDefinition,
   FixApplicator,
   isBlock,
@@ -98,6 +100,13 @@ export async function check(
         return undefined;
       }
       return extractDocDefinition(file.uri, file.ast);
+    },
+    async getCSSClassesForURI(uri) {
+      const mockFs = new MockFileSystem({ '.theme-check.yml': '', ...themeDesc });
+      if (uri.endsWith('.css')) {
+        return extractCSSClassesFromAssetUri(uri, mockFs);
+      }
+      return extractCSSClassesFromLiquidUri(uri, mockFs);
     },
     themeDocset: {
       async filters() {

--- a/packages/theme-check-common/src/types.ts
+++ b/packages/theme-check-common/src/types.ts
@@ -388,10 +388,24 @@ export interface Dependencies {
   getDocDefinition?: (relativePath: string) => Promise<DocDefinition | undefined>;
 
   /**
+   * Get CSS class names defined in a file.
+   * For .css asset files, returns all class selectors in the file.
+   * For .liquid files, extracts class selectors from {% stylesheet %} tags.
+   * Returns undefined when unavailable.
+   */
+  getCSSClassesForURI?: (uri: string) => Promise<Set<string>>;
+
+  /**
    * Get references to a file (which files reference this file)
    * Returns an empty array if no files reference this file
    */
   getReferences?: (uri: string) => Promise<Reference[]>;
+
+  /**
+   * Get dependencies of a file (which files this file references/renders)
+   * Returns an empty array if no dependencies found
+   */
+  getDependencies?: (uri: string) => Promise<Reference[]>;
 }
 
 export type ValidateJSON = (

--- a/packages/theme-check-common/src/utils/index.ts
+++ b/packages/theme-check-common/src/utils/index.ts
@@ -6,3 +6,5 @@ export * from './types';
 export * from './memo';
 export * from './indexBy';
 export * from './block';
+export * from './styles';
+export * from './traversal';

--- a/packages/theme-check-common/src/utils/styles.spec.ts
+++ b/packages/theme-check-common/src/utils/styles.spec.ts
@@ -1,0 +1,312 @@
+import { expect, describe, it } from 'vitest';
+import { toLiquidHtmlAST, NodeTypes } from '@shopify/liquid-html-parser';
+import {
+  extractCSSClassNames,
+  extractCSSClassesFromLiquidUri,
+  extractCSSClassesFromAssetUri,
+  extractCSSClassesFromAssets,
+  extractAllThemeCSSClasses,
+  collectUsedClasses,
+  collectUsedClassesFromSvg,
+} from './styles';
+import { MockFileSystem } from '../test/MockFileSystem';
+
+describe('extractCSSClassNames', () => {
+  it('extracts simple class selectors', () => {
+    const classes = extractCSSClassNames('.my-class { color: red; }');
+    expect(classes).toEqual(new Set(['my-class']));
+  });
+
+  it('extracts multiple classes from a single rule', () => {
+    const classes = extractCSSClassNames('.a .b { color: red; }');
+    expect(classes).toEqual(new Set(['a', 'b']));
+  });
+
+  it('extracts classes from comma-separated selectors', () => {
+    const classes = extractCSSClassNames('.a, .b { color: red; }');
+    expect(classes).toEqual(new Set(['a', 'b']));
+  });
+
+  it('extracts classes from complex selectors', () => {
+    const classes = extractCSSClassNames('.parent > .child + .sibling ~ .cousin { color: red; }');
+    expect(classes).toEqual(new Set(['parent', 'child', 'sibling', 'cousin']));
+  });
+
+  it('extracts classes from pseudo-class selectors', () => {
+    const classes = extractCSSClassNames(
+      '.btn:hover { color: red; } .link::before { content: ""; }',
+    );
+    expect(classes).toEqual(new Set(['btn', 'link']));
+  });
+
+  it('extracts classes inside media queries', () => {
+    const classes = extractCSSClassNames(
+      '@media (min-width: 768px) { .responsive { display: block; } }',
+    );
+    expect(classes).toEqual(new Set(['responsive']));
+  });
+
+  it('ignores classes inside CSS comments', () => {
+    const classes = extractCSSClassNames(
+      '/* .commented-out { color: red; } */ .real { color: blue; }',
+    );
+    expect(classes).toEqual(new Set(['real']));
+  });
+
+  it('returns empty set for invalid CSS', () => {
+    const classes = extractCSSClassNames('this is {{ not }} valid css {{{');
+    expect(classes.size).toBe(0);
+  });
+
+  it('returns empty set for empty string', () => {
+    const classes = extractCSSClassNames('');
+    expect(classes.size).toBe(0);
+  });
+
+  it('handles classes with hyphens and underscores', () => {
+    const classes = extractCSSClassNames(
+      '.my-class_name { color: red; } ._private { color: blue; }',
+    );
+    expect(classes).toEqual(new Set(['my-class_name', '_private']));
+  });
+
+  it('handles compound class selectors', () => {
+    const classes = extractCSSClassNames('.a.b { color: red; }');
+    expect(classes).toEqual(new Set(['a', 'b']));
+  });
+});
+
+describe('collectUsedClasses', () => {
+  function parseAttributes(html: string) {
+    const ast = toLiquidHtmlAST(html);
+    if (ast instanceof Error) throw ast;
+    const node = ast.children[0];
+    if (!('attributes' in node)) throw new Error('Expected HTML element');
+    return node.attributes;
+  }
+
+  it('extracts class names from a simple class attribute', () => {
+    const attrs = parseAttributes('<div class="a b c"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns empty for elements without class attribute', () => {
+    const attrs = parseAttributes('<div id="test"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses).toHaveLength(0);
+  });
+
+  it('returns empty for empty class attribute', () => {
+    const attrs = parseAttributes('<div class=""></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses).toHaveLength(0);
+  });
+
+  it('skips dynamic Liquid values', () => {
+    const attrs = parseAttributes('<div class="static {{ dynamic }}"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['static']);
+  });
+
+  it('tracks correct start and end positions', () => {
+    const html = '<div class="foo bar"></div>';
+    const attrs = parseAttributes(html);
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(html.slice(usedClasses[0].startIndex, usedClasses[0].endIndex)).toBe('foo');
+    expect(html.slice(usedClasses[1].startIndex, usedClasses[1].endIndex)).toBe('bar');
+  });
+
+  it('discards partial token glued to a following Liquid node', () => {
+    const attrs = parseAttributes('<div class="btn-{{ size }} active"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['active']);
+  });
+
+  it('discards partial token glued to a preceding Liquid node', () => {
+    const attrs = parseAttributes('<div class="{{ prefix }}-suffix active"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['active']);
+  });
+
+  it('discards tokens on both sides when sandwiched between Liquid nodes', () => {
+    const attrs = parseAttributes('<div class="prefix{{ a }}middle{{ b }}suffix other"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['other']);
+  });
+
+  it('keeps tokens separated from Liquid nodes by whitespace', () => {
+    const attrs = parseAttributes('<div class="static {{ dynamic }} also-static"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['static', 'also-static']);
+  });
+
+  it('keeps tokens separated from Liquid nodes by tabs or other whitespace', () => {
+    const attrs = parseAttributes('<div class="btn-{{ size }}\tstatic"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['static']);
+  });
+
+  it('keeps all tokens when there are no Liquid nodes', () => {
+    const attrs = parseAttributes('<div class="a b c"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles fully dynamic class attribute', () => {
+    const attrs = parseAttributes('<div class="{{ dynamic }}"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses).toHaveLength(0);
+  });
+
+  it('matches CLASS (uppercase) attribute', () => {
+    const attrs = parseAttributes('<div CLASS="a b"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['a', 'b']);
+  });
+
+  it('matches Class (mixed case) attribute', () => {
+    const attrs = parseAttributes('<div Class="x y z"></div>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClasses(attrs, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['x', 'y', 'z']);
+  });
+});
+
+describe('collectUsedClassesFromSvg', () => {
+  function parseSvg(html: string) {
+    const ast = toLiquidHtmlAST(html);
+    if (ast instanceof Error) throw ast;
+    const node = ast.children[0] as any;
+    return {
+      attributes: node.attributes,
+      bodyValue: node.body.value,
+      bodyStart: node.body.position.start,
+    };
+  }
+
+  it('extracts classes from the svg tag itself', () => {
+    const { attributes, bodyValue, bodyStart } = parseSvg('<svg class="icon"></svg>');
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClassesFromSvg(attributes, bodyValue, bodyStart, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['icon']);
+  });
+
+  it('extracts classes from inner SVG elements', () => {
+    const html =
+      '<svg class="a"><rect class="b" /><g class="c"></g><circle class="d" /><path class="e" /></svg>';
+    const { attributes, bodyValue, bodyStart } = parseSvg(html);
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClassesFromSvg(attributes, bodyValue, bodyStart, usedClasses);
+    expect(usedClasses.map((c) => c.className)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('maps inner element positions correctly back to the original source', () => {
+    const html = '<svg><rect class="inner" /></svg>';
+    const { attributes, bodyValue, bodyStart } = parseSvg(html);
+    const usedClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    collectUsedClassesFromSvg(attributes, bodyValue, bodyStart, usedClasses);
+    expect(usedClasses).toHaveLength(1);
+    expect(html.slice(usedClasses[0].startIndex, usedClasses[0].endIndex)).toBe('inner');
+  });
+});
+
+describe('extractCSSClassesFromLiquidUri', () => {
+  it('extracts classes from stylesheet tags in a liquid file', async () => {
+    const fs = new MockFileSystem({
+      'snippets/styles.liquid': `
+        {% stylesheet %}
+          .snippet-class { color: red; }
+          .another { color: blue; }
+        {% endstylesheet %}
+      `,
+    });
+    const classes = await extractCSSClassesFromLiquidUri('file:///snippets/styles.liquid', fs);
+    expect(classes).toEqual(new Set(['snippet-class', 'another']));
+  });
+
+  it('returns empty set for file without stylesheet tags', async () => {
+    const fs = new MockFileSystem({
+      'snippets/plain.liquid': '<div>Hello</div>',
+    });
+    const classes = await extractCSSClassesFromLiquidUri('file:///snippets/plain.liquid', fs);
+    expect(classes.size).toBe(0);
+  });
+
+  it('returns empty set for missing file', async () => {
+    const fs = new MockFileSystem({});
+    const classes = await extractCSSClassesFromLiquidUri('file:///missing.liquid', fs);
+    expect(classes.size).toBe(0);
+  });
+});
+
+describe('extractCSSClassesFromAssetUri', () => {
+  it('extracts classes from a CSS file', async () => {
+    const fs = new MockFileSystem({
+      'assets/theme.css': '.asset-class { color: red; } .other { color: blue; }',
+    });
+    const classes = await extractCSSClassesFromAssetUri('file:///assets/theme.css', fs);
+    expect(classes).toEqual(new Set(['asset-class', 'other']));
+  });
+
+  it('returns empty set for missing file', async () => {
+    const fs = new MockFileSystem({});
+    const classes = await extractCSSClassesFromAssetUri('file:///missing.css', fs);
+    expect(classes.size).toBe(0);
+  });
+});
+
+describe('extractCSSClassesFromAssets', () => {
+  it('collects classes from all .css files in assets', async () => {
+    const fs = new MockFileSystem({
+      'assets/base.css': '.base { color: red; }',
+      'assets/theme.css': '.theme { color: blue; }',
+      'assets/app.js': 'console.log("not css")',
+    });
+    const toUri = (rel: string) => `file:///${rel}`;
+    const classes = await extractCSSClassesFromAssets(fs, toUri);
+    expect(classes).toEqual(new Set(['base', 'theme']));
+  });
+
+  it('returns empty set when assets directory does not exist', async () => {
+    const fs = new MockFileSystem({});
+    const toUri = (rel: string) => `file:///${rel}`;
+    const classes = await extractCSSClassesFromAssets(fs, toUri);
+    expect(classes.size).toBe(0);
+  });
+});
+
+describe('extractAllThemeCSSClasses', () => {
+  it('collects classes from both liquid stylesheets and CSS assets', async () => {
+    const fs = new MockFileSystem({
+      'assets/theme.css': '.asset-class { color: red; }',
+      'sections/section.liquid':
+        '{% stylesheet %} .section-class { color: blue; } {% endstylesheet %}',
+      'snippets/snippet.liquid':
+        '{% stylesheet %} .snippet-class { font-size: 14px; } {% endstylesheet %}',
+    });
+    const toUri = (rel: string) => `file:///${rel}`;
+    const classes = await extractAllThemeCSSClasses(fs, toUri);
+    expect(classes).toEqual(new Set(['asset-class', 'section-class', 'snippet-class']));
+  });
+
+  it('returns empty set for empty theme', async () => {
+    const fs = new MockFileSystem({});
+    const toUri = (rel: string) => `file:///${rel}`;
+    const classes = await extractAllThemeCSSClasses(fs, toUri);
+    expect(classes.size).toBe(0);
+  });
+});

--- a/packages/theme-check-common/src/utils/styles.ts
+++ b/packages/theme-check-common/src/utils/styles.ts
@@ -1,0 +1,238 @@
+import {
+  NodeTypes,
+  TextNode,
+  LiquidRawTag,
+  toLiquidHtmlAST,
+  AttributeNode,
+} from '@shopify/liquid-html-parser';
+import safeParse from 'postcss-safe-parser';
+import selectorParser from 'postcss-selector-parser';
+import { SourceCodeType } from '../types';
+import { AbstractFileSystem } from '../AbstractFileSystem';
+import { recursiveReadDirectory } from '../context-utils';
+import { isValuedHtmlAttribute, ValuedHtmlAttribute } from '../checks/utils';
+import { visit } from '../visitor';
+
+export function extractCSSClassNames(css: string): Set<string> {
+  const classNames = new Set<string>();
+
+  const root = safeParse(css);
+  root.walkRules((rule: { selector: string }) => {
+    try {
+      const parsed = selectorParser().astSync(rule.selector);
+      parsed.walk((node) => {
+        if (node.type === 'class') {
+          classNames.add(node.value);
+        }
+      });
+    } catch {
+      // If a selector fails to parse, skip it
+    }
+  });
+
+  return classNames;
+}
+
+/** Read a Liquid file and extract CSS class names from its {% stylesheet %} tags. */
+export async function extractCSSClassesFromLiquidUri(
+  uri: string,
+  fs: AbstractFileSystem,
+): Promise<Set<string>> {
+  const classes = new Set<string>();
+  try {
+    const source = await fs.readFile(uri);
+    const ast = toLiquidHtmlAST(source);
+    if (ast instanceof Error) return classes;
+    const cssStrings = visit<SourceCodeType.LiquidHtml, string>(ast, {
+      LiquidRawTag(node: LiquidRawTag) {
+        if (node.name === 'stylesheet') {
+          return node.body.value;
+        }
+      },
+    });
+    for (const css of cssStrings) {
+      for (const cls of extractCSSClassNames(css)) {
+        classes.add(cls);
+      }
+    }
+  } catch {
+    // File not found or parse error — skip
+  }
+  return classes;
+}
+
+/** Read a CSS asset file and extract class names from it. */
+export async function extractCSSClassesFromAssetUri(
+  uri: string,
+  fs: AbstractFileSystem,
+): Promise<Set<string>> {
+  try {
+    const source = await fs.readFile(uri);
+    return extractCSSClassNames(source);
+  } catch {
+    return new Set();
+  }
+}
+
+/** Collect all CSS class names from all .css files in the assets directory. */
+export async function extractCSSClassesFromAssets(
+  fs: AbstractFileSystem,
+  toUri: (relativePath: string) => string,
+): Promise<Set<string>> {
+  const classes = new Set<string>();
+  try {
+    const assetsUri = toUri('assets');
+    const files = await fs.readDirectory(assetsUri);
+    const cssFiles = files.filter(([uri]) => uri.endsWith('.css'));
+    const results = await Promise.all(
+      cssFiles.map(([uri]) => extractCSSClassesFromAssetUri(uri, fs)),
+    );
+    for (const fileClasses of results) {
+      for (const cls of fileClasses) {
+        classes.add(cls);
+      }
+    }
+  } catch {
+    // assets directory might not exist
+  }
+  return classes;
+}
+
+/** Collect ALL CSS classes defined anywhere in the theme (all liquid stylesheet tags + CSS assets). */
+export async function extractAllThemeCSSClasses(
+  fs: AbstractFileSystem,
+  toUri: (relativePath: string) => string,
+): Promise<Set<string>> {
+  const allClasses = new Set<string>();
+
+  // Collect from CSS asset files
+  const assetClasses = await extractCSSClassesFromAssets(fs, toUri);
+  for (const cls of assetClasses) allClasses.add(cls);
+
+  // Collect from all liquid files' stylesheet tags
+  try {
+    const rootUri = toUri('');
+    const liquidFiles = await recursiveReadDirectory(fs, rootUri, ([uri]) =>
+      uri.endsWith('.liquid'),
+    );
+    const results = await Promise.all(
+      liquidFiles.map((uri) => extractCSSClassesFromLiquidUri(uri, fs)),
+    );
+    for (const classes of results) {
+      for (const cls of classes) allClasses.add(cls);
+    }
+  } catch {
+    // root directory read failure
+  }
+
+  return allClasses;
+}
+
+/** Case-insensitive check for the `class` attribute (HTML attributes are case-insensitive). */
+function isClassAttribute(attr: ValuedHtmlAttribute): boolean {
+  return (
+    attr.name.length === 1 &&
+    attr.name[0].type === NodeTypes.TextNode &&
+    attr.name[0].value.toLowerCase() === 'class'
+  );
+}
+
+/**
+ * Extract used class names from an HTML element's class attribute.
+ *
+ * Tokens adjacent to Liquid nodes are discarded because they are fragments
+ * of a dynamic class, not standalone static classes.
+ * e.g. `class="btn-{{ size }} active"` → only `active` is collected,
+ *      `btn-` is discarded because it's glued to `{{ size }}`.
+ */
+export function collectUsedClasses(
+  attributes: AttributeNode[],
+  usedClasses: { className: string; startIndex: number; endIndex: number }[],
+): void {
+  for (const attr of attributes) {
+    if (!isValuedHtmlAttribute(attr) || !isClassAttribute(attr)) continue;
+
+    const valueNodes = attr.value;
+    for (let i = 0; i < valueNodes.length; i++) {
+      const valueNode = valueNodes[i];
+      if (valueNode.type !== NodeTypes.TextNode) continue;
+
+      const textNode = valueNode as TextNode;
+      const value = textNode.value;
+      const baseOffset = textNode.position.start;
+
+      const prevIsLiquid = i > 0 && valueNodes[i - 1].type !== NodeTypes.TextNode;
+      const nextIsLiquid =
+        i < valueNodes.length - 1 && valueNodes[i + 1].type !== NodeTypes.TextNode;
+
+      const tokens: { className: string; startIndex: number; endIndex: number }[] = [];
+      const regex = /\S+/g;
+      let match;
+      while ((match = regex.exec(value)) !== null) {
+        tokens.push({
+          className: match[0],
+          startIndex: baseOffset + match.index,
+          endIndex: baseOffset + match.index + match[0].length,
+        });
+      }
+
+      if (tokens.length === 0) continue;
+
+      // Drop first token if it touches the preceding Liquid node (no leading whitespace)
+      if (prevIsLiquid && !/^\s/.test(value)) {
+        tokens.shift();
+      }
+
+      // Drop last token if it touches the following Liquid node (no trailing whitespace)
+      if (nextIsLiquid && !/\s$/.test(value)) {
+        tokens.pop();
+      }
+
+      usedClasses.push(...tokens);
+    }
+  }
+}
+
+/**
+ * Extract used class names from an SVG element (HtmlRawNode with name "svg").
+ * Collects classes from the SVG tag's own attributes, then re-parses the body
+ * to extract classes from inner elements (rect, g, circle, path, etc.).
+ */
+export function collectUsedClassesFromSvg(
+  attributes: AttributeNode[],
+  bodyValue: string,
+  bodyStartOffset: number,
+  usedClasses: { className: string; startIndex: number; endIndex: number }[],
+): void {
+  // Collect classes from the <svg> tag's own attributes
+  collectUsedClasses(attributes, usedClasses);
+
+  // Re-parse the SVG body to extract classes from inner elements
+  try {
+    const innerAst = toLiquidHtmlAST(bodyValue);
+    if (innerAst instanceof Error) return;
+    const innerClasses: { className: string; startIndex: number; endIndex: number }[] = [];
+    const visitor = {
+      HtmlElement(node: { attributes: AttributeNode[] }) {
+        collectUsedClasses(node.attributes, innerClasses);
+      },
+      HtmlVoidElement(node: { attributes: AttributeNode[] }) {
+        collectUsedClasses(node.attributes, innerClasses);
+      },
+      HtmlSelfClosingElement(node: { attributes: AttributeNode[] }) {
+        collectUsedClasses(node.attributes, innerClasses);
+      },
+    };
+    visit<SourceCodeType.LiquidHtml, void>(innerAst, visitor);
+    // Adjust positions from body-relative to file-relative
+    for (const cls of innerClasses) {
+      usedClasses.push({
+        className: cls.className,
+        startIndex: cls.startIndex + bodyStartOffset,
+        endIndex: cls.endIndex + bodyStartOffset,
+      });
+    }
+  } catch {
+    // If body can't be parsed, skip inner elements
+  }
+}

--- a/packages/theme-check-common/src/utils/traversal.spec.ts
+++ b/packages/theme-check-common/src/utils/traversal.spec.ts
@@ -1,0 +1,198 @@
+import { expect, describe, it } from 'vitest';
+import { Reference } from '../types';
+import { getAncestorUris, getAllSnippetDescendantUris, getRenderedSnippetUris } from './traversal';
+
+function ref(
+  sourceUri: string,
+  targetUri: string,
+  type: 'direct' | 'indirect' | 'preset' = 'direct',
+): Reference {
+  return { source: { uri: sourceUri }, target: { uri: targetUri }, type };
+}
+
+describe('getAncestorUris', () => {
+  it('returns direct ancestors', async () => {
+    const getReferences = async (uri: string) => {
+      if (uri === 'file:///snippets/child.liquid') {
+        return [ref('file:///sections/parent.liquid', 'file:///snippets/child.liquid')];
+      }
+      return [];
+    };
+
+    const ancestors = await getAncestorUris('file:///snippets/child.liquid', getReferences);
+    expect(ancestors).toEqual(['file:///sections/parent.liquid']);
+  });
+
+  it('follows grandparent chain', async () => {
+    const getReferences = async (uri: string) => {
+      if (uri === 'file:///snippets/child.liquid') {
+        return [ref('file:///sections/section.liquid', 'file:///snippets/child.liquid')];
+      }
+      if (uri === 'file:///sections/section.liquid') {
+        return [ref('file:///layout/theme.liquid', 'file:///sections/section.liquid')];
+      }
+      return [];
+    };
+
+    const ancestors = await getAncestorUris('file:///snippets/child.liquid', getReferences);
+    expect(ancestors).toEqual(['file:///sections/section.liquid', 'file:///layout/theme.liquid']);
+  });
+
+  it('ignores indirect references', async () => {
+    const getReferences = async (uri: string) => {
+      if (uri === 'file:///snippets/child.liquid') {
+        return [
+          ref('file:///sections/section.liquid', 'file:///snippets/child.liquid', 'indirect'),
+        ];
+      }
+      return [];
+    };
+
+    const ancestors = await getAncestorUris('file:///snippets/child.liquid', getReferences);
+    expect(ancestors).toEqual([]);
+  });
+
+  it('ignores preset references', async () => {
+    const getReferences = async (uri: string) => {
+      if (uri === 'file:///snippets/child.liquid') {
+        return [ref('file:///sections/section.liquid', 'file:///snippets/child.liquid', 'preset')];
+      }
+      return [];
+    };
+
+    const ancestors = await getAncestorUris('file:///snippets/child.liquid', getReferences);
+    expect(ancestors).toEqual([]);
+  });
+
+  it('handles cycles without infinite loop', async () => {
+    const getReferences = async (uri: string) => {
+      if (uri === 'file:///a.liquid') return [ref('file:///b.liquid', 'file:///a.liquid')];
+      if (uri === 'file:///b.liquid') return [ref('file:///a.liquid', 'file:///b.liquid')];
+      return [];
+    };
+
+    const ancestors = await getAncestorUris('file:///a.liquid', getReferences);
+    expect(ancestors).toEqual(['file:///b.liquid']);
+  });
+
+  it('returns empty for file with no references', async () => {
+    const ancestors = await getAncestorUris('file:///orphan.liquid', async () => []);
+    expect(ancestors).toEqual([]);
+  });
+});
+
+describe('getAllSnippetDescendantUris', () => {
+  it('returns the initial snippets themselves', async () => {
+    const result = await getAllSnippetDescendantUris(['file:///snippets/a.liquid'], async () => []);
+    expect(result).toEqual(['file:///snippets/a.liquid']);
+  });
+
+  it('follows snippet dependencies recursively', async () => {
+    const getDependencies = async (uri: string) => {
+      if (uri === 'file:///snippets/a.liquid') {
+        return [ref('file:///snippets/a.liquid', 'file:///snippets/b.liquid')];
+      }
+      if (uri === 'file:///snippets/b.liquid') {
+        return [ref('file:///snippets/b.liquid', 'file:///snippets/c.liquid')];
+      }
+      return [];
+    };
+
+    const result = await getAllSnippetDescendantUris(
+      ['file:///snippets/a.liquid'],
+      getDependencies,
+    );
+    expect(result).toEqual([
+      'file:///snippets/a.liquid',
+      'file:///snippets/b.liquid',
+      'file:///snippets/c.liquid',
+    ]);
+  });
+
+  it('skips non-snippet dependencies', async () => {
+    const getDependencies = async (uri: string) => {
+      if (uri === 'file:///snippets/a.liquid') {
+        return [
+          ref('file:///snippets/a.liquid', 'file:///snippets/b.liquid'),
+          ref('file:///snippets/a.liquid', 'file:///sections/not-a-snippet.liquid'),
+        ];
+      }
+      return [];
+    };
+
+    const result = await getAllSnippetDescendantUris(
+      ['file:///snippets/a.liquid'],
+      getDependencies,
+    );
+    expect(result).toEqual(['file:///snippets/a.liquid', 'file:///snippets/b.liquid']);
+  });
+
+  it('skips indirect dependencies', async () => {
+    const getDependencies = async (uri: string) => {
+      if (uri === 'file:///snippets/a.liquid') {
+        return [ref('file:///snippets/a.liquid', 'file:///snippets/b.liquid', 'indirect')];
+      }
+      return [];
+    };
+
+    const result = await getAllSnippetDescendantUris(
+      ['file:///snippets/a.liquid'],
+      getDependencies,
+    );
+    expect(result).toEqual(['file:///snippets/a.liquid']);
+  });
+
+  it('handles cycles without infinite loop', async () => {
+    const getDependencies = async (uri: string) => {
+      if (uri === 'file:///snippets/a.liquid') {
+        return [ref('file:///snippets/a.liquid', 'file:///snippets/b.liquid')];
+      }
+      if (uri === 'file:///snippets/b.liquid') {
+        return [ref('file:///snippets/b.liquid', 'file:///snippets/a.liquid')];
+      }
+      return [];
+    };
+
+    const result = await getAllSnippetDescendantUris(
+      ['file:///snippets/a.liquid'],
+      getDependencies,
+    );
+    expect(result).toEqual(['file:///snippets/a.liquid', 'file:///snippets/b.liquid']);
+  });
+});
+
+describe('getRenderedSnippetUris', () => {
+  it('returns direct snippet dependencies', async () => {
+    const getDependencies = async () => [
+      ref('file:///sections/section.liquid', 'file:///snippets/a.liquid'),
+      ref('file:///sections/section.liquid', 'file:///snippets/b.liquid'),
+    ];
+
+    const result = await getRenderedSnippetUris('file:///sections/section.liquid', getDependencies);
+    expect(result).toEqual(['file:///snippets/a.liquid', 'file:///snippets/b.liquid']);
+  });
+
+  it('excludes non-snippet dependencies', async () => {
+    const getDependencies = async () => [
+      ref('file:///sections/section.liquid', 'file:///snippets/a.liquid'),
+      ref('file:///sections/section.liquid', 'file:///sections/other.liquid'),
+    ];
+
+    const result = await getRenderedSnippetUris('file:///sections/section.liquid', getDependencies);
+    expect(result).toEqual(['file:///snippets/a.liquid']);
+  });
+
+  it('excludes indirect snippet dependencies', async () => {
+    const getDependencies = async () => [
+      ref('file:///sections/section.liquid', 'file:///snippets/a.liquid', 'indirect'),
+    ];
+
+    const result = await getRenderedSnippetUris('file:///sections/section.liquid', getDependencies);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty when no dependencies', async () => {
+    const result = await getRenderedSnippetUris('file:///sections/section.liquid', async () => []);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/theme-check-common/src/utils/traversal.ts
+++ b/packages/theme-check-common/src/utils/traversal.ts
@@ -1,0 +1,70 @@
+import { Reference } from '../types';
+import { isSnippet } from '../to-schema';
+
+/** BFS upward through direct references to find all ancestor URIs. */
+export async function getAncestorUris(
+  uri: string,
+  getReferences: (uri: string) => Promise<Reference[]>,
+): Promise<string[]> {
+  const ancestors: string[] = [];
+  const visited = new Set<string>();
+  const queue = [uri];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    const refs = await getReferences(current);
+    for (const ref of refs) {
+      if (ref.type === 'direct' && !visited.has(ref.source.uri)) {
+        ancestors.push(ref.source.uri);
+        queue.push(ref.source.uri);
+      }
+    }
+  }
+
+  return ancestors;
+}
+
+/**
+ * BFS through direct dependencies to find all snippet descendant URIs
+ * (including the initial snippet URIs themselves).
+ */
+export async function getAllSnippetDescendantUris(
+  initialUris: string[],
+  getDependencies: (uri: string) => Promise<Reference[]>,
+): Promise<string[]> {
+  const result: string[] = [];
+  const visited = new Set<string>();
+  const queue = [...initialUris];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    result.push(current);
+
+    const deps = await getDependencies(current);
+    for (const dep of deps) {
+      if (dep.type === 'direct' && isSnippet(dep.target.uri) && !visited.has(dep.target.uri)) {
+        queue.push(dep.target.uri);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get all direct snippet dependency URIs from a file.
+ */
+export async function getRenderedSnippetUris(
+  uri: string,
+  getDependencies: (uri: string) => Promise<Reference[]>,
+): Promise<string[]> {
+  const deps = await getDependencies(uri);
+  return deps
+    .filter((dep) => dep.type === 'direct' && isSnippet(dep.target.uri))
+    .map((dep) => dep.target.uri);
+}

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -196,6 +196,9 @@ ValidSchemaName:
 ValidSchemaTranslations:
   enabled: true
   severity: 0
+ValidScopedCSSClass:
+  enabled: true
+  severity: 1
 ValidSettingsKey:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -174,6 +174,9 @@ ValidSchemaName:
 ValidSchemaTranslations:
   enabled: true
   severity: 0
+ValidScopedCSSClass:
+  enabled: true
+  severity: 1
 ValidSettingsKey:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/package.json
+++ b/packages/theme-check-node/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@shopify/theme-check-common": "3.24.0",
     "@shopify/theme-check-docs-updater": "3.24.0",
+    "@shopify/theme-graph": "^0.2.3",
     "glob": "^8.0.3",
     "vscode-uri": "^3.0.7",
     "yaml": "^2.8.3"

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -5,11 +5,14 @@ import {
   JSONValidator,
   LiquidSourceCode,
   Offense,
+  Reference,
   SectionSchema,
   Theme,
   ThemeBlockSchema,
   toSourceCode as commonToSourceCode,
   check as coreCheck,
+  extractCSSClassesFromAssetUri,
+  extractCSSClassesFromLiquidUri,
   extractDocDefinition,
   filePathSupportsLiquidDoc,
   isBlock,
@@ -19,6 +22,7 @@ import {
   path as pathUtils,
   toSchema,
 } from '@shopify/theme-check-common';
+import { buildThemeGraph, ThemeGraph } from '@shopify/theme-graph';
 import { ThemeLiquidDocsManager } from '@shopify/theme-check-docs-updater';
 import { isLiquidHtmlNode } from '@shopify/liquid-html-parser';
 import fs from 'node:fs/promises';
@@ -134,6 +138,43 @@ export async function themeCheckRun(
       }),
     ]),
   );
+  const cssClassesForURI = new Map<string, () => Promise<Set<string>>>(
+    theme
+      .filter((source) => source.uri.endsWith('.liquid'))
+      .map((source) => [
+        source.uri,
+        memo(async () => extractCSSClassesFromLiquidUri(source.uri, NodeFileSystem)),
+      ]),
+  );
+  // Also include CSS asset files
+  try {
+    const assetsUri = pathUtils.join(config.rootUri, 'assets');
+    const files = await NodeFileSystem.readDirectory(assetsUri);
+    for (const [uri] of files.filter(([u]) => u.endsWith('.css'))) {
+      cssClassesForURI.set(
+        uri,
+        memo(async () => extractCSSClassesFromAssetUri(uri, NodeFileSystem)),
+      );
+    }
+  } catch {
+    // assets directory might not exist
+  }
+
+  // Build theme graph for cross-file checks (e.g. ValidScopedCSSClass)
+  const getSectionSchema = async (name: string) => sectionSchemas.get(name)?.();
+  const getBlockSchema = async (name: string) => blockSchemas.get(name)?.();
+
+  let themeGraph: ThemeGraph | undefined;
+  try {
+    themeGraph = await buildThemeGraph(config.rootUri, {
+      fs: NodeFileSystem,
+      getSectionSchema,
+      getBlockSchema,
+      getWebComponentDefinitionReference: () => undefined,
+    });
+  } catch {
+    // If graph building fails, cross-file checks will gracefully degrade
+  }
 
   const offenses = await coreCheck(theme, config, {
     fs: NodeFileSystem,
@@ -143,10 +184,23 @@ export async function themeCheckRun(
     // This is kind of gross, but we want those things to be lazy and called by name so...
     // In the language server, this is memo'ed in DocumentManager, but we don't have that kind
     // of luxury in CLI-mode.
-    getSectionSchema: async (name) => sectionSchemas.get(name)?.(),
-    getBlockSchema: async (name) => blockSchemas.get(name)?.(),
+    getSectionSchema,
+    getBlockSchema,
     getAppBlockSchema: async (name) => blockSchemas.get(name)?.() as any, // cheating... but TODO
     getDocDefinition: async (relativePath) => docDefinitions.get(relativePath)?.(),
+    getCSSClassesForURI: async (uri: string) => cssClassesForURI.get(uri)?.() ?? new Set(),
+
+    async getReferences(uri: string): Promise<Reference[]> {
+      if (!themeGraph) return [];
+      const mod = themeGraph.modules[uri];
+      return mod?.references ?? [];
+    },
+
+    async getDependencies(uri: string): Promise<Reference[]> {
+      if (!themeGraph) return [];
+      const mod = themeGraph.modules[uri];
+      return mod?.dependencies ?? [];
+    },
   });
 
   return {

--- a/packages/theme-check-node/tsconfig.build.json
+++ b/packages/theme-check-node/tsconfig.build.json
@@ -3,6 +3,7 @@
   "exclude": ["**/*.spec.ts"],
   "references": [
     { "path": "../theme-check-common/tsconfig.build.json" },
-    { "path": "../theme-check-docs-updater/tsconfig.build.json" }
+    { "path": "../theme-check-docs-updater/tsconfig.build.json" },
+    { "path": "../theme-graph/tsconfig.build.json" }
   ]
 }

--- a/packages/theme-graph/bin/theme-graph
+++ b/packages/theme-graph/bin/theme-graph
@@ -2,12 +2,13 @@
 
 const { buildThemeGraph, serializeThemeGraph, toSourceCode } = require('@shopify/theme-graph');
 const {
-  NodeFileSystem,
   memoize,
   toSchema,
   path: pathUtils,
   recursiveReadDirectory,
-} = require('@shopify/theme-check-node');
+  FileType,
+} = require('@shopify/theme-check-common');
+const fs = require('node:fs/promises');
 const path = require('path');
 const { URI } = require('vscode-uri');
 
@@ -20,6 +21,26 @@ Example:
 `;
 
 const identity = (/** @type {any} */ x) => x;
+
+/** @type {import('@shopify/theme-check-common').AbstractFileSystem} */
+const NodeFileSystem = {
+  async readFile(uri) {
+    return fs.readFile(pathUtils.fsPath(uri), 'utf8');
+  },
+  async readDirectory(uri) {
+    const files = await fs.readdir(pathUtils.fsPath(uri), { withFileTypes: true });
+    return files.map((file) => {
+      return [pathUtils.join(uri, file.name), file.isDirectory() ? FileType.Directory : FileType.File];
+    });
+  },
+  async stat(uri) {
+    const stats = await fs.stat(pathUtils.fsPath(uri));
+    return {
+      type: stats.isDirectory() ? FileType.Directory : FileType.File,
+      size: stats.size,
+    };
+  },
+};
 
 /**
  * Outputs the JSON representing the theme graph for a Shopify theme directory.
@@ -39,9 +60,8 @@ async function main(root) {
   const getSourceCode = makeGetSourceCode();
 
   // Preload files to get a sense of what is slow
-  const fs = NodeFileSystem;
   const rootUri = URI.file(root).toString(true);
-  const filesToPreload = await recursiveReadDirectory(fs, rootUri, ([uri]) =>
+  const filesToPreload = await recursiveReadDirectory(NodeFileSystem, rootUri, ([uri]) =>
     ['.json', '.liquid'].some((ext) => uri.endsWith(ext)),
   );
   await bench('Preloading files', async () => {
@@ -57,7 +77,7 @@ async function main(root) {
 
   /** @type {import('@shopify/theme-graph').Dependencies} */
   const dependencies = {
-    fs,
+    fs: NodeFileSystem,
     // @ts-ignore
     getSectionSchema: memoize(async (name) => {
       const uri = pathUtils.join(rootUri, 'sections', `${name}.liquid`);

--- a/packages/theme-graph/package.json
+++ b/packages/theme-graph/package.json
@@ -31,9 +31,11 @@
   "dependencies": {
     "@shopify/liquid-html-parser": "^2.9.2",
     "@shopify/theme-check-common": "^3.24.0",
-    "@shopify/theme-check-node": "^3.24.0",
     "acorn": "^8.14.1",
     "acorn-walk": "^8.3.4",
     "vscode-uri": "^3.0.7"
+  },
+  "devDependencies": {
+    "@shopify/theme-check-node": "^3.24.0"
   }
 }

--- a/packages/theme-graph/tsconfig.build.json
+++ b/packages/theme-graph/tsconfig.build.json
@@ -6,7 +6,8 @@
   ],
   "exclude": [
     "node_modules",
-    "src/**/*.spec.ts"
+    "src/**/*.spec.ts",
+    "src/**/test-helpers.ts"
   ],
   "references": [
     {

--- a/packages/theme-language-server-common/src/diagnostics/runChecks.ts
+++ b/packages/theme-language-server-common/src/diagnostics/runChecks.ts
@@ -1,5 +1,7 @@
 import {
   check,
+  extractCSSClassesFromLiquidUri,
+  extractCSSClassesFromAssetUri,
   findRoot,
   makeFileExists,
   Offense,
@@ -70,6 +72,18 @@ export function makeRunChecks(
         async getReferences(uri: string): Promise<Reference[]> {
           if (!themeGraphManager) return [];
           return themeGraphManager.getReferences(uri);
+        },
+
+        async getDependencies(uri: string): Promise<Reference[]> {
+          if (!themeGraphManager) return [];
+          return themeGraphManager.getDependencies(uri);
+        },
+
+        async getCSSClassesForURI(uri: string): Promise<Set<string>> {
+          if (uri.endsWith('.css')) {
+            return extractCSSClassesFromAssetUri(uri, fs);
+          }
+          return extractCSSClassesFromLiquidUri(uri, fs);
         },
 
         // TODO should do something for app blocks?

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -460,6 +460,9 @@ export function startServer(
           globPattern: '**/*.liquid',
         },
         {
+          globPattern: '**/assets/*.css',
+        },
+        {
           globPattern: '**/{locales,sections,templates,customers}/*.json',
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,6 +1373,13 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
+"@types/postcss-safe-parser@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/postcss-safe-parser/-/postcss-safe-parser-5.0.4.tgz#2913271fb07e62b8829753e809f011be967d6652"
+  integrity sha512-5zGTm1jsW3j4+omgND1SIDbrZOcigTuxa4ihppvKbLkg2INUGBHV/fWNRSRFibK084tU3fxqZ/kVoSIGqRHnrQ==
+  dependencies:
+    postcss "^8.4.4"
+
 "@types/prettier@^2.4.2":
   version "2.7.3"
   resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
@@ -5805,6 +5812,11 @@ mute-stream@~0.0.4:
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+nanoid@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
 nanoid@^3.3.7:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
@@ -6352,10 +6364,23 @@ postcss-modules-values@^4.0.0:
   dependencies:
     icss-utils "^5.0.0"
 
+postcss-safe-parser@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz#36e4f7e608111a0ca940fd9712ce034718c40ec0"
+  integrity sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==
+
 postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
   version "6.0.13"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
   integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss-selector-parser@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz#e75d2e0d843f620e5df69076166f4e16f891cb9f"
+  integrity sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
@@ -6371,6 +6396,15 @@ postcss@^8.4.21, postcss@^8.4.43:
   integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
   dependencies:
     nanoid "^3.3.7"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@^8.4.4, postcss@^8.5.9:
+  version "8.5.9"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.9.tgz#f6ee9e0b94f0f19c97d2f172bfbd7fc71fe1cca4"
+  integrity sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==
+  dependencies:
+    nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
## 🗒️ Summary

Adds a new theme check `ValidScopedCSSClass` that warns when a CSS class used in an HTML `class` attribute may be defined outside the scope of the current file.

This helps theme developers catch cases where a CSS class is used in a file but is only defined in a stylesheet tag that isn't accessible from that file's scope — indicating a potential dependency issue or misplaced style.

## ❓ What is considered "in scope"

A CSS class is considered in scope for a file if it is defined in any of the following:

- **Local `{% stylesheet %}` tag** — the file's own stylesheet
- **Ancestor `{% stylesheet %}` tags** — any file that directly renders this file (via `{% render %}`, `{% section %}`, etc.), traversed upward through the full ancestor chain. Only `direct` type references count (not `indirect` or `preset`)
- **Rendered snippet stylesheets** — any snippet the file renders via `{% render %}`, including that snippet's own snippet descendants (recursive)
- **Ancestor-rendered snippet stylesheets** — any snippet rendered by an ancestor file, including descendants
- **CSS asset files** — all `.css` files in the theme's `assets/` directory are globally in scope

## 👍 What is NOT reported

- **Classes not defined anywhere in the theme** — classes from external sources (CDNs, utility frameworks like Tailwind, inline JS injection, etc.) are silently ignored. The check only reports a class if it exists somewhere in the theme but isn't reachable from the current file's scope
- **Dynamic class attributes** — Liquid output tags (`{{ variable }}`) in class attributes are skipped since they can't be statically analyzed


## 🎩 Tophatting

#### Via VSCode Extension
- Checkout this branch
- Run `yarn install && yarn build`
- Press F5 to run the VScode extension in another window (might be `fn + F5` for some)
- Open a theme (or create one using Shopify CLI by running `npx shopify theme init`)
- Add a few CSS classes in stylesheet tags or `assets/*.css` files


#### Run cli-like environment
- Run the following command against the theme from this repo's root `node packages/theme-check-node/dist/cli.js [path-to-theme] > result` (replace [path-to-theme] with an actual path to theme)
  - See the theme check results from above appear in the `result` file it generated
