### PR TITLE
fix: remove ValidScopedCSSClass from recommended config (temp)

### DIFF
--- a/.changeset/disable-valid-scoped-css-class-recommended.md
+++ b/.changeset/disable-valid-scoped-css-class-recommended.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': patch
+'@shopify/theme-check-node': patch
+---
+
+Temporarily remove `ValidScopedCSSClass` from the recommended config. The check causes severe save lag in VS Code on larger themes (see [#1179](https://github.com/Shopify/theme-tools/issues/1179)) because it re-parses every `{% stylesheet %}` tag in the theme on every save. It remains available as an opt-in check. Will be re-enabled once the performance issue is resolved.

--- a/packages/theme-check-common/src/checks/valid-scoped-css-class/index.ts
+++ b/packages/theme-check-common/src/checks/valid-scoped-css-class/index.ts
@@ -76,7 +76,7 @@ export const ValidScopedCSSClass: LiquidCheckDefinition = {
     docs: {
       description:
         'Reports CSS classes used in HTML class attributes that are not defined in any in-scope stylesheet tag or CSS asset file.',
-      recommended: true,
+      recommended: false,
       url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-scoped-css-class',
     },
     type: SourceCodeType.LiquidHtml,

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -174,9 +174,6 @@ ValidSchemaName:
 ValidSchemaTranslations:
   enabled: true
   severity: 0
-ValidScopedCSSClass:
-  enabled: true
-  severity: 1
 ValidSettingsKey:
   enabled: true
   severity: 0


### PR DESCRIPTION
## Summary

- Set `recommended: false` on the `ValidScopedCSSClass` check
- Regenerated `packages/theme-check-node/configs/recommended.yml` (factory-generated file)
- Added a patch changeset

## ⚠️ Temporary fix

This is a **temporary fix** while we resolve performance issues for this theme-check on VS Code. The check was introduced in v3.11.2 and causes severe save lag on larger themes — users report VS Code hanging for several seconds on every save with a \"Getting code actions from 'Shopify Liquid'\" message (see #1179).

Root cause: every save re-parses every \`{% stylesheet %}\` tag in the theme to build the in-scope CSS class set. On a 240-file theme that's ~128 liquid-HTML + postcss parses per save.

A performance fix (session-level caching of per-file CSS classes + substring short-circuit before AST parse) is in progress and will be landed as a separate PR. Once that ships and is validated on large themes, we'll flip this check back to \`recommended: true\`.

## Impact

- Users upgrading to the next patch release will no longer see \`ValidScopedCSSClass\` warnings by default.
- The check still works and is available via \`extends: theme-check:all\` or by opting in explicitly in \`.theme-check.yml\`.
- No API changes.

## Test plan
- [ ] \`yarn build\` completes successfully (generated configs updated)
- [ ] \`ValidScopedCSSClass\` no longer appears in \`packages/theme-check-node/configs/recommended.yml\`
- [ ] \`ValidScopedCSSClass\` still appears in \`packages/theme-check-node/configs/all.yml\`
- [ ] Existing tests for the check still pass (\`yarn test\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)