### PR TITLE
feat(prettier-plugin-liquid): support prettier-ignore-start / prettier-ignore-end ranges

### DIFF
--- a/.changeset/bright-ignore-range.md
+++ b/.changeset/bright-ignore-range.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': minor
+---
+
+Add support for prettier-ignore-start / prettier-ignore-end range-based ignoring in Liquid templates

--- a/packages/prettier-plugin-liquid/src/printer/utils/node.ts
+++ b/packages/prettier-plugin-liquid/src/printer/utils/node.ts
@@ -156,7 +156,85 @@ export function isPrettierIgnoreNode(
 }
 
 export function hasPrettierIgnore(node: LiquidHtmlNode) {
-  return isPrettierIgnoreNode(node) || isPrettierIgnoreNode(node.prev);
+  return (
+    isPrettierIgnoreNode(node) ||
+    isPrettierIgnoreNode(node.prev) ||
+    isPrettierIgnoreRangeStartNode(node) ||
+    isPrettierIgnoreRangeEndNode(node) ||
+    isInsidePrettierIgnoreRange(node)
+  );
+}
+
+export function isPrettierIgnoreRangeStartHtmlNode(
+  node: LiquidHtmlNode | undefined,
+): node is HtmlComment {
+  return (
+    !!node &&
+    node.type === NodeTypes.HtmlComment &&
+    /^\s*prettier-ignore-start(?=\s|$)/m.test(node.body)
+  );
+}
+
+export function isPrettierIgnoreRangeStartLiquidNode(
+  node: LiquidHtmlNode | undefined,
+): node is LiquidTag {
+  return (
+    !!node &&
+    node.type === NodeTypes.LiquidTag &&
+    node.name === '#' &&
+    /^\s*prettier-ignore-start(?=\s|$)/m.test(node.markup)
+  );
+}
+
+export function isPrettierIgnoreRangeStartNode(
+  node: LiquidHtmlNode | undefined,
+): node is HtmlComment | LiquidTag {
+  return isPrettierIgnoreRangeStartHtmlNode(node) || isPrettierIgnoreRangeStartLiquidNode(node);
+}
+
+export function isPrettierIgnoreRangeEndHtmlNode(
+  node: LiquidHtmlNode | undefined,
+): node is HtmlComment {
+  return (
+    !!node &&
+    node.type === NodeTypes.HtmlComment &&
+    /^\s*prettier-ignore-end(?=\s|$)/m.test(node.body)
+  );
+}
+
+export function isPrettierIgnoreRangeEndLiquidNode(
+  node: LiquidHtmlNode | undefined,
+): node is LiquidTag {
+  return (
+    !!node &&
+    node.type === NodeTypes.LiquidTag &&
+    node.name === '#' &&
+    /^\s*prettier-ignore-end(?=\s|$)/m.test(node.markup)
+  );
+}
+
+export function isPrettierIgnoreRangeEndNode(
+  node: LiquidHtmlNode | undefined,
+): node is HtmlComment | LiquidTag {
+  return isPrettierIgnoreRangeEndHtmlNode(node) || isPrettierIgnoreRangeEndLiquidNode(node);
+}
+
+/**
+ * Walk backward through siblings to determine if a node is inside an
+ * unmatched prettier-ignore-start / prettier-ignore-end range.
+ */
+export function isInsidePrettierIgnoreRange(node: LiquidHtmlNode): boolean {
+  let current = node.prev;
+  while (current) {
+    if (isPrettierIgnoreRangeEndNode(current)) {
+      return false;
+    }
+    if (isPrettierIgnoreRangeStartNode(current)) {
+      return true;
+    }
+    current = current.prev;
+  }
+  return false;
 }
 
 function getPrettierIgnoreAttributeCommentData(value: string): boolean {

--- a/packages/prettier-plugin-liquid/src/test/prettier-ignore-range/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/prettier-ignore-range/fixed.liquid
@@ -1,0 +1,41 @@
+It should preserve formatting inside html prettier-ignore-start / prettier-ignore-end range
+<!-- prettier-ignore-start -->
+<div class="custom-layout">
+  {{ some_variable | complicated_filter: foo: bar }}
+  {% render 'component', foo: bar %}
+</div>
+<!-- prettier-ignore-end -->
+
+It should preserve formatting inside liquid comment prettier-ignore-start / prettier-ignore-end range
+{% # prettier-ignore-start %}
+<div class="custom-layout">
+  {{ some_variable | complicated_filter: foo: bar }}
+  {% render 'component', foo: bar %}
+</div>
+{% # prettier-ignore-end %}
+
+It should only ignore nodes between start and end, formatting nodes outside normally
+printWidth: 40
+<p>{{ a | append: 'b' }}</p>
+<!-- prettier-ignore-start -->
+<div>{{ some_variable   |   complicated_filter: foo: bar }}</div>
+<!-- prettier-ignore-end -->
+<p>{{ a | append: 'b' }}</p>
+
+It should handle multiple ignore ranges in the same parent
+printWidth: 40
+<p>{{ a | append: 'b' }}</p>
+<!-- prettier-ignore-start -->
+<div>{{ x   |   y: z }}</div>
+<!-- prettier-ignore-end -->
+<p>{{ a | append: 'b' }}</p>
+<!-- prettier-ignore-start -->
+<span>{{ m   |   n: o }}</span>
+<!-- prettier-ignore-end -->
+<p>{{ a | append: 'b' }}</p>
+
+It should handle liquid comment ranges with multiple nodes
+{% # prettier-ignore-start %}
+{%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}
+<div>{{ x   |   y: z }}</div>
+{% # prettier-ignore-end %}

--- a/packages/prettier-plugin-liquid/src/test/prettier-ignore-range/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/prettier-ignore-range/index.liquid
@@ -1,0 +1,41 @@
+It should preserve formatting inside html prettier-ignore-start / prettier-ignore-end range
+<!-- prettier-ignore-start -->
+<div class="custom-layout">
+  {{ some_variable | complicated_filter: foo: bar }}
+  {% render 'component', foo: bar %}
+</div>
+<!-- prettier-ignore-end -->
+
+It should preserve formatting inside liquid comment prettier-ignore-start / prettier-ignore-end range
+{% # prettier-ignore-start %}
+<div class="custom-layout">
+  {{ some_variable | complicated_filter: foo: bar }}
+  {% render 'component', foo: bar %}
+</div>
+{% # prettier-ignore-end %}
+
+It should only ignore nodes between start and end, formatting nodes outside normally
+printWidth: 40
+<p>{{ a   |   append: 'b' }}</p>
+<!-- prettier-ignore-start -->
+<div>{{ some_variable   |   complicated_filter: foo: bar }}</div>
+<!-- prettier-ignore-end -->
+<p>{{ a   |   append: 'b' }}</p>
+
+It should handle multiple ignore ranges in the same parent
+printWidth: 40
+<p>{{ a   |   append: 'b' }}</p>
+<!-- prettier-ignore-start -->
+<div>{{ x   |   y: z }}</div>
+<!-- prettier-ignore-end -->
+<p>{{ a   |   append: 'b' }}</p>
+<!-- prettier-ignore-start -->
+<span>{{ m   |   n: o }}</span>
+<!-- prettier-ignore-end -->
+<p>{{ a   |   append: 'b' }}</p>
+
+It should handle liquid comment ranges with multiple nodes
+{% # prettier-ignore-start %}
+{%capture foo%}{% for x in (0 .. 1) %}{% cycle a,b,c %}{% endfor %}{%endcapture%}
+<div>{{ x   |   y: z }}</div>
+{% # prettier-ignore-end %}

--- a/packages/prettier-plugin-liquid/src/test/prettier-ignore-range/index.spec.ts
+++ b/packages/prettier-plugin-liquid/src/test/prettier-ignore-range/index.spec.ts
@@ -1,0 +1,6 @@
+import { test } from 'vitest';
+import { assertFormattedEqualsFixed } from '../test-helpers';
+
+test('Unit: prettier-ignore-start / prettier-ignore-end range', async () => {
+  await assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## What is this PR?

This PR adds support for range-based formatting ignores (`prettier-ignore-start` / `prettier-ignore-end`) to the Liquid prettier plugin. Currently, the plugin only supports single-node ignores with `<!-- prettier-ignore -->` or `{% # prettier-ignore %}`, which means if you want to preserve the formatting of a multi-node block, you have to add a separate ignore comment before every single node. That gets noisy fast, especially in larger templates with intentional whitespace or layout.

## What was the issue?

[Issue #1150](https://github.com/Shopify/theme-tools/issues/1150) describes the problem well: there's no way to tell the formatter "leave this entire section alone." The only workarounds are per-node `prettier-ignore` comments (verbose) or `.prettierignore` for the whole file (too coarse).

Standard Prettier supports `prettier-ignore-start` / `prettier-ignore-end` for HTML, but the Liquid plugin didn't implement it.

## How does this PR address it?

The implementation builds on the existing `prettier-ignore` infrastructure. The plugin already has functions that detect ignore comments and a code path in `printChild` that outputs raw source text for ignored nodes. I extended this with three changes:

1. **Detection functions** in `printer/utils/node.ts`: Added `isPrettierIgnoreRangeStartNode` and `isPrettierIgnoreRangeEndNode` that recognize both HTML comments (`<!-- prettier-ignore-start -->`) and Liquid inline comments (`{% # prettier-ignore-start %}`), following the same dual-format pattern as the existing single-node ignore.

2. **Range resolution** via `isInsidePrettierIgnoreRange`: When the printer asks "should this node be printed raw?", this function walks backward through the node's siblings looking for an unmatched `prettier-ignore-start`. If it finds one before finding a `prettier-ignore-end` (or running out of siblings), the node is inside a range and gets printed as raw source text. The start and end comment nodes themselves are also printed raw.

3. **Test fixtures** covering the key scenarios: HTML comment ranges, Liquid comment ranges, nodes outside the range still being formatted, multiple ranges in the same parent, and ranges spanning several different node types.

Both syntaxes are supported:

```liquid
<!-- prettier-ignore-start -->
<div class="custom-layout">
  {{ some_variable | complicated_filter: foo: bar }}
  {% render 'component', foo: bar %}
</div>
<!-- prettier-ignore-end -->
```

```liquid
{% # prettier-ignore-start %}
<div class="custom-layout">
  {{ some_variable | complicated_filter: foo: bar }}
  {% render 'component', foo: bar %}
</div>
{% # prettier-ignore-end %}
```

## Test plan

- [x] New test suite (`prettier-ignore-range`) passes with 5 test cases
- [x] Existing `liquid-prettier-ignore` tests still pass (single-node ignores unaffected)
- [x] Both HTML comment and Liquid comment syntax work
- [x] Nodes outside the range are formatted normally
- [x] Multiple ranges in the same parent work independently

Closes #1150