### PR TITLE
Accept common Theme Check config aliases

### DIFF
--- a/.changeset/fuzzy-configs-smile.md
+++ b/.changeset/fuzzy-configs-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-node': patch
+---
+
+Accept common aliases for built-in Theme Check configs in YAML `extends` values.

--- a/packages/theme-check-node/src/config/resolve/read-yaml.spec.ts
+++ b/packages/theme-check-node/src/config/resolve/read-yaml.spec.ts
@@ -146,13 +146,43 @@ describe('Unit: readYamlConfigDescription', () => {
           expected: ['theme-check:recommended'],
         },
         {
+          testCase: 'translates legacy `recommended` to `theme-check:recommended`',
+          extendsValue: 'recommended',
+          expected: ['theme-check:recommended'],
+        },
+        {
+          testCase: 'translates legacy `all` to `theme-check:all`',
+          extendsValue: 'all',
+          expected: ['theme-check:all'],
+        },
+        {
           testCase:
             'translates legacy `:theme_app_extensions` to `theme-check:theme-app-extension`',
           extendsValue: [':theme_app_extensions'],
           expected: ['theme-check:theme-app-extension'],
         },
         {
-          testCase: 'translates legacy [`:nothing`] to []',
+          testCase: 'translates legacy `theme_app_extension` to `theme-check:theme-app-extension`',
+          extendsValue: 'theme_app_extension',
+          expected: ['theme-check:theme-app-extension'],
+        },
+        {
+          testCase: 'translates legacy `:theme_app_extension` to `theme-check:theme-app-extension`',
+          extendsValue: [':theme_app_extension'],
+          expected: ['theme-check:theme-app-extension'],
+        },
+        {
+          testCase: 'translates legacy `theme-app-extension` to `theme-check:theme-app-extension`',
+          extendsValue: 'theme-app-extension',
+          expected: ['theme-check:theme-app-extension'],
+        },
+        {
+          testCase: 'translates legacy `theme-app-extensions` to `theme-check:theme-app-extension`',
+          extendsValue: 'theme-app-extensions',
+          expected: ['theme-check:theme-app-extension'],
+        },
+        {
+          testCase: 'translates legacy [`:nothing`] to `theme-check:nothing`',
           extendsValue: [':nothing'],
           expected: ['theme-check:nothing'],
         },

--- a/packages/theme-check-node/src/config/resolve/read-yaml.ts
+++ b/packages/theme-check-node/src/config/resolve/read-yaml.ts
@@ -121,9 +121,10 @@ export async function readYamlConfigDescription(
  * resolves the `extends:` property of configuration files.
  *
  * pathLike can be any of the following:
- * - legacy identifiers:
+ * - legacy/convenience identifiers:
  *   - a symbol (e.g. :default, :nothing, :theme_app_extension)
  *   - the special string version of the symbols (e.g. default, nothing)
+ *   - common built-in config aliases (e.g. recommended, all, theme-app-extension)
  * - modern identifiers:
  *   - theme-check:all
  *   - theme-check:recommended

--- a/packages/theme-check-node/src/config/types.ts
+++ b/packages/theme-check-node/src/config/types.ts
@@ -42,8 +42,13 @@ export type ModernIdentifier = (typeof ModernIdentifiers)[number];
 export const LegacyIdentifiers = new Map(
   Object.entries({
     default: 'theme-check:recommended',
+    recommended: 'theme-check:recommended',
+    all: 'theme-check:all',
     nothing: 'theme-check:nothing',
+    theme_app_extension: 'theme-check:theme-app-extension',
     theme_app_extensions: 'theme-check:theme-app-extension',
+    'theme-app-extension': 'theme-check:theme-app-extension',
+    'theme-app-extensions': 'theme-check:theme-app-extension',
   }),
 );
 


### PR DESCRIPTION
## What are you adding in this PR?

Theme Check config files already support built-in configs with the `theme-check:` prefix. This PR makes the YAML `extends` loader a little more forgiving for config names that look like built-in Theme Check configs, so they are resolved before falling back to Node module resolution.

This avoids misleading module resolution errors when a config uses a likely built-in config name without the prefix.

Examples that were already supported:

```yaml
extends: theme-check:recommended
```

```yaml
extends: theme-check:theme-app-extension
```

Examples that are now accepted as aliases:

```yaml
extends: recommended
# resolves to theme-check:recommended
```

```yaml
extends: all
# resolves to theme-check:all
```

```yaml
extends: theme-app-extension
# resolves to theme-check:theme-app-extension
```

```yaml
extends: theme-app-extensions
# resolves to theme-check:theme-app-extension
```

```yaml
extends: theme_app_extension
# resolves to theme-check:theme-app-extension
```

```yaml
extends: :theme_app_extension
# resolves to theme-check:theme-app-extension
```

The existing aliases continue to work, including `default`, `:default`, `nothing`, and `:theme_app_extensions`.

## What's next? Any followup issues?

No follow-up planned.

## What did you learn?

N/A

## Tophatting

- [x] `pnpm exec vitest run packages/theme-check-node/src/config/resolve/read-yaml.spec.ts`
- [x] `pnpm exec prettier --check packages/theme-check-node/src/config/types.ts packages/theme-check-node/src/config/resolve/read-yaml.ts packages/theme-check-node/src/config/resolve/read-yaml.spec.ts .changeset/fuzzy-configs-smile.md`
- [x] `pnpm --dir packages/theme-check-common build:ts`
- [x] `pnpm --dir packages/theme-check-node type-check`
- [ ] I added screenshots of the changes (before and after the changes if applicable)

## Before you deploy

<!-- Bug fixes -->
- [x] I included a patch bump `changeset`

Fixes shop/issues#47796