### PR TITLE
fix(prettier-plugin-liquid): route standalone externals to prettier/standalone

### DIFF
--- a/.changeset/fix-standalone-prettier-import.md
+++ b/.changeset/fix-standalone-prettier-import.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+---
+
+Fix standalone build importing `prettier` instead of `prettier/standalone`, which caused browser bundlers (webpack, rollup, vite) consuming `standalone.js` to try to resolve Node builtins (`module`, `url`, `path`) from prettier's main entry

--- a/packages/prettier-plugin-liquid/webpack.config.js
+++ b/packages/prettier-plugin-liquid/webpack.config.js
@@ -15,9 +15,18 @@ module.exports = {
     },
   },
   externals: {
+    // The standalone bundle is browser-only. Downstream bundlers that consume
+    // standalone.js (webpack, rollup, vite) see a UMD wrapper whose `commonjs`
+    // and `commonjs2` branches `require('prettier')`. That import resolves to
+    // prettier's Node-flavored main entry, which pulls in `module`, `url`, and
+    // `path` and breaks browser builds. Route those branches to
+    // `prettier/standalone` so downstream bundlers land on prettier's
+    // browser-safe entry. `root: 'prettier'` is kept so <script>-tag loading
+    // still works against the global `window.prettier` populated by
+    // `prettier/standalone.js` on the page.
     prettier: {
-      commonjs: 'prettier',
-      commonjs2: 'prettier',
+      commonjs: 'prettier/standalone',
+      commonjs2: 'prettier/standalone',
       amd: 'prettier/standalone',
       root: 'prettier',
     },


### PR DESCRIPTION
## What is this PR?

Fixes [#1098](https://github.com/Shopify/theme-tools/issues/1098). The standalone browser bundle of `@shopify/prettier-plugin-liquid` has been emitting `require("prettier")` in its UMD wrapper, which breaks browser consumers because prettier's main entry imports Node builtins (`module`, `url`, `path`).

## What was the issue?

The reporter's screenshot on the issue shows three webpack errors when consuming `standalone.js` from a browser build:

```
ERROR in ./node_modules/prettier/index.mjs
  Module not found: Error: Can't resolve 'module' in '…/node_modules/prettier'
ERROR in ./node_modules/prettier/index.mjs
  Module not found: Error: Can't resolve 'url'
ERROR in ./node_modules/prettier/index.mjs
  Module not found: Error: Can't resolve 'path'
```

The root cause is the webpack `externals` declaration at `packages/prettier-plugin-liquid/webpack.config.js`:

```js
externals: {
  prettier: {
    commonjs: 'prettier',        // wrong
    commonjs2: 'prettier',       // wrong
    amd: 'prettier/standalone',  // correct
    root: 'prettier',            // correct — script tag global
  },
},
```

The generated UMD wrapper checks `commonjs`/`commonjs2` first (because `module.exports` is defined), so downstream bundlers target those branches and get `require("prettier")`. That resolves to `prettier/index.mjs`, which is the full Node-flavored entry that imports `module`, `url`, and `path`. Those are Node builtins and cannot be resolved for browser targets.

The intended browser entry, `prettier/standalone`, is browser-safe and already correctly wired for the AMD branch.

## How this PR fixes it

One-file change in `webpack.config.js`: route the `commonjs` and `commonjs2` keys to `prettier/standalone`, matching the `amd` branch. The `root: 'prettier'` key stays as-is because a `<script>` tag for `prettier/standalone.js` still populates `window.prettier`, so the global name is unchanged.

## Verification

After the fix, the top of the freshly built `standalone.js` now shows:

```js
(function webpackUniversalModuleDefinition(root, factory) {
    if(typeof exports === 'object' && typeof module === 'object')
        module.exports = factory(require("prettier/standalone"));
    else if(typeof define === 'function' && define.amd)
        define(["prettier/standalone"], factory);
    else if(typeof exports === 'object')
        exports["prettierPluginLiquid"] = factory(require("prettier/standalone"));
    else
        root["prettierPluginLiquid"] = factory(root["prettier"]);
})(this, …);
```

`grep 'require("prettier")' standalone.js` returns zero matches. All references to prettier inside the bundle are now routed through the browser-safe entry.

## Tests

All 141 existing `prettier-plugin-liquid` tests still pass. No existing test covered the build output of `standalone.js` (the test suite is formatter-input/output scenarios run through Node), and the fix is entirely a build-configuration change.

Closes #1098