### PR TITLE
fix(parser): allow dot-lookup property names to start with a digit

### DIFF
--- a/.changeset/fix-dot-lookup-digit-property.md
+++ b/.changeset/fix-dot-lookup-digit-property.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': minor
+---
+
+Allow property names starting with a digit in dot lookups (e.g. `{{ address.2country.name }}`). This fixes an autocomplete regression in the language server where suggestions were silently dropped after a property whose name started with a number, because the grammar treated the dot lookup as an unparseable token. `variableSegment` (used for variable declarations and filter names) is unchanged and still rejects leading digits.

--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -285,7 +285,12 @@ Liquid <: Helpers {
     | indexLookup<delim>
     | dotLookup
   indexLookup<delim> = space* "[" space* liquidExpression<delim> space* "]"
-  dotLookup = space* "." space* identifier
+  dotLookup = space* "." space* propertyName
+  // Property names accessed via dot lookup can start with a digit
+  // (e.g. `settings.2country`). This differs from `variableSegment`, which
+  // is used for variable declarations and filter names where leading
+  // digits are not allowed.
+  propertyName = (letter | "_" | digit) (~endOfTagName identifierCharacter)* "?"?
 
   liquidFilter<delim> = space* "|" space* identifier (space* ":" space* arguments<delim> (space* ",")?)?
 
@@ -583,6 +588,7 @@ WithPlaceholderLiquid <: Liquid {
     snippetExpression renderVariableExpression? renderAliasExpression? completionModeRenderArguments
   liquidTagName := (letter | "█") (alnum | "_")*
   variableSegment := (letter | "_" | "█") (identifierCharacter | "█")*
+  propertyName := (letter | "_" | digit | "█") (identifierCharacter | "█")* "?"?
   liquidDoc :=
     liquidDocStart
       liquidDocBody
@@ -597,6 +603,7 @@ WithPlaceholderLiquidStatement <: LiquidStatement {
     snippetExpression renderVariableExpression? renderAliasExpression? completionModeRenderArguments
   liquidTagName := (letter | "█") (alnum | "_")*
   variableSegment := (letter | "_" | "█") (identifierCharacter | "█")*
+  propertyName := (letter | "_" | digit | "█") (identifierCharacter | "█")* "?"?
   liquidDoc :=
     liquidDocStart
       liquidDocBody
@@ -611,6 +618,7 @@ WithPlaceholderLiquidHTML <: LiquidHTML {
     snippetExpression renderVariableExpression? renderAliasExpression? completionModeRenderArguments
   liquidTagName := (letter | "█") (alnum | "_")*
   variableSegment := (letter | "_" | "█") (identifierCharacter | "█")*
+  propertyName := (letter | "_" | digit | "█") (identifierCharacter | "█")* "?"?
   leadingTagNameTextNode := (letter | "█") (alnum | "-" | ":" | "█")*
   trailingTagNameTextNode := (alnum | "-" | ":" | "█")+
   liquidDoc :=

--- a/packages/liquid-html-parser/src/stage-1-cst.spec.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.spec.ts
@@ -174,6 +174,9 @@ describe('Unit: Stage 1 (CST)', () => {
           { expression: `x["y"].z`, name: 'x', lookups: ['y', 'z'] },
           { expression: `["product"]`, name: null, lookups: ['product'] },
           { expression: `page.about-us`, name: 'page', lookups: ['about-us'] },
+          // Property names (dot lookup targets) can start with a digit
+          { expression: `address.2country`, name: 'address', lookups: ['2country'] },
+          { expression: `address.2country.name`, name: 'address', lookups: ['2country', 'name'] },
           { expression: `["x"].y`, name: null, lookups: ['x', 'y'] },
           { expression: `["x"]["y"]`, name: null, lookups: ['x', 'y'] },
           { expression: `x[y]`, name: 'x', lookups: [v('y')] },
@@ -1881,6 +1884,17 @@ describe('Unit: Stage 1 (CST)', () => {
       expectPath(cst, '0.markup.expression.type').to.eql('VariableLookup');
       expectPath(cst, '0.markup.expression.lookups.0.type').to.eql('VariableLookup');
       expectPath(cst, '0.markup.expression.lookups.0.name').to.eql('█');
+
+      // Completion after a property whose name starts with a digit
+      cst = toCST('{{ address.2country.█ }}');
+      expectPath(cst, '0.type').to.eql('LiquidVariableOutput');
+      expectPath(cst, '0.markup.type').to.eql('LiquidVariable');
+      expectPath(cst, '0.markup.expression.type').to.eql('VariableLookup');
+      expectPath(cst, '0.markup.expression.name').to.eql('address');
+      expectPath(cst, '0.markup.expression.lookups.0.type').to.eql('String');
+      expectPath(cst, '0.markup.expression.lookups.0.value').to.eql('2country');
+      expectPath(cst, '0.markup.expression.lookups.1.type').to.eql('String');
+      expectPath(cst, '0.markup.expression.lookups.1.value').to.eql('█');
 
       cst = toCST('{% echo █ %}');
       expectPath(cst, '0.type').to.eql('LiquidTag');


### PR DESCRIPTION
## What is this PR?

Fixes [#858](https://github.com/Shopify/theme-tools/issues/858). The language server was silently dropping autocomplete after a property whose name started with a digit:

```liquid
{{ address.2country.█ }}   <- no completions offered for `name` or `code`
{{ address.country.█ }}    <- completions offered
```

## What was the issue?

The parser grammar (`liquid-html.ohm`) defined:

```ohm
dotLookup         = space* "." space* identifier
identifier        = variableSegment "?"?
variableSegment   = (letter | "_") (~endOfTagName identifierCharacter)*
```

Every dot-lookup segment was funnelled through `variableSegment`, which only accepts `letter` or `_` as the first character. Any property whose name started with a digit (e.g. `2country`) was treated as unparseable text.

Downstream effect on completion: `createLiquidCompletionParams` appends the cursor placeholder `█` and calls `toLiquidHtmlAST(..., { mode: 'completion' })`. When that parse throws or falls through to the base-case fallback, `completionContext` is set to `undefined`, and `ObjectAttributeCompletionProvider` returns `[]` at its first guard (`if (!params.completionContext) return []`).

## The fix

Introduce a new `propertyName` rule that mirrors `identifier` but allows leading digits, and use it in `dotLookup` only. `variableSegment` stays restricted so variable declarations, filter names, `for`/`capture` targets, and named arguments continue to reject leading digits.

```ohm
dotLookup    = space* "." space* propertyName
propertyName = (letter | "_" | digit) (~endOfTagName identifierCharacter)* "?"?
```

Matching overrides are added to the three `WithPlaceholder*` grammars so that the completion-mode placeholder `█` is also accepted in property-name position:

```ohm
propertyName := (letter | "_" | digit | "█") (identifierCharacter | "█")* "?"?
```

### Why this is the right scope

Shopify actually supports property names that start with a digit — the issue's reproduction is a legitimate custom-object definition accepted by the platform. The grammar was incorrectly rejecting valid Liquid. Narrowing the fix to `dotLookup` (rather than loosening `identifier` or `variableSegment`) preserves existing constraints where they matter:

- Variable declarations (`{% assign 2x = 1 %}`) still fail — correct, Liquid forbids this
- Filter names (`{{ x | 2upcase }}`) still fail — correct
- `for` / `capture` loop variables still reject leading digits — correct
- Named arguments still reject leading digits — correct
- Only `.propertyName` in a dot chain accepts leading digits — the only place it should

## Verification

Minimal reproduction:

```ts
toLiquidHtmlCST('{{ address.2country.name }}');
// → VariableLookup { name: "address", lookups: ["2country", "name"] }

toLiquidHtmlCST('{{ address.2country.█ }}', { mode: 'completion' });
// → VariableLookup { name: "address", lookups: ["2country", "█"] }
```

The completion provider now gets a valid `completionContext` with the cursor positioned inside a dot lookup on `2country`, so it walks the object graph normally and offers the nested properties.

## Tests

Added test cases in `stage-1-cst.spec.ts`:

- `address.2country` parses with lookups `["2country"]`
- `address.2country.name` parses with lookups `["2country", "name"]`
- Completion mode: `{{ address.2country.█ }}` parses with lookups `["2country", "█"]` so completion providers can resolve the parent object and offer its properties

### Regression coverage

All 1,592 existing tests still pass across `liquid-html-parser` (162), `theme-check-common` (856), `prettier-plugin-liquid` (141), and `theme-language-server-common` (433). Zero regressions.

Closes #858