### PR TITLE
feat: add DeprecatedFontsOnSettingsData check for config/settings_data.json

### DIFF
--- a/.changeset/warm-fonts-glow.md
+++ b/.changeset/warm-fonts-glow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Add DeprecatedFontsOnSettingsData check for config/settings_data.json

--- a/packages/theme-check-common/src/checks/deprecated-fonts-on-settings-data/index.spec.ts
+++ b/packages/theme-check-common/src/checks/deprecated-fonts-on-settings-data/index.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { DeprecatedFontsOnSettingsData } from './index';
+import { runJSONCheck } from '../../test';
+
+describe('Module: DeprecatedFontsOnSettingsData', () => {
+  it('reports a warning when settings_data.json has a deprecated font in current settings', async () => {
+    const sourceCode = JSON.stringify({
+      current: {
+        heading_font: 'helvetica_n4',
+        body_font: 'alegreya_n4',
+      },
+    });
+
+    const offenses = await runJSONCheck(
+      DeprecatedFontsOnSettingsData,
+      sourceCode,
+      'config/settings_data.json',
+    );
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual('The font "helvetica_n4" is deprecated');
+  });
+
+  it('reports warnings for deprecated fonts in presets', async () => {
+    const sourceCode = JSON.stringify({
+      current: {},
+      presets: {
+        Default: {
+          heading_font: 'helvetica_n4',
+          body_font: 'agmena_n4',
+        },
+      },
+    });
+
+    const offenses = await runJSONCheck(
+      DeprecatedFontsOnSettingsData,
+      sourceCode,
+      'config/settings_data.json',
+    );
+
+    expect(offenses).toHaveLength(2);
+    expect(offenses.map((o) => o.message)).toContain('The font "helvetica_n4" is deprecated');
+    expect(offenses.map((o) => o.message)).toContain('The font "agmena_n4" is deprecated');
+  });
+
+  it('reports no warning when settings_data.json has no deprecated fonts', async () => {
+    const sourceCode = JSON.stringify({
+      current: {
+        heading_font: 'alegreya_n4',
+        body_font: 'bitter_n4',
+      },
+    });
+
+    const offenses = await runJSONCheck(
+      DeprecatedFontsOnSettingsData,
+      sourceCode,
+      'config/settings_data.json',
+    );
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports no warning for non-string values', async () => {
+    const sourceCode = JSON.stringify({
+      current: {
+        show_header: true,
+        items_per_page: 12,
+        colors_body_bg: '#ffffff',
+      },
+    });
+
+    const offenses = await runJSONCheck(
+      DeprecatedFontsOnSettingsData,
+      sourceCode,
+      'config/settings_data.json',
+    );
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('does not run check on files other than settings_data.json', async () => {
+    const sourceCode = JSON.stringify({
+      current: {
+        heading_font: 'helvetica_n4',
+      },
+    });
+
+    const offenses = await runJSONCheck(
+      DeprecatedFontsOnSettingsData,
+      sourceCode,
+      'config/settings_schema.json',
+    );
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports warnings for deprecated fonts deeply nested in preset blocks', async () => {
+    const sourceCode = JSON.stringify({
+      current: {
+        blocks: {
+          'block-id-1': {
+            type: 'header',
+            settings: {
+              heading_font: 'helvetica_n4',
+            },
+          },
+        },
+      },
+    });
+
+    const offenses = await runJSONCheck(
+      DeprecatedFontsOnSettingsData,
+      sourceCode,
+      'config/settings_data.json',
+    );
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toEqual('The font "helvetica_n4" is deprecated');
+  });
+});

--- a/packages/theme-check-common/src/checks/deprecated-fonts-on-settings-data/index.ts
+++ b/packages/theme-check-common/src/checks/deprecated-fonts-on-settings-data/index.ts
@@ -1,0 +1,40 @@
+import { JSONCheckDefinition, Severity, SourceCodeType } from '../../types';
+import { getLocStart, getLocEnd } from '../../json';
+import { DEPRECATED_FONT_HANDLES } from '../deprecated-fonts-on-sections-and-blocks/deprecated-fonts-data';
+
+export const DeprecatedFontsOnSettingsData: JSONCheckDefinition = {
+  meta: {
+    code: 'DeprecatedFontsOnSettingsData',
+    name: 'Check for deprecated fonts in settings_data settings values',
+    docs: {
+      description: 'Warns on deprecated fonts in settings_data settings values.',
+      recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/deprecated-fonts-on-settings-data',
+    },
+    type: SourceCodeType.JSON,
+    severity: Severity.WARNING,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    const relativePath = context.toRelativePath(context.file.uri);
+    if (relativePath !== 'config/settings_data.json') return {};
+
+    return {
+      async Property(node) {
+        if (
+          node.value.type === 'Literal' &&
+          typeof node.value.value === 'string' &&
+          DEPRECATED_FONT_HANDLES.has(node.value.value)
+        ) {
+          context.report({
+            message: `The font "${node.value.value}" is deprecated`,
+            startIndex: getLocStart(node.value),
+            endIndex: getLocEnd(node.value),
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -13,6 +13,7 @@ import { DeprecateBgsizes } from './deprecate-bgsizes';
 import { DeprecateLazysizes } from './deprecate-lazysizes';
 import { DeprecatedFilter } from './deprecated-filter';
 import { DeprecatedFontsOnSectionsAndBlocks } from './deprecated-fonts-on-sections-and-blocks';
+import { DeprecatedFontsOnSettingsData } from './deprecated-fonts-on-settings-data';
 import { DeprecatedFontsOnSettingsSchema } from './deprecated-fonts-on-settings-schema';
 import { DeprecatedTag } from './deprecated-tag';
 import { DuplicateRenderSnippetArguments } from './duplicate-render-snippet-arguments';
@@ -81,6 +82,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   DeprecateLazysizes,
   DeprecatedFilter,
   DeprecatedFontsOnSectionsAndBlocks,
+  DeprecatedFontsOnSettingsData,
   DeprecatedFontsOnSettingsSchema,
   DeprecatedTag,
   DuplicateContentForArguments,

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -49,6 +49,9 @@ DeprecatedFilter:
 DeprecatedFontsOnSectionsAndBlocks:
   enabled: true
   severity: 1
+DeprecatedFontsOnSettingsData:
+  enabled: true
+  severity: 1
 DeprecatedFontsOnSettingsSchema:
   enabled: true
   severity: 1

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -27,6 +27,9 @@ DeprecatedFilter:
 DeprecatedFontsOnSectionsAndBlocks:
   enabled: true
   severity: 1
+DeprecatedFontsOnSettingsData:
+  enabled: true
+  severity: 1
 DeprecatedFontsOnSettingsSchema:
   enabled: true
   severity: 1


### PR DESCRIPTION
## Summary

- Add new `DeprecatedFontsOnSettingsData` JSON check that warns on deprecated font handles in `config/settings_data.json`

This complements the existing `DeprecatedFontsOnSectionsAndBlocks` (sections/blocks `{% schema %}` tags) and `DeprecatedFontsOnSettingsSchema` (`config/settings_schema.json`) checks by covering the remaining unchecked surface: saved preset values in `settings_data.json`.

### How it works

The check walks all string literal `Property` values in `config/settings_data.json` and flags any that match the shared `DEPRECATED_FONT_HANDLES` set. This covers:

- `current` settings (live theme values)
- `presets` (theme demo presets)
- Deeply nested block settings within presets

### Implementation details

- Reuses the shared `DEPRECATED_FONT_HANDLES` set from `deprecated-fonts-data.ts`
- Follows the same pattern as `DeprecatedFontsOnSettingsSchema`
- Registered in `allChecks` with `recommended: true`

### Tests

6 test cases covering:
- Deprecated font in current settings
- Deprecated fonts in presets
- No warnings for non-deprecated fonts
- No warnings for non-string values
- File targeting (only `config/settings_data.json`)
- Deeply nested block settings

All existing tests continue to pass (21 tests across the other two deprecated font checks).

Closes #1008