### PR TITLE
feat(theme-check-common): warn when select default isn't a valid option

### DIFF
--- a/.changeset/valid-select-default.md
+++ b/.changeset/valid-select-default.md
@@ -1,0 +1,5 @@
+---
+"@shopify/theme-check-common": minor
+---
+
+Add `ValidSelectDefault` check that warns when a `select` or `radio` setting's `default` value is not one of its declared `options`. The check also validates preset setting values and section `default.settings` values, and runs against `config/settings_schema.json`.

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -61,6 +61,10 @@ import { ValidRenderSnippetArgumentTypes } from './valid-render-snippet-argument
 import { ValidSchema } from './valid-schema';
 import { ValidSchemaName } from './valid-schema-name';
 import { ValidSchemaTranslations } from './valid-schema-translations';
+import {
+  ValidSelectDefault,
+  ValidSelectDefaultSettingsSchema,
+} from './valid-select-default';
 import { ValidSettingsKey } from './valid-settings-key';
 import { ValidStaticBlockType } from './valid-static-block-type';
 import { ValidVisibleIf, ValidVisibleIfSettingsSchema } from './valid-visible-if';
@@ -130,6 +134,8 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   ValidLocalBlocks,
   ValidRenderSnippetArgumentTypes,
   ValidSchema,
+  ValidSelectDefault,
+  ValidSelectDefaultSettingsSchema,
   ValidSettingsKey,
   ValidStaticBlockType,
   ValidVisibleIf,

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -62,6 +62,7 @@ import { ValidRenderSnippetArgumentTypes } from './valid-render-snippet-argument
 import { ValidSchema } from './valid-schema';
 import { ValidSchemaName } from './valid-schema-name';
 import { ValidSchemaTranslations } from './valid-schema-translations';
+import { ValidSelectDefault, ValidSelectDefaultSettingsSchema } from './valid-select-default';
 import { ValidSettingsKey } from './valid-settings-key';
 import { ValidStaticBlockType } from './valid-static-block-type';
 import { ValidVisibleIf, ValidVisibleIfSettingsSchema } from './valid-visible-if';
@@ -132,6 +133,8 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   ValidLocalBlocks,
   ValidRenderSnippetArgumentTypes,
   ValidSchema,
+  ValidSelectDefault,
+  ValidSelectDefaultSettingsSchema,
   ValidSettingsKey,
   ValidStaticBlockType,
   ValidVisibleIf,

--- a/packages/theme-check-common/src/checks/valid-select-default/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-select-default/index.spec.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from 'vitest';
+import { check, runJSONCheck } from '../../test';
+import { ValidSelectDefault, ValidSelectDefaultSettingsSchema } from './index';
+
+function toLiquidFile(content: unknown) {
+  return `
+    {% schema %}
+      ${JSON.stringify(content)}
+    {% endschema %}
+  `;
+}
+
+const alignmentOptions = [
+  { value: 'flex-start', label: 'Left' },
+  { value: 'center', label: 'Center' },
+  { value: 'flex-end', label: 'Right' },
+];
+
+describe('Module: ValidSelectDefault (Liquid schema)', () => {
+  describe('setting defaults', () => {
+    it('does not report when the select default matches an option', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              default: 'center',
+              options: alignmentOptions,
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('reports when the select default is not in options', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              default: 'this-is-not-an-option',
+              options: alignmentOptions,
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).toMatch(/alignment/);
+      expect(offenses[0].message).toMatch(/this-is-not-an-option/);
+      expect(offenses[0].message).toMatch(/flex-start/);
+    });
+
+    it('reports when a radio default is not in options', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'radio',
+              id: 'layout_direction',
+              default: 'bogus',
+              options: [
+                { value: 'row', label: 'Row' },
+                { value: 'column', label: 'Column' },
+              ],
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).toMatch(/layout_direction/);
+      expect(offenses[0].message).toMatch(/bogus/);
+    });
+
+    it('does not report when the setting has no default', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              options: alignmentOptions,
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('ignores non-choice settings', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            { type: 'text', id: 'heading', default: 'anything' },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+  });
+
+  describe('preset settings', () => {
+    it('does not report when preset setting matches an option', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              options: alignmentOptions,
+            },
+          ],
+          presets: [
+            {
+              name: 'Column',
+              settings: { alignment: 'flex-end' },
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('reports when preset setting is not in options', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              options: alignmentOptions,
+            },
+          ],
+          presets: [
+            {
+              name: 'Column',
+              settings: { alignment: 'this-is-not-an-option' },
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).toMatch(/alignment/);
+      expect(offenses[0].message).toMatch(/this-is-not-an-option/);
+    });
+
+    it('reports both invalid default and invalid preset setting', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              default: 'bad-default',
+              options: alignmentOptions,
+            },
+          ],
+          presets: [
+            {
+              name: 'Column',
+              settings: { alignment: 'also-bad' },
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(2);
+    });
+
+    it('does not report when preset references a non-select setting', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [{ type: 'text', id: 'heading' }],
+          presets: [
+            {
+              name: 'Column',
+              settings: { heading: 'free-form text' },
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('reports invalid values in section default.settings', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              options: alignmentOptions,
+            },
+          ],
+          default: {
+            settings: { alignment: 'nope' },
+          },
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).toMatch(/alignment/);
+      expect(offenses[0].message).toMatch(/nope/);
+    });
+  });
+});
+
+describe('Module: ValidSelectDefaultSettingsSchema (config/settings_schema.json)', () => {
+  it('reports an invalid default in config/settings_schema.json', async () => {
+    const source = JSON.stringify([
+      {
+        name: 'Layout',
+        settings: [
+          {
+            type: 'select',
+            id: 'alignment',
+            default: 'this-is-not-an-option',
+            options: alignmentOptions,
+          },
+        ],
+      },
+    ]);
+
+    const offenses = await runJSONCheck(
+      ValidSelectDefaultSettingsSchema,
+      source,
+      'config/settings_schema.json',
+    );
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toMatch(/alignment/);
+    expect(offenses[0].message).toMatch(/this-is-not-an-option/);
+  });
+
+  it('does not report a valid default', async () => {
+    const source = JSON.stringify([
+      {
+        name: 'Layout',
+        settings: [
+          {
+            type: 'select',
+            id: 'alignment',
+            default: 'center',
+            options: alignmentOptions,
+          },
+        ],
+      },
+    ]);
+
+    const offenses = await runJSONCheck(
+      ValidSelectDefaultSettingsSchema,
+      source,
+      'config/settings_schema.json',
+    );
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('does not run on files other than settings_schema.json', async () => {
+    const source = JSON.stringify([
+      {
+        name: 'Layout',
+        settings: [
+          {
+            type: 'select',
+            id: 'alignment',
+            default: 'this-is-not-an-option',
+            options: alignmentOptions,
+          },
+        ],
+      },
+    ]);
+
+    const offenses = await runJSONCheck(
+      ValidSelectDefaultSettingsSchema,
+      source,
+      'config/other.json',
+    );
+    expect(offenses).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/valid-select-default/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-select-default/index.spec.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest';
+import { check, runJSONCheck } from '../../test';
+import { ValidSelectDefault, ValidSelectDefaultSettingsSchema } from './index';
+
+function toLiquidFile(content: unknown) {
+  return `
+    {% schema %}
+      ${JSON.stringify(content)}
+    {% endschema %}
+  `;
+}
+
+const alignmentOptions = [
+  { value: 'flex-start', label: 'Left' },
+  { value: 'center', label: 'Center' },
+  { value: 'flex-end', label: 'Right' },
+];
+
+describe('Module: ValidSelectDefault (Liquid schema)', () => {
+  describe('setting defaults', () => {
+    it('does not report when the select default matches an option', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              default: 'center',
+              options: alignmentOptions,
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('reports when the select default is not in options', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              default: 'this-is-not-an-option',
+              options: alignmentOptions,
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).toMatch(/alignment/);
+      expect(offenses[0].message).toMatch(/this-is-not-an-option/);
+      expect(offenses[0].message).toMatch(/flex-start/);
+    });
+
+    it('reports when a radio default is not in options', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'radio',
+              id: 'layout_direction',
+              default: 'bogus',
+              options: [
+                { value: 'row', label: 'Row' },
+                { value: 'column', label: 'Column' },
+              ],
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).toMatch(/layout_direction/);
+      expect(offenses[0].message).toMatch(/bogus/);
+    });
+
+    it('does not report when the setting has no default', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              options: alignmentOptions,
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('ignores non-choice settings', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [{ type: 'text', id: 'heading', default: 'anything' }],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+  });
+
+  describe('preset settings', () => {
+    it('does not report when preset setting matches an option', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              options: alignmentOptions,
+            },
+          ],
+          presets: [
+            {
+              name: 'Column',
+              settings: { alignment: 'flex-end' },
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('reports when preset setting is not in options', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              options: alignmentOptions,
+            },
+          ],
+          presets: [
+            {
+              name: 'Column',
+              settings: { alignment: 'this-is-not-an-option' },
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).toMatch(/alignment/);
+      expect(offenses[0].message).toMatch(/this-is-not-an-option/);
+    });
+
+    it('reports both invalid default and invalid preset setting', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              default: 'bad-default',
+              options: alignmentOptions,
+            },
+          ],
+          presets: [
+            {
+              name: 'Column',
+              settings: { alignment: 'also-bad' },
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(2);
+    });
+
+    it('does not report when preset references a non-select setting', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [{ type: 'text', id: 'heading' }],
+          presets: [
+            {
+              name: 'Column',
+              settings: { heading: 'free-form text' },
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(0);
+    });
+
+    it('reports invalid values in section default.settings', async () => {
+      const theme = {
+        'sections/example.liquid': toLiquidFile({
+          name: 'Example',
+          settings: [
+            {
+              type: 'select',
+              id: 'alignment',
+              options: alignmentOptions,
+            },
+          ],
+          default: {
+            settings: { alignment: 'nope' },
+          },
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSelectDefault]);
+      expect(offenses).toHaveLength(1);
+      expect(offenses[0].message).toMatch(/alignment/);
+      expect(offenses[0].message).toMatch(/nope/);
+    });
+  });
+});
+
+describe('Module: ValidSelectDefaultSettingsSchema (config/settings_schema.json)', () => {
+  it('reports an invalid default in config/settings_schema.json', async () => {
+    const source = JSON.stringify([
+      {
+        name: 'Layout',
+        settings: [
+          {
+            type: 'select',
+            id: 'alignment',
+            default: 'this-is-not-an-option',
+            options: alignmentOptions,
+          },
+        ],
+      },
+    ]);
+
+    const offenses = await runJSONCheck(
+      ValidSelectDefaultSettingsSchema,
+      source,
+      'config/settings_schema.json',
+    );
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toMatch(/alignment/);
+    expect(offenses[0].message).toMatch(/this-is-not-an-option/);
+  });
+
+  it('does not report a valid default', async () => {
+    const source = JSON.stringify([
+      {
+        name: 'Layout',
+        settings: [
+          {
+            type: 'select',
+            id: 'alignment',
+            default: 'center',
+            options: alignmentOptions,
+          },
+        ],
+      },
+    ]);
+
+    const offenses = await runJSONCheck(
+      ValidSelectDefaultSettingsSchema,
+      source,
+      'config/settings_schema.json',
+    );
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('does not run on files other than settings_schema.json', async () => {
+    const source = JSON.stringify([
+      {
+        name: 'Layout',
+        settings: [
+          {
+            type: 'select',
+            id: 'alignment',
+            default: 'this-is-not-an-option',
+            options: alignmentOptions,
+          },
+        ],
+      },
+    ]);
+
+    const offenses = await runJSONCheck(
+      ValidSelectDefaultSettingsSchema,
+      source,
+      'config/other.json',
+    );
+    expect(offenses).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/valid-select-default/index.ts
+++ b/packages/theme-check-common/src/checks/valid-select-default/index.ts
@@ -1,0 +1,262 @@
+import {
+  JSONCheckDefinition,
+  JSONNode,
+  LiquidCheckDefinition,
+  Setting,
+  Severity,
+  SourceCodeType,
+  isArrayNode,
+  isLiteralNode,
+  isObjectNode,
+} from '../../types';
+import { getLocEnd, getLocStart, nodeAtPath } from '../../json';
+import { getSchema, isSectionSchema } from '../../to-schema';
+
+// Note: like ValidVisibleIf, this exports two checks: one for Liquid files
+// ({% schema %} in sections/blocks) and one for 'config/settings_schema.json'.
+// They perform the same check using the same logic (modulo differences in
+// how the schema is extracted and how warning locations are determined).
+
+// Setting is a `declare namespace`, so Setting.Type has no runtime value.
+const CHOICE_SETTING_TYPES = new Set<string>(['select', 'radio']);
+
+const meta = {
+  code: 'ValidSelectDefault',
+  name: 'Validate default values and preset values for select/radio settings',
+  docs: {
+    description:
+      "Warns when a select/radio setting's default value (or a preset's setting value) is not one of the setting's declared options.",
+    recommended: true,
+    url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-select-default',
+  },
+  severity: Severity.WARNING,
+  schema: {},
+  targets: [],
+};
+
+type ChoiceSetting = {
+  id: string;
+  type: string;
+  options: Array<{ value: unknown }>;
+  default?: unknown;
+};
+
+function getChoiceSettings(settings: readonly Setting.Any[] | undefined): ChoiceSetting[] {
+  if (!settings) return [];
+  const result: ChoiceSetting[] = [];
+  for (const setting of settings) {
+    if (!setting || typeof setting !== 'object') continue;
+    if (!('type' in setting) || !CHOICE_SETTING_TYPES.has(setting.type as string)) continue;
+    if (!('id' in setting) || typeof setting.id !== 'string') continue;
+    const options = (setting as { options?: unknown }).options;
+    if (!Array.isArray(options)) continue;
+    result.push(setting as unknown as ChoiceSetting);
+  }
+  return result;
+}
+
+function getAllowedValues(setting: ChoiceSetting): string[] {
+  const values: string[] = [];
+  for (const option of setting.options) {
+    if (option && typeof option === 'object' && 'value' in option) {
+      const value = (option as { value: unknown }).value;
+      if (typeof value === 'string') values.push(value);
+      else if (typeof value === 'number' || typeof value === 'boolean') values.push(String(value));
+    }
+  }
+  return values;
+}
+
+function invalidDefaultMessage(setting: ChoiceSetting, actual: unknown): string {
+  const allowed = getAllowedValues(setting)
+    .map((v) => `"${v}"`)
+    .join(', ');
+  return `Default value ${JSON.stringify(actual)} for setting "${setting.id}" is not one of the valid options: ${allowed}.`;
+}
+
+function invalidPresetMessage(setting: ChoiceSetting, actual: unknown): string {
+  const allowed = getAllowedValues(setting)
+    .map((v) => `"${v}"`)
+    .join(', ');
+  return `Value ${JSON.stringify(actual)} for setting "${setting.id}" is not one of the valid options: ${allowed}.`;
+}
+
+function isValidChoiceValue(setting: ChoiceSetting, value: unknown): boolean {
+  if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+    return true; // leave non-scalar mismatches to JSON schema validation
+  }
+  const allowed = getAllowedValues(setting);
+  return allowed.includes(String(value));
+}
+
+export const ValidSelectDefault: LiquidCheckDefinition = {
+  meta: { ...meta, type: SourceCodeType.LiquidHtml },
+
+  create(context) {
+    return {
+      async LiquidRawTag(node) {
+        if (node.name !== 'schema' || node.body.kind !== 'json') return;
+
+        const schema = await getSchema(context);
+        const { validSchema, ast } = schema ?? {};
+        if (!validSchema || validSchema instanceof Error) return;
+        if (!ast || ast instanceof Error) return;
+
+        const offset = node.blockStartPosition.end;
+        const choiceSettings = getChoiceSettings(validSchema.settings);
+        if (choiceSettings.length === 0) return;
+
+        const settingsById = new Map(choiceSettings.map((s) => [s.id, s]));
+
+        // 1. Validate setting defaults
+        for (let i = 0; i < (validSchema.settings?.length ?? 0); i++) {
+          const setting = validSchema.settings![i];
+          if (!setting || !('id' in setting)) continue;
+          const choice = settingsById.get(setting.id as string);
+          if (!choice) continue;
+          if (!('default' in choice) || choice.default === undefined) continue;
+
+          if (!isValidChoiceValue(choice, choice.default)) {
+            const defaultNode = nodeAtPath(ast, ['settings', i, 'default']);
+            if (defaultNode) {
+              reportAtNode(context, offset, defaultNode, invalidDefaultMessage(choice, choice.default));
+            }
+          }
+        }
+
+        // 2. Validate presets[].settings values
+        if (Array.isArray(validSchema.presets)) {
+          for (let i = 0; i < validSchema.presets.length; i++) {
+            validatePresetSettings(
+              context,
+              offset,
+              ast,
+              ['presets', String(i), 'settings'],
+              (validSchema.presets[i] as { settings?: Record<string, unknown> }).settings,
+              settingsById,
+            );
+          }
+        }
+
+        // 3. Validate section default.settings values
+        if (isSectionSchema(schema) && 'default' in validSchema && validSchema.default?.settings) {
+          validatePresetSettings(
+            context,
+            offset,
+            ast,
+            ['default', 'settings'],
+            validSchema.default.settings as Record<string, unknown>,
+            settingsById,
+          );
+        }
+      },
+    };
+  },
+};
+
+function validatePresetSettings(
+  context: Parameters<LiquidCheckDefinition['create']>[0],
+  offset: number,
+  ast: JSONNode,
+  settingsPath: string[],
+  settings: Record<string, unknown> | undefined,
+  settingsById: Map<string, ChoiceSetting>,
+) {
+  if (!settings) return;
+  const settingsNode = nodeAtPath(ast, settingsPath);
+  if (!settingsNode || !isObjectNode(settingsNode)) return;
+
+  for (const property of settingsNode.children) {
+    const key = property.key.value;
+    if (typeof key !== 'string') continue;
+    const choice = settingsById.get(key);
+    if (!choice) continue;
+
+    const valueNode = property.value;
+    if (!isLiteralNode(valueNode)) continue;
+
+    if (!isValidChoiceValue(choice, valueNode.value)) {
+      reportAtNode(context, offset, valueNode, invalidPresetMessage(choice, valueNode.value));
+    }
+  }
+}
+
+function reportAtNode(
+  context: Parameters<LiquidCheckDefinition['create']>[0],
+  offset: number,
+  astNode: JSONNode,
+  message: string,
+) {
+  context.report({
+    message,
+    startIndex: offset + getLocStart(astNode),
+    endIndex: offset + getLocEnd(astNode),
+  });
+}
+
+export const ValidSelectDefaultSettingsSchema: JSONCheckDefinition = {
+  meta: { ...meta, type: SourceCodeType.JSON },
+
+  create(context) {
+    const relativePath = context.toRelativePath(context.file.uri);
+    if (relativePath !== 'config/settings_schema.json') return {};
+
+    return {
+      async Property(node) {
+        if (node.key.value !== 'settings' || !isArrayNode(node.value)) return;
+
+        for (const settingNode of node.value.children) {
+          if (!isObjectNode(settingNode)) continue;
+
+          const typeProp = settingNode.children.find((p) => p.key.value === 'type');
+          if (!typeProp || !isLiteralNode(typeProp.value)) continue;
+          const typeValue = typeProp.value.value;
+          if (typeof typeValue !== 'string' || !CHOICE_SETTING_TYPES.has(typeValue)) continue;
+
+          const idProp = settingNode.children.find((p) => p.key.value === 'id');
+          const idValue =
+            idProp && isLiteralNode(idProp.value) && typeof idProp.value.value === 'string'
+              ? idProp.value.value
+              : undefined;
+
+          const optionsProp = settingNode.children.find((p) => p.key.value === 'options');
+          if (!optionsProp || !isArrayNode(optionsProp.value)) continue;
+
+          const allowedValues: string[] = [];
+          for (const optionNode of optionsProp.value.children) {
+            if (!isObjectNode(optionNode)) continue;
+            const valueProp = optionNode.children.find((p) => p.key.value === 'value');
+            if (!valueProp || !isLiteralNode(valueProp.value)) continue;
+            const v = valueProp.value.value;
+            if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+              allowedValues.push(String(v));
+            }
+          }
+
+          const defaultProp = settingNode.children.find((p) => p.key.value === 'default');
+          if (!defaultProp || !isLiteralNode(defaultProp.value)) continue;
+          const defaultValue = defaultProp.value.value;
+          if (
+            typeof defaultValue !== 'string' &&
+            typeof defaultValue !== 'number' &&
+            typeof defaultValue !== 'boolean'
+          ) {
+            continue;
+          }
+
+          if (!allowedValues.includes(String(defaultValue))) {
+            const id = idValue ?? 'unknown';
+            const allowed = allowedValues.map((v) => `"${v}"`).join(', ');
+            context.report({
+              message: `Default value ${JSON.stringify(
+                defaultValue,
+              )} for setting "${id}" is not one of the valid options: ${allowed}.`,
+              startIndex: getLocStart(defaultProp.value),
+              endIndex: getLocEnd(defaultProp.value),
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/valid-select-default/index.ts
+++ b/packages/theme-check-common/src/checks/valid-select-default/index.ts
@@ -1,0 +1,267 @@
+import {
+  JSONCheckDefinition,
+  JSONNode,
+  LiquidCheckDefinition,
+  Setting,
+  Severity,
+  SourceCodeType,
+  isArrayNode,
+  isLiteralNode,
+  isObjectNode,
+} from '../../types';
+import { getLocEnd, getLocStart, nodeAtPath } from '../../json';
+import { getSchema, isSectionSchema } from '../../to-schema';
+
+// Note: like ValidVisibleIf, this exports two checks: one for Liquid files
+// ({% schema %} in sections/blocks) and one for 'config/settings_schema.json'.
+// They perform the same check using the same logic (modulo differences in
+// how the schema is extracted and how warning locations are determined).
+
+// Setting is a `declare namespace`, so Setting.Type has no runtime value.
+const CHOICE_SETTING_TYPES = new Set<string>(['select', 'radio']);
+
+const meta = {
+  code: 'ValidSelectDefault',
+  name: 'Validate default values and preset values for select/radio settings',
+  docs: {
+    description:
+      "Warns when a select/radio setting's default value (or a preset's setting value) is not one of the setting's declared options.",
+    recommended: true,
+    url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-select-default',
+  },
+  severity: Severity.WARNING,
+  schema: {},
+  targets: [],
+};
+
+type ChoiceSetting = {
+  id: string;
+  type: string;
+  options: Array<{ value: unknown }>;
+  default?: unknown;
+};
+
+function getChoiceSettings(settings: readonly Setting.Any[] | undefined): ChoiceSetting[] {
+  if (!settings) return [];
+  const result: ChoiceSetting[] = [];
+  for (const setting of settings) {
+    if (!setting || typeof setting !== 'object') continue;
+    if (!('type' in setting) || !CHOICE_SETTING_TYPES.has(setting.type as string)) continue;
+    if (!('id' in setting) || typeof setting.id !== 'string') continue;
+    const options = (setting as { options?: unknown }).options;
+    if (!Array.isArray(options)) continue;
+    result.push(setting as unknown as ChoiceSetting);
+  }
+  return result;
+}
+
+function getAllowedValues(setting: ChoiceSetting): string[] {
+  const values: string[] = [];
+  for (const option of setting.options) {
+    if (option && typeof option === 'object' && 'value' in option) {
+      const value = (option as { value: unknown }).value;
+      if (typeof value === 'string') values.push(value);
+      else if (typeof value === 'number' || typeof value === 'boolean') values.push(String(value));
+    }
+  }
+  return values;
+}
+
+function invalidDefaultMessage(setting: ChoiceSetting, actual: unknown): string {
+  const allowed = getAllowedValues(setting)
+    .map((v) => `"${v}"`)
+    .join(', ');
+  return `Default value ${JSON.stringify(actual)} for setting "${setting.id}" is not one of the valid options: ${allowed}.`;
+}
+
+function invalidPresetMessage(setting: ChoiceSetting, actual: unknown): string {
+  const allowed = getAllowedValues(setting)
+    .map((v) => `"${v}"`)
+    .join(', ');
+  return `Value ${JSON.stringify(actual)} for setting "${setting.id}" is not one of the valid options: ${allowed}.`;
+}
+
+function isValidChoiceValue(setting: ChoiceSetting, value: unknown): boolean {
+  if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+    return true; // leave non-scalar mismatches to JSON schema validation
+  }
+  const allowed = getAllowedValues(setting);
+  return allowed.includes(String(value));
+}
+
+export const ValidSelectDefault: LiquidCheckDefinition = {
+  meta: { ...meta, type: SourceCodeType.LiquidHtml },
+
+  create(context) {
+    return {
+      async LiquidRawTag(node) {
+        if (node.name !== 'schema' || node.body.kind !== 'json') return;
+
+        const schema = await getSchema(context);
+        const { validSchema, ast } = schema ?? {};
+        if (!validSchema || validSchema instanceof Error) return;
+        if (!ast || ast instanceof Error) return;
+
+        const offset = node.blockStartPosition.end;
+        const choiceSettings = getChoiceSettings(validSchema.settings);
+        if (choiceSettings.length === 0) return;
+
+        const settingsById = new Map(choiceSettings.map((s) => [s.id, s]));
+
+        // 1. Validate setting defaults
+        for (let i = 0; i < (validSchema.settings?.length ?? 0); i++) {
+          const setting = validSchema.settings![i];
+          if (!setting || !('id' in setting)) continue;
+          const choice = settingsById.get(setting.id as string);
+          if (!choice) continue;
+          if (!('default' in choice) || choice.default === undefined) continue;
+
+          if (!isValidChoiceValue(choice, choice.default)) {
+            const defaultNode = nodeAtPath(ast, ['settings', i, 'default']);
+            if (defaultNode) {
+              reportAtNode(
+                context,
+                offset,
+                defaultNode,
+                invalidDefaultMessage(choice, choice.default),
+              );
+            }
+          }
+        }
+
+        // 2. Validate presets[].settings values
+        if (Array.isArray(validSchema.presets)) {
+          for (let i = 0; i < validSchema.presets.length; i++) {
+            validatePresetSettings(
+              context,
+              offset,
+              ast,
+              ['presets', String(i), 'settings'],
+              (validSchema.presets[i] as { settings?: Record<string, unknown> }).settings,
+              settingsById,
+            );
+          }
+        }
+
+        // 3. Validate section default.settings values
+        if (isSectionSchema(schema) && 'default' in validSchema && validSchema.default?.settings) {
+          validatePresetSettings(
+            context,
+            offset,
+            ast,
+            ['default', 'settings'],
+            validSchema.default.settings as Record<string, unknown>,
+            settingsById,
+          );
+        }
+      },
+    };
+  },
+};
+
+function validatePresetSettings(
+  context: Parameters<LiquidCheckDefinition['create']>[0],
+  offset: number,
+  ast: JSONNode,
+  settingsPath: string[],
+  settings: Record<string, unknown> | undefined,
+  settingsById: Map<string, ChoiceSetting>,
+) {
+  if (!settings) return;
+  const settingsNode = nodeAtPath(ast, settingsPath);
+  if (!settingsNode || !isObjectNode(settingsNode)) return;
+
+  for (const property of settingsNode.children) {
+    const key = property.key.value;
+    if (typeof key !== 'string') continue;
+    const choice = settingsById.get(key);
+    if (!choice) continue;
+
+    const valueNode = property.value;
+    if (!isLiteralNode(valueNode)) continue;
+
+    if (!isValidChoiceValue(choice, valueNode.value)) {
+      reportAtNode(context, offset, valueNode, invalidPresetMessage(choice, valueNode.value));
+    }
+  }
+}
+
+function reportAtNode(
+  context: Parameters<LiquidCheckDefinition['create']>[0],
+  offset: number,
+  astNode: JSONNode,
+  message: string,
+) {
+  context.report({
+    message,
+    startIndex: offset + getLocStart(astNode),
+    endIndex: offset + getLocEnd(astNode),
+  });
+}
+
+export const ValidSelectDefaultSettingsSchema: JSONCheckDefinition = {
+  meta: { ...meta, type: SourceCodeType.JSON },
+
+  create(context) {
+    const relativePath = context.toRelativePath(context.file.uri);
+    if (relativePath !== 'config/settings_schema.json') return {};
+
+    return {
+      async Property(node) {
+        if (node.key.value !== 'settings' || !isArrayNode(node.value)) return;
+
+        for (const settingNode of node.value.children) {
+          if (!isObjectNode(settingNode)) continue;
+
+          const typeProp = settingNode.children.find((p) => p.key.value === 'type');
+          if (!typeProp || !isLiteralNode(typeProp.value)) continue;
+          const typeValue = typeProp.value.value;
+          if (typeof typeValue !== 'string' || !CHOICE_SETTING_TYPES.has(typeValue)) continue;
+
+          const idProp = settingNode.children.find((p) => p.key.value === 'id');
+          const idValue =
+            idProp && isLiteralNode(idProp.value) && typeof idProp.value.value === 'string'
+              ? idProp.value.value
+              : undefined;
+
+          const optionsProp = settingNode.children.find((p) => p.key.value === 'options');
+          if (!optionsProp || !isArrayNode(optionsProp.value)) continue;
+
+          const allowedValues: string[] = [];
+          for (const optionNode of optionsProp.value.children) {
+            if (!isObjectNode(optionNode)) continue;
+            const valueProp = optionNode.children.find((p) => p.key.value === 'value');
+            if (!valueProp || !isLiteralNode(valueProp.value)) continue;
+            const v = valueProp.value.value;
+            if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+              allowedValues.push(String(v));
+            }
+          }
+
+          const defaultProp = settingNode.children.find((p) => p.key.value === 'default');
+          if (!defaultProp || !isLiteralNode(defaultProp.value)) continue;
+          const defaultValue = defaultProp.value.value;
+          if (
+            typeof defaultValue !== 'string' &&
+            typeof defaultValue !== 'number' &&
+            typeof defaultValue !== 'boolean'
+          ) {
+            continue;
+          }
+
+          if (!allowedValues.includes(String(defaultValue))) {
+            const id = idValue ?? 'unknown';
+            const allowed = allowedValues.map((v) => `"${v}"`).join(', ');
+            context.report({
+              message: `Default value ${JSON.stringify(
+                defaultValue,
+              )} for setting "${id}" is not one of the valid options: ${allowed}.`,
+              startIndex: getLocStart(defaultProp.value),
+              endIndex: getLocEnd(defaultProp.value),
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -202,6 +202,9 @@ ValidSchemaTranslations:
 ValidScopedCSSClass:
   enabled: true
   severity: 1
+ValidSelectDefault:
+  enabled: true
+  severity: 1
 ValidSettingsKey:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -180,6 +180,9 @@ ValidSchemaTranslations:
 ValidScopedCSSClass:
   enabled: true
   severity: 1
+ValidSelectDefault:
+  enabled: true
+  severity: 1
 ValidSettingsKey:
   enabled: true
   severity: 0


### PR DESCRIPTION
## What are you adding in this PR?

This adds a new theme-check, `ValidSelectDefault`, that warns when a `select` or `radio` setting's `default` value isn't one of the values declared in its `options`. Today you can ship a schema whose `default` doesn't exist in `options` and theme-check stays silent. The merchant then sees the editor silently fall back to the first option (or no selection), which is confusing and easy to miss in review.

`solves #943`

The check validates three places:

- A setting's `default` value.
- A preset's `settings` values (`presets[i].settings`).
- A section's `default.settings` values.

It runs in two variants, mirroring `ValidVisibleIf`:

- `ValidSelectDefault` (`LiquidCheck`) → `{% schema %}` in `sections/*.liquid` and `blocks/*.liquid`.
- `ValidSelectDefaultSettingsSchema` (`JSONCheck`) → `config/settings_schema.json`.

Severity is `WARNING` and it's `recommended: true`, so it surfaces out of the box without blocking themes that have legacy schemas.

### Example

```json
{
  "type": "select",
  "id": "alignment",
  "default": "this-is-not-an-option",
  "options": [
    { "value": "flex-start", "label": "t:options.alignment.left" },
    { "value": "center",     "label": "t:options.alignment.center" },
    { "value": "flex-end",   "label": "t:options.alignment.right" }
  ]
}
```

Now warns: `Default value "this-is-not-an-option" for setting "alignment" is not one of the valid options: "flex-start", "center", "flex-end".`

The preset case from the issue gets a warning pointing right at the offending value inside `presets[i].settings`.

## What's next? Any followup issues?

None planned. The check leaves non-scalar mismatches to JSON schema validation, so it stays focused on the select/radio option case.

## What did you learn?

The factory configs (`all.yml` / `recommended.yml`) are generated from `meta.code`, so two checks sharing the same `code` (the Liquid + JSON variants, like `ValidVisibleIf`) collapse to a single config entry.

## Tophatting

- [ ] I added screenshots of the changes (before and after the changes if applicable)

Tested via unit tests rather than screenshots (this is a non-visual lint check). 13 new tests in `valid-select-default/index.spec.ts` cover:

- valid + invalid `default` for `select` and `radio`
- setting with no `default` (no-op)
- non-choice settings left alone
- valid + invalid preset values
- preset referencing a non-select setting (no-op)
- section `default.settings` invalid value
- `config/settings_schema.json` via the `JSONCheck` variant (valid, invalid, wrong-file path)
- combined default + preset case reporting both

```
✓ packages/theme-check-common/src/checks/valid-select-default/index.spec.ts (13 tests)
```

The full `theme-check-common` checks suite stays green (780 tests across 79 files), and `tsc --noEmit` passes.

## Before you deploy

- [x] This PR includes a new check
  - [x] I included a minor bump `changeset`
  - [x] I ran `pnpm build` and committed the updated configuration files (`all.yml`, `recommended.yml`)
    - [ ] If applicable, I've updated the `theme-app-extension.yml` config — not applicable; the check is generally relevant and isn't theme-app-extension specific.
    - [ ] [Shopifolk] I've made a PR to update the shopify.dev theme check docs — N/A (not a Shopifolk).

- [x] My feature is backward compatible
