### PR TITLE
Fix UnusedAssign false positive inside inline {% liquid ... style ... endstyle %}

### DIFF
--- a/.changeset/fix-unused-assign-inline-liquid-style.md
+++ b/.changeset/fix-unused-assign-inline-liquid-style.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+Fix false-positive UnusedAssign warnings for variables used inside a `style` block within an inline `{% liquid %}` tag. The inline-liquid raw-tag CST mapping parsed every raw-tag body as plain text, so variable references inside `{% liquid ... style ... echo foo ... endstyle %}` never became AST nodes and checks that walk the tree saw no usage. The mapping now mirrors the top-level `liquidRawTagImpl` behavior: `schema` and `raw` remain text, all other raw tags are parsed as Liquid so references inside `style` and friends are preserved. Fixes Shopify/theme-tools#465.

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -1212,14 +1212,38 @@ function toCST<T>(
       name: 0,
       body: 4,
       children(nodes) {
-        return toCST(
-          source,
-          grammars,
-          TextNodeGrammar,
-          ['HelperMappings'],
-          nodes[4].sourceString,
-          offset + nodes[4].source.startIdx,
-        );
+        const nameNode = nodes[0];
+        const rawMarkupStringNode = nodes[4];
+        switch (nameNode.sourceString) {
+          // {% schema %} parses its content as a string and should not be visited
+          case 'schema':
+          // {% raw %} accepts syntax errors, we shouldn't try to parse that
+          case 'raw': {
+            return toCST(
+              source,
+              grammars,
+              TextNodeGrammar,
+              ['HelperMappings'],
+              rawMarkupStringNode.sourceString,
+              offset + rawMarkupStringNode.source.startIdx,
+            );
+          }
+
+          // Match the top-level liquidRawTagImpl behavior so variables
+          // referenced inside {% liquid ... style ... endstyle %} are
+          // detected as used by checks that walk the AST. The body is
+          // still inline-liquid, so re-parse with LiquidStatement.
+          default: {
+            return toCST(
+              source,
+              grammars,
+              grammars.LiquidStatement,
+              ['HelperMappings', 'LiquidMappings', 'LiquidStatement'],
+              rawMarkupStringNode.sourceString,
+              offset + rawMarkupStringNode.source.startIdx,
+            );
+          }
+        }
       },
       whitespaceStart: null,
       whitespaceEnd: null,

--- a/packages/theme-check-common/src/checks/unused-assign/index.spec.ts
+++ b/packages/theme-check-common/src/checks/unused-assign/index.spec.ts
@@ -114,6 +114,25 @@ describe('Module: UnusedAssign', () => {
     }
   });
 
+  it('should not report unused assigns for variables used inside a style block within {% liquid %}', async () => {
+    const sourceCode = `
+      {%- liquid
+        assign shopName = shop.name
+        capture example
+          echo 'Shopify'
+        endcapture
+
+        style
+          echo example
+          echo shopName
+        endstyle
+      -%}
+    `;
+
+    const offenses = await runLiquidCheck(UnusedAssign, sourceCode);
+    expect(offenses).to.be.empty;
+  });
+
   it('should not report unused assigns for things used in a HTML raw-like tag', async () => {
     const tags = ['style', 'script'];
     for (const tag of tags) {


### PR DESCRIPTION
## What are you adding in this PR?

Fixes a false-positive `UnusedAssign` warning for variables that are only referenced inside a `style` block within an inline `{% liquid %}` tag.

Repro from the issue:
```liquid
{%- liquid
  assign shopName = shop.name
  capture example
    echo 'Shopify'
  endcapture

  style
    echo example
    echo shopName
  endstyle
-%}
```
Before the fix, both `example` and `shopName` get reported as *"assigned but not used"*. After the fix, no offense is reported.

### Root cause
The CST mapping in `packages/liquid-html-parser/src/stage-1-cst.ts` has two `liquidRawTagImpl` entries — one for the main `Liquid` grammar (top-level `{% style %}...{% endstyle %}`) and one for the `LiquidStatement` grammar (inline `{% liquid ... style ... endstyle %}`).

The top-level mapping already distinguishes:
- `schema` / `raw` → `TextNodeGrammar` (raw string, not visited)
- everything else (`style`, `stylesheet`, `javascript`) → re-parsed with `grammars.Liquid` so children end up in the AST

The inline mapping forced **every** raw tag body through `TextNodeGrammar`. That meant the `echo example` and `echo shopName` inside the inline `style` block never produced `VariableLookup` nodes, and `UnusedAssign` (which walks `VariableLookup` to decide "used") never registered them as used.

### Fix
Mirror the top-level switch in the inline mapping. `schema` and `raw` still stay as raw text; every other raw tag is re-parsed with `grammars.LiquidStatement` (the inline-liquid grammar) so references inside `style` and friends become first-class AST nodes.

Adds a regression test in `unused-assign/index.spec.ts` using the exact snippet from #465.

### Related
This supersedes the grammar-level attempt in #683 — the real bug was not in the grammar (style is a valid raw tag name in both the top-level and inline-liquid grammars) but in how the CST mapping re-parsed the raw body.

## What's next? Any followup issues?

The inline form of `{% liquid ... javascript %}` / `{% liquid ... stylesheet %}` / `{% liquid ... schema %}` is exotic but now produces the same AST shape as their top-level counterparts. No follow-ups I can see.

## Before you deploy

- [x] I included a patch bump `changeset` for `@shopify/liquid-html-parser`
- [x] Full `vitest run` green — 294 files, 1860 tests, 1 pre-existing skip
- [x] `yarn format:check` clean
- [x] `yarn workspace ... type-check` clean for `@shopify/liquid-html-parser`, `@shopify/theme-check-common`, `@shopify/theme-check-node`, `@shopify/theme-language-server-common`, `@shopify/prettier-plugin-liquid`

Closes #465