### PR TITLE
Use app blocks as theme graph entry points

### DIFF
--- a/.changeset/little-donkeys-mix.md
+++ b/.changeset/little-donkeys-mix.md
@@ -1,0 +1,7 @@
+---
+"@shopify/theme-language-server-common": patch
+"@shopify/theme-check-node": patch
+"@shopify/theme-graph": patch
+---
+
+Treat theme app extension blocks as theme graph entry points so snippets rendered by app blocks are not reported as orphaned.

--- a/packages/theme-check-node/src/index.ts
+++ b/packages/theme-check-node/src/index.ts
@@ -171,6 +171,7 @@ export async function themeCheckRun(
       getSectionSchema,
       getBlockSchema,
       getWebComponentDefinitionReference: () => undefined,
+      mode: config.context,
     });
   } catch {
     // If graph building fails, cross-file checks will gracefully degrade

--- a/packages/theme-check-node/tsconfig.json
+++ b/packages/theme-check-node/tsconfig.json
@@ -8,12 +8,13 @@
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "paths": {
       "@shopify/theme-check-common": ["../theme-check-common/src"],
-      "@shopify/theme-check-docs-updater": ["../theme-check-docs-updater/src"]
+      "@shopify/theme-check-docs-updater": ["../theme-check-docs-updater/src"],
+      "@shopify/theme-graph": ["../theme-graph/src"]
     }
   },
   "references": [
     { "path": "../theme-check-common" },
-    { "path": "../theme-check-docs-updater" }
+    { "path": "../theme-check-docs-updater" },
+    { "path": "../theme-graph" }
   ]
 }
-

--- a/packages/theme-graph/fixtures/theme-app-extension/blocks/app-block.liquid
+++ b/packages/theme-graph/fixtures/theme-app-extension/blocks/app-block.liquid
@@ -1,0 +1,9 @@
+{% render 'shared' %}
+
+{% schema %}
+{
+  "name": "App block",
+  "target": "section",
+  "settings": []
+}
+{% endschema %}

--- a/packages/theme-graph/fixtures/theme-app-extension/shopify.extension.toml
+++ b/packages/theme-graph/fixtures/theme-app-extension/shopify.extension.toml
@@ -1,0 +1,2 @@
+name = "Example theme app extension"
+type = "theme"

--- a/packages/theme-graph/fixtures/theme-app-extension/snippets/shared.liquid
+++ b/packages/theme-graph/fixtures/theme-app-extension/snippets/shared.liquid
@@ -1,0 +1,1 @@
+<div>Shared snippet</div>

--- a/packages/theme-graph/src/graph/augment.ts
+++ b/packages/theme-graph/src/graph/augment.ts
@@ -25,6 +25,7 @@ export function augmentDependencies(rootUri: string, ideps: IDependencies): Augm
     ),
 
     getWebComponentDefinitionReference: ideps.getWebComponentDefinitionReference,
+    mode: ideps.mode ?? 'theme',
     getThemeBlockNames: memo(() =>
       findAllFiles(ideps.fs, path.join(rootUri, 'blocks'), ([uri]) => uri.endsWith('.liquid')).then(
         (uris) => uris.map((uri) => path.basename(uri, '.liquid')),

--- a/packages/theme-graph/src/graph/build.spec.ts
+++ b/packages/theme-graph/src/graph/build.spec.ts
@@ -2,7 +2,7 @@ import { path as pathUtils, SourceCodeType } from '@shopify/theme-check-common';
 import { assert, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { buildThemeGraph } from '../index';
 import { Dependencies, JsonModuleKind, LiquidModuleKind, ModuleType, ThemeGraph } from '../types';
-import { getDependencies, skeleton } from './test-helpers';
+import { getDependencies, skeleton, themeAppExtension } from './test-helpers';
 
 describe('Module: index', () => {
   const rootUri = skeleton;
@@ -25,6 +25,20 @@ describe('Module: index', () => {
 
       beforeEach(async () => {
         graph = await buildThemeGraph(rootUri, dependencies);
+      });
+
+      it('uses app blocks as entry points in app mode', async () => {
+        const appDependencies = await getDependencies(themeAppExtension);
+        const appGraph = await buildThemeGraph(themeAppExtension, {
+          ...appDependencies,
+          mode: 'app',
+        });
+        const app = (part: string) => pathUtils.join(themeAppExtension, ...part.split('/'));
+
+        expect(appGraph.entryPoints.map((x) => x.uri)).toEqual([app('blocks/app-block.liquid')]);
+        expect(
+          appGraph.modules[app('snippets/shared.liquid')].references.map((x) => x.source.uri),
+        ).toEqual([app('blocks/app-block.liquid')]);
       });
 
       it('have a root URI', () => {

--- a/packages/theme-graph/src/graph/build.ts
+++ b/packages/theme-graph/src/graph/build.ts
@@ -26,7 +26,14 @@ export async function buildThemeGraph(
       const isSectionFile =
         uri.startsWith(path.join(rootUri, 'sections')) && uri.endsWith('.liquid');
 
-      return isTemplateFile || isSectionFile;
+      // Theme app extension app blocks and app embed blocks are independently
+      // renderable by Shopify, so treat them as graph entry points too.
+      const isThemeAppExtensionBlockFile =
+        deps.mode === 'app' &&
+        uri.startsWith(path.join(rootUri, 'blocks')) &&
+        uri.endsWith('.liquid');
+
+      return isTemplateFile || isSectionFile || isThemeAppExtensionBlockFile;
     }));
 
   const graph: ThemeGraph = {

--- a/packages/theme-graph/src/graph/test-helpers.ts
+++ b/packages/theme-graph/src/graph/test-helpers.ts
@@ -23,18 +23,19 @@ export function makeGetSourceCode(fs: AbstractFileSystem) {
 
 export const fixturesRoot = pathUtils.join(URI.file(__dirname), ...'../../fixtures'.split('/'));
 export const skeleton = pathUtils.join(fixturesRoot, 'skeleton');
+export const themeAppExtension = pathUtils.join(fixturesRoot, 'theme-app-extension');
 
 export async function getDependencies(rootUri: string, fs: AbstractFileSystem = NodeFileSystem) {
   const getSourceCode = makeGetSourceCode(fs);
   const deps = {
     fs,
     getSectionSchema: memoize(async (name: string) => {
-      const uri = pathUtils.join(skeleton, 'sections', `${name}.liquid`);
+      const uri = pathUtils.join(rootUri, 'sections', `${name}.liquid`);
       const sourceCode = (await getSourceCode(uri)) as LiquidSourceCode;
       return (await toSchema('theme', uri, sourceCode, async () => true)) as SectionSchema;
     }, identity),
     getBlockSchema: memoize(async (name: string) => {
-      const uri = pathUtils.join(skeleton, 'blocks', `${name}.liquid`);
+      const uri = pathUtils.join(rootUri, 'blocks', `${name}.liquid`);
       const sourceCode = (await getSourceCode(uri)) as LiquidSourceCode;
       return (await toSchema('theme', uri, sourceCode, async () => true)) as ThemeBlockSchema;
     }, identity),

--- a/packages/theme-graph/src/graph/traverse.ts
+++ b/packages/theme-graph/src/graph/traverse.ts
@@ -212,7 +212,7 @@ async function traverseLiquidModule(
     const sectionName = path.basename(module.uri, '.liquid');
     const sectionSchema = await deps.getSectionSchema(sectionName);
     promises.push(traverseLiquidSchema(sectionSchema, module, themeGraph, deps));
-  } else if (module.kind === LiquidModuleKind.Block) {
+  } else if (module.kind === LiquidModuleKind.Block && deps.mode === 'theme') {
     const blockName = path.basename(module.uri, '.liquid');
     const blockSchema = await deps.getBlockSchema(blockName);
     promises.push(traverseLiquidSchema(blockSchema, module, themeGraph, deps));

--- a/packages/theme-graph/src/types.ts
+++ b/packages/theme-graph/src/types.ts
@@ -6,6 +6,7 @@ import {
   Reference,
   Location,
   Range,
+  Mode,
 } from '@shopify/theme-check-common';
 import { Program } from 'acorn';
 
@@ -31,11 +32,15 @@ export interface IDependencies {
   getWebComponentDefinitionReference: (
     customElementName: string,
   ) => { assetName: string; range: Range } | undefined;
+
+  /** Whether the graph is for a full theme or a theme app extension. */
+  mode?: Mode;
 }
 
-export type Dependencies = Required<IDependencies>;
+export type Dependencies = Required<Omit<IDependencies, 'mode'>> & Pick<IDependencies, 'mode'>;
 
-export type AugmentedDependencies = Dependencies & {
+export type AugmentedDependencies = Required<Omit<IDependencies, 'mode'>> & {
+  mode: Mode;
   getThemeBlockNames: () => Promise<string[]>;
 };
 

--- a/packages/theme-language-server-common/src/server/ThemeGraphManager.ts
+++ b/packages/theme-language-server-common/src/server/ThemeGraphManager.ts
@@ -5,6 +5,7 @@ import {
   SectionSchema,
   SourceCodeType,
   ThemeBlockSchema,
+  Mode,
 } from '@shopify/theme-check-common';
 import {
   buildThemeGraph,
@@ -35,6 +36,7 @@ export class ThemeGraphManager {
     private documentManager: DocumentManager,
     private fs: AbstractFileSystem,
     private findThemeRootURI: FindThemeRootURI,
+    private getModeForURI: (uri: string) => Promise<Mode> = async () => 'theme',
   ) {}
 
   async getThemeGraphForURI(uri: string) {
@@ -237,10 +239,14 @@ export class ThemeGraphManager {
 
   private async graphDependencies(rootUri: string): Promise<GraphDependencies> {
     const { documentManager, fs, getSourceCode } = this;
-    const webComponentDefs = await this.getWebComponentMap(rootUri);
+    const [webComponentDefs, mode] = await Promise.all([
+      this.getWebComponentMap(rootUri),
+      this.getModeForURI(rootUri),
+    ]);
     return {
       fs: fs,
       getSourceCode: getSourceCode,
+      mode,
       async getBlockSchema(name: string) {
         const blockUri = path.join(rootUri, 'blocks', `${name}.liquid`);
         const doc = documentManager.get(blockUri);

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -120,6 +120,7 @@ export function startServer(
     documentManager,
     fs,
     findThemeRootURI,
+    getModeForURI,
   );
   const diagnosticsManager = new DiagnosticsManager(connection);
   const documentLinksProvider = new DocumentLinksProvider(documentManager, findThemeRootURI);


### PR DESCRIPTION
## Summary

Fixes a false positive where `OrphanedSnippet` reported snippets in theme app extensions as unused even when they were rendered by app blocks.

Theme app extension blocks are rendered by Shopify directly, without an in-repo template or section parent. The theme graph only used templates and sections as entrypoints, so the graph never traversed app blocks and never recorded their `{% render %}` references.

## What changed

- passes the theme-check config context into theme graph construction from the Node runner and language server
- treats `blocks/*.liquid` as graph entrypoints only in `context: app`
- leaves normal theme blocks on the existing reachability path so genuinely unused theme block trees can still be reported
- adds regression coverage for a TAE app block rendering a snippet
- adds a patch changeset for the affected packages

## Context

This became visible in `shopify app dev` after the CLI picked up theme-check-node 3.25.0. `OrphanedSnippet` existed before then, but the Node runner did not provide `getReferences`, so the check no-op'd in CLI mode. Once `getReferences` was wired through for other cross-file checks, the existing graph entrypoint gap started surfacing as orphaned snippet warnings.

## 🎩 Tophatting

This is unfortunately tough to test locally because theme-check doesn't use the local version of `theme-graph` (tbh this seems like something we should fix. I feel like all packages should use local package references during development).

I confirmed through a custom script that I only get `OrphanedSnippet` hitting on snippets that are actually orphaned.