### PR TITLE
Fix section rename updates for settings_data

### DIFF
--- a/.changeset/fix-section-rename-settings-data.md
+++ b/.changeset/fix-section-rename-settings-data.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Update `config/settings_data.json` section types when sections are renamed.

--- a/packages/theme-language-server-common/src/renamed/handlers/SectionRenameHandler.spec.ts
+++ b/packages/theme-language-server-common/src/renamed/handlers/SectionRenameHandler.spec.ts
@@ -54,6 +54,17 @@ describe('Module: SectionRenameHandler', () => {
               },
               "order": ["section-id"]
             }`,
+
+        'config/settings_data.json': `
+            {
+              "current": {
+                "sections": {
+                  "section-id": {
+                    "type": "old-name"
+                  }
+                }
+              }
+            }`,
       },
       mockRoot,
     );
@@ -132,6 +143,11 @@ describe('Module: SectionRenameHandler', () => {
         replaceWithNewNameTextEditAtAnyLocation,
       ];
 
+      const settingsDataTextEdits = [
+        // Section type is updated in config/settings_data.json
+        replaceWithNewNameTextEditAtAnyLocation,
+      ];
+
       expect(connection.spies.sendRequest).toHaveBeenCalledWith('workspace/applyEdit', {
         label: "Rename section 'old-name' to 'new-name'",
         edit: {
@@ -162,6 +178,13 @@ describe('Module: SectionRenameHandler', () => {
                 version: null,
               },
               edits: sectionGroupTextEdits,
+            },
+            {
+              textDocument: {
+                uri: 'mock-fs:/config/settings_data.json',
+                version: null,
+              },
+              edits: settingsDataTextEdits,
             },
           ]),
         },
@@ -212,6 +235,17 @@ describe('Module: SectionRenameHandler', () => {
                 }
               },
               "order": ["section-id"]
+            }`,
+
+          'config/settings_data.json': `
+            {
+              "current": {
+                "sections": {
+                  "section-id": {
+                    "type": "new-name"
+                  }
+                }
+              }
             }`,
         },
         mockRoot,

--- a/packages/theme-language-server-common/src/renamed/handlers/SectionRenameHandler.ts
+++ b/packages/theme-language-server-common/src/renamed/handlers/SectionRenameHandler.ts
@@ -28,9 +28,9 @@ import {
   isLiquidSourceCode,
 } from '../../documents';
 import { FindThemeRootURI } from '../../internal-types';
-import { isSection, isSectionGroup, isTemplate, sectionName } from '../../utils/uri';
+import { isSection, isSectionGroup, isSettingsData, isTemplate, sectionName } from '../../utils/uri';
 import { BaseRenameHandler } from '../BaseRenameHandler';
-import { isValidSectionGroup, isValidTemplate } from './utils';
+import { isValidSectionGroup, isValidSettingsData, isValidTemplate } from './utils';
 
 type DocumentChange = TextDocumentEdit;
 
@@ -69,6 +69,7 @@ export class SectionRenameHandler implements BaseRenameHandler {
     const liquidFiles = theme.filter(isLiquidSourceCode);
     const templates = theme.filter(isJsonSourceCode).filter((file) => isTemplate(file.uri));
     const sectionGroups = theme.filter(isJsonSourceCode).filter((file) => isSectionGroup(file.uri));
+    const settingsData = theme.filter(isJsonSourceCode).filter((file) => isSettingsData(file.uri));
     const oldSectionName = sectionName(rename.oldUri);
     const newSectionName = sectionName(rename.newUri);
     const editLabel = `Rename section '${oldSectionName}' to '${newSectionName}'`;
@@ -84,13 +85,15 @@ export class SectionRenameHandler implements BaseRenameHandler {
 
     // All the templates/*.json files need to be updated with the new block name
     // when the old block name wasn't a local block.
-    const [templateChanges, sectionGroupChanges, sectionTagChanges] = await Promise.all([
-      Promise.all(templates.map(this.getTemplateChanges(oldSectionName, newSectionName))),
-      Promise.all(sectionGroups.map(this.getSectionGroupChanges(oldSectionName, newSectionName))),
-      Promise.all(liquidFiles.map(this.getSectionTagChanges(oldSectionName, newSectionName))),
-    ]);
+    const [templateChanges, sectionGroupChanges, settingsDataChanges, sectionTagChanges] =
+      await Promise.all([
+        Promise.all(templates.map(this.getTemplateChanges(oldSectionName, newSectionName))),
+        Promise.all(sectionGroups.map(this.getSectionGroupChanges(oldSectionName, newSectionName))),
+        Promise.all(settingsData.map(this.getSettingsDataChanges(oldSectionName, newSectionName))),
+        Promise.all(liquidFiles.map(this.getSectionTagChanges(oldSectionName, newSectionName))),
+      ]);
 
-    for (const docChange of [...templateChanges, ...sectionGroupChanges]) {
+    for (const docChange of [...templateChanges, ...sectionGroupChanges, ...settingsDataChanges]) {
       if (docChange !== null) {
         workspaceEdit.documentChanges!.push(docChange);
       }
@@ -163,6 +166,33 @@ export class SectionRenameHandler implements BaseRenameHandler {
             .filter(([_key, section]) => section.type === oldSectionName)
             .map(([key]) => {
               const node = nodeAtPath(ast, ['sections', key, 'type']) as LiteralNode;
+              return {
+                annotationId,
+                newText: newSectionName,
+                range: Range.create(
+                  textDocument.positionAt(node.loc.start.offset + 1),
+                  textDocument.positionAt(node.loc.end.offset - 1),
+                ),
+              } as AnnotatedTextEdit;
+            });
+
+      if (edits.length === 0) return null;
+
+      return documentChanges(sourceCode, edits);
+    };
+  }
+
+  private getSettingsDataChanges(oldSectionName: string, newSectionName: string) {
+    return async (sourceCode: AugmentedJsonSourceCode) => {
+      const { textDocument, ast, source } = sourceCode;
+      const parsed = parseJSON(source);
+      if (!parsed || isError(parsed) || isError(ast)) return null;
+      const edits: TextEdit[] = !isValidSettingsData(parsed)
+        ? []
+        : Object.entries(parsed.current?.sections ?? {})
+            .filter(([_key, section]) => section.type === oldSectionName)
+            .map(([key]) => {
+              const node = nodeAtPath(ast, ['current', 'sections', key, 'type']) as LiteralNode;
               return {
                 annotationId,
                 newText: newSectionName,

--- a/packages/theme-language-server-common/src/renamed/handlers/utils.ts
+++ b/packages/theme-language-server-common/src/renamed/handlers/utils.ts
@@ -20,3 +20,13 @@ export function isValidSectionGroup(parsed: unknown): parsed is Template.Section
     Array.isArray((parsed as Template.SectionGroup).order)
   );
 }
+
+export type SettingsData = {
+  current?: {
+    sections?: Record<string, { type?: string }>;
+  };
+};
+
+export function isValidSettingsData(parsed: unknown): parsed is SettingsData {
+  return typeof parsed === 'object' && parsed !== null && 'current' in parsed;
+}

--- a/packages/theme-language-server-common/src/utils/uri.ts
+++ b/packages/theme-language-server-common/src/utils/uri.ts
@@ -20,3 +20,5 @@ export const isSectionGroup = (uri: string) =>
 
 export const templateName = (uri: string) => path.basename(uri, '.json');
 export const isTemplate = (uri: string) => /\btemplates(\\|\/)[^\\\/]/.test(uri);
+
+export const isSettingsData = (uri: string) => /\bconfig(\\|\/)settings_data\.json$/.test(uri);


### PR DESCRIPTION
## What are you adding in this PR?

Fixes Shopify/theme-tools#713.

When a section file is renamed, the language server already updates references in template JSON files, section group JSON files, and `{% section %}` tags. This adds the same focused rename behavior for `config/settings_data.json`, updating only `current.sections[*].type` values that match the renamed section.

I also added coverage to the existing section rename handler spec and included the required patch changeset.

## What's next? Any followup issues?

Nothing from this patch. It intentionally does not rename block references inside `settings_data.json`; the maintainer note on the issue asked to update only the section `type` attribute.

## What did you learn?

The rename flow already had a nice split between template, section group, and Liquid tag edits, so `settings_data.json` could be added as one more JSON source without changing the broader rename behavior.

## Tophatting

- [ ] I added screenshots of the changes (before and after the changes if applicable)

Not applicable; language server rename behavior.

Verification:

- `yarn workspace @shopify/liquid-html-parser build`
- `yarn workspace @shopify/theme-check-common build`
- `yarn workspace @shopify/theme-language-server-common build`
- `yarn vitest run packages/theme-language-server-common/src/renamed/handlers/SectionRenameHandler.spec.ts`
- `yarn workspace @shopify/theme-language-server-common type-check`

Note: `yarn install --frozen-lockfile` initially failed on Windows because the `theme-check-vscode` postinstall script calls `sh scripts/fetch-syntaxes.sh`; after dependencies were linked, building the needed workspaces allowed the targeted test/type-check path to run.

This was implemented with Codex assistance and manually reviewed before opening the PR.

## Before you deploy

<!-- Delete the checklists you don't need -->

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`