### PR TITLE
fix: allow theme-check-disable-next-line to suppress checks inside doc tags

### DIFF
--- a/.changeset/fix-disable-doc-tag.md
+++ b/.changeset/fix-disable-doc-tag.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fix theme-check-disable-next-line not working for checks inside doc tags

--- a/packages/theme-check-common/src/disabled-checks/index.spec.ts
+++ b/packages/theme-check-common/src/disabled-checks/index.spec.ts
@@ -3,6 +3,7 @@ import { Offense } from '..';
 import { describe, it, expect } from 'vitest';
 import { LiquidFilter, RenderMarkup } from './test-checks';
 import { UndefinedObject } from '../checks/undefined-object';
+import { UniqueDocParamNames } from '../checks/unique-doc-param-names';
 
 const commentTypes = [
   (text: string) => `{% # ${text} %}`,
@@ -254,6 +255,43 @@ ${buildComment('theme-check-enable')}
         expect(offenses).toContainEqual(
           expect.objectContaining({
             message: "Unknown object 'foo' used.",
+          }),
+        );
+      });
+
+      it('should disable checks inside doc tags when disable-next-line is placed before the doc tag', async () => {
+        const file = `{% # theme-check-disable-next-line UniqueDocParamNames %}
+{% doc %}
+  @param foo - first param
+  @param foo - duplicate param
+{% enddoc %}`;
+
+        const offenses = await check({ 'code.liquid': file }, [UniqueDocParamNames]);
+        expect(offenses).to.have.length(0);
+      });
+
+      it('should disable all checks inside doc tags when disable-next-line is used without specific check names', async () => {
+        const file = `{% # theme-check-disable-next-line %}
+{% doc %}
+  @param bar - first param
+  @param bar - duplicate param
+{% enddoc %}`;
+
+        const offenses = await check({ 'code.liquid': file }, [UniqueDocParamNames]);
+        expect(offenses).to.have.length(0);
+      });
+
+      it('should still report offenses in doc tags when disable-next-line is not present', async () => {
+        const file = `{% doc %}
+  @param baz - first param
+  @param baz - duplicate param
+{% enddoc %}`;
+
+        const offenses = await check({ 'code.liquid': file }, [UniqueDocParamNames]);
+        expect(offenses).to.have.length(1);
+        expect(offenses).toContainEqual(
+          expect.objectContaining({
+            message: "The parameter 'baz' is defined more than once.",
           }),
         );
       });

--- a/packages/theme-check-common/src/disabled-checks/index.ts
+++ b/packages/theme-check-common/src/disabled-checks/index.ts
@@ -154,8 +154,16 @@ export function findNextLinePosition(
   /*
    * If the node contains children nodes, we don't want to disable checks for them.
    * We want to keep it exclusively to the tag itself.
+   *
+   * Exception: For `{% doc %}` tags, the checks we care about (ValidDocParamTypes,
+   * UniqueDocParamNames, ReservedDocParamNames, etc.) report offenses at positions
+   * inside the doc body. Using only `blockStartPosition` would miss those offenses,
+   * so we use the full `position` span to cover the entire tag including its body.
    */
   if ('blockStartPosition' in nextNode) {
+    if (nextNode.type === LiquidHtmlNodeTypes.LiquidRawTag && nextNode.name === 'doc') {
+      return nextNode.position;
+    }
     return nextNode.blockStartPosition;
   }
 


### PR DESCRIPTION
## What are you adding in this PR?

Fixes the case where `{% # theme-check-disable-next-line %}` placed before a `{% doc %}` tag does not actually suppress the checks that run against the doc tag's contents.

Today, when a snippet has a duplicate `@param` you intentionally want to keep, the only workaround is wrapping the whole tag in a disable/enable pair:

```liquid
{% # theme-check-disable-next-line UniqueDocParamNames %}
{% doc %}
  @param prods - products
  @param prods - intentional duplicate
{% enddoc %}
```

This is verbose. The single-line `disable-next-line` should just work.

**Root cause:** `findNextLinePosition` in `disabled-checks/index.ts` has a guard for block tags. When the next node has a `blockStartPosition` (like `{% if %}`, `{% for %}`, `{% doc %}`), it returns only `blockStartPosition` instead of the full `position`. That guard is there so `disable-next-line` does not accidentally suppress checks on nested children of control flow tags. But doc tag checks (`UniqueDocParamNames`, `ValidDocParamTypes`, `ReservedDocParamNames`) report offenses at positions *inside* the doc body, so they fall outside `blockStartPosition` and are never suppressed.

**Fix:** when the next node is a `LiquidRawTag` with `name === 'doc'`, return the full `position` span instead of `blockStartPosition`. Safe because doc tag bodies are parsed by a separate grammar (`LiquidDocGrammar`) that only produces doc-specific nodes (`@param`, `@description`, `@example`), so there is no risk of accidentally silencing unrelated checks on nested control flow.

The change is a 4-line conditional in `findNextLinePosition`.

Three new test cases were added to `disabled-checks/index.spec.ts`:
- `disable-next-line UniqueDocParamNames` before a doc tag with a duplicate param suppresses the offense
- `disable-next-line` (no specific check) suppresses all checks inside the doc tag
- Without the disable comment, the offense still fires (regression guard)

All 18 tests pass (15 existing + 3 new).

Closes #945

## What's next? Any followup issues?

None planned. The narrow scope here (only `{% doc %}`, only when matched as the "next node") avoids the larger question of how to support `disable-next-line` *inside* a doc tag body, which is a separate problem because `LiquidDocGrammar` does not parse Liquid tags at all, so the comment would never appear as a `LiquidTag` node in the first place. That's out of scope for this PR.

## What did you learn?

The `blockStartPosition` guard in `findNextLinePosition` is correct for control flow tags (`{% if %}`, `{% for %}`) and the wrong default for "leaf-ish" block tags like `{% doc %}` whose children are themselves the thing being checked. Worth keeping in mind if other block tags in the future also report offenses on their inner nodes rather than on their wrappers.

## Tophatting

In a theme with a snippet that intentionally duplicates a `@param` for documentation purposes:

```liquid
{% # theme-check-disable-next-line UniqueDocParamNames %}
{% doc %}
  @param prods - products
  @param prods - intentional duplicate
{% enddoc %}
```

- Before this PR: `UniqueDocParamNames` still reports an offense.
- After this PR: the offense is suppressed.

Also confirm that `disable-next-line` before a regular block (e.g. `{% if %}`) still only disables the opening line, not the children inside.

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump \`changeset\` (\`@shopify/theme-check-common: patch\`)