### PR TITLE
fix(prettier-plugin-liquid): preserve U+00A0 and don't drop borrowed closing tags

### DIFF
--- a/.changeset/preserve-nbsp-html-text.md
+++ b/.changeset/preserve-nbsp-html-text.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+---
+
+Preserve non-breaking spaces (U+00A0) in HTML text nodes and stop dropping borrowed closing tag markers when a text node is pure whitespace.

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -158,7 +158,19 @@ function printTextNode(
 
   if (isYamlFrontMatter(node)) return node.value;
 
-  if (node.value.match(/^\s*$/)) return '';
+  // Only ASCII/HTML whitespace is collapsible. Do not treat U+00A0 (NBSP) or
+  // other unicode "whitespace" as collapsible, since they are meaningful
+  // characters in the rendered output.
+  const HTML_WHITESPACE_RUN = /[ \t\n\r\f]+/g;
+  const HTML_WHITESPACE_TRIM = /^[ \t\n\r\f]+|[ \t\n\r\f]+$/g;
+
+  // If the text is purely collapsible whitespace we still need to emit the
+  // open/close prefixes so that any tag markers borrowed from the parent
+  // aren't lost (see needsToBorrowParentClosingTagStartMarker).
+  if (node.value.replace(HTML_WHITESPACE_RUN, '') === '') {
+    return [printOpeningTagPrefix(node, options), printClosingTagSuffix(node, options)];
+  }
+
   const text = node.value;
 
   const paragraphs = text
@@ -166,7 +178,7 @@ function printTextNode(
     .filter(Boolean) // removes empty paragraphs (trailingWhitespace)
     .map((curr) => {
       let doc = [];
-      const words = curr.trim().split(/\s+/g);
+      const words = curr.replace(HTML_WHITESPACE_TRIM, '').split(HTML_WHITESPACE_RUN);
       let isFirst = true;
       for (let j = 0; j < words.length; j++) {
         const word = words[j];

--- a/packages/prettier-plugin-liquid/src/test/unit-paragraphs/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/unit-paragraphs/fixed.liquid
@@ -74,3 +74,8 @@ printWidth: 20
     >Lorem Ipsum</span
   >
 </p>
+
+it should preserve non-breaking spaces (U+00A0) as text and not drop borrowed closing tags
+<p>
+  <strong><em> </em></strong>
+</p>

--- a/packages/prettier-plugin-liquid/src/test/unit-paragraphs/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/unit-paragraphs/index.liquid
@@ -56,3 +56,6 @@ printWidth: 20
 <p>
   {{ drop }}<span>Lorem Ipsum</span>
 </p>
+
+it should preserve non-breaking spaces (U+00A0) as text and not drop borrowed closing tags
+<p><strong><em> </em></strong></p>


### PR DESCRIPTION
## What are you adding in this PR?

Fix a `@shopify/prettier-plugin-liquid` bug where formatting an HTML text node containing only a non-breaking space (U+00A0) inside borrowed-closing-tag contexts produced broken output:

Input:

```liquid
<p><strong><em>\u00A0</em></strong></p>
```

Previous output (incorrect — both the NBSP and the `</em>` are lost):

```liquid
<p>
  <strong><em></strong>
</p>
```

Expected output (preserves the NBSP and the `</em>`):

```liquid
<p>
  <strong><em> </em></strong>
</p>
```

### Root cause

`printTextNode` short-circuited whitespace-only text with `return ''`. Two problems:

1. JavaScript's `\s` matches U+00A0, but in HTML a non-breaking space is a meaningful character and must not be collapsed away.
2. The early `return ''` skipped `printOpeningTagPrefix` / `printClosingTagSuffix`, which is exactly where tag markers borrowed from the parent (see `needsToBorrowParentClosingTagStartMarker`) are emitted. When that runs on a whitespace-only text node, the borrowed `</em>` marker gets silently dropped.

### Fix (`packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts`)

- Use the HTML whitespace set `[ \t\n\r\f]` instead of `\s` for the short-circuit, the trim, and the word split — so U+00A0 (and other non-collapsible Unicode "whitespace") flows through as a regular character.
- When the text really is pure HTML whitespace, still emit `printOpeningTagPrefix` / `printClosingTagSuffix` so any borrowed open/close markers survive.

Adds a regression case to the `unit-paragraphs` printer fixture covering `<p><strong><em>\u00A0</em></strong></p>`.

## What's next? Any followup issues?

None.

## What did you learn?

`\s` in JavaScript matches U+00A0 — which is fine for "is this byte whitespace-ish", but wrong any time you actually care about HTML semantics, where NBSP is non-collapsible content. Whenever a printer special-cases "whitespace-only" nodes, the early-return path also has to honor whatever work the surrounding tag-borrowing logic relies on.

## Tophatting

- [ ] I added screenshots of the changes (before and after the changes if applicable)

Repro / verification:

```bash
yarn workspace @shopify/prettier-plugin-liquid test
```

The new fixture under `unit-paragraphs` (`it should preserve non-breaking spaces (U+00A0) as text and not drop borrowed closing tags`) covers the regression.

## Before you deploy

- [x] I included a patch bump `changeset` (`.changeset/preserve-nbsp-html-text.md`)