### PR TITLE
fix: keep tag/filter doc warnings on their own line on hover

### DIFF
--- a/.changeset/fix-hover-warning-blockquote.md
+++ b/.changeset/fix-hover-warning-blockquote.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Fix tag/filter doc warnings collapsing onto the previous line on hover. Blockquote admonitions (e.g. the `image_url` filter's Caution/Note) are now preserved on their own lines instead of being flattened into the surrounding text.

--- a/packages/theme-language-server-common/src/docset/MarkdownRenderer.spec.ts
+++ b/packages/theme-language-server-common/src/docset/MarkdownRenderer.spec.ts
@@ -36,6 +36,21 @@ describe('MarkdownRenderer', () => {
         });
       });
     });
+
+    describe('when the description contains a blockquote (e.g. a Caution/Note warning)', () => {
+      it('preserves the blockquote on its own line instead of collapsing it onto the previous line', () => {
+        const entry: DocsetEntry = {
+          name: 'image_url',
+          description:
+            'Use it on image objects.\n\n&gt; Caution:\n&gt; You must specify either a width or height parameter.',
+          deprecated: false,
+        };
+
+        expect(render(entry)).toEqual(
+          '### image_url\nUse it on image objects.\n\n> Caution:\n> You must specify either a width or height parameter.',
+        );
+      });
+    });
   });
 
   describe('renderHtmlEntry()', () => {

--- a/packages/theme-language-server-common/src/docset/MarkdownRenderer.ts
+++ b/packages/theme-language-server-common/src/docset/MarkdownRenderer.ts
@@ -38,8 +38,7 @@ function title(
 
 function sanitize(s: string | undefined) {
   return s
-    ?.replace(/(^|\n+)&gt;/g, ' ')
-    .replace(/&gt;/g, '>')
+    ?.replace(/&gt;/g, '>')
     .replace(/&lt;/g, '<')
     .replace(/\]\(\//g, '](https://shopify.dev/')
     .trim();


### PR DESCRIPTION
## What are you adding in this PR?

Fixes #506.

When a Liquid tag/filter's documentation contains a warning (a `> Caution:` / `> Note:` blockquote in the source docs), the hover tooltip flattened it onto the previous line, so the warning ran into the surrounding text and was easy to miss (the `image_url` filter is the example in the issue).

The cause is in `MarkdownRenderer.sanitize()`:

```ts
?.replace(/(^|\n+)&gt;/g, ' ')   // replaces "newline(s) + escaped >" with a single space
.replace(/&gt;/g, '>')
```

The docs HTML-escape `>` to `&gt;`, so blockquote lines start with `&gt;`. The first replace swallows the **newline** together with the `&gt;` marker and substitutes a single space — collapsing a multi-line blockquote into the preceding paragraph.

The fix drops that lossy first replace. The existing `&gt;` → `>` conversion on the next line then preserves the admonition as a proper markdown blockquote, which both the VS Code hover renderer and CodeMirror render on their own lines.

It's a one-line removal (plus a regression test and a changeset).

## Tophatting

Rendered hover markdown for the `image_url` filter, before and after (focused on the warning region):

**Before** — warning collapsed into the bullet list / prose:
```
- `country`  Caution: You need to specify either a `width` or `height` parameter. If neither are specified, then an error is returned.  Note: Regardless of the specified dimensions, an image can never be resized to be larger than its original dimensions.
```

**After** — warnings preserved as blockquotes on their own lines:
```
- `country`

> Caution:
> You need to specify either a `width` or `height` parameter. If neither are specified, then an error is returned.

> Note:
> Regardless of the specified dimensions, an image can never be resized to be larger than its original dimensions.
```

- [x] Added a regression test in `MarkdownRenderer.spec.ts` (built from the real `image_url` doc markup). Happy to add a VS Code hover screenshot too if you'd prefer that over the rendered-string comparison.

## Before you deploy

- [x] I included a patch bump `changeset`

## A note for reviewers

I render the warnings as markdown blockquotes (`> …`). I couldn't tell from the history why the original code stripped the `>` marker, so if you'd rather these warnings render as plain paragraphs instead of blockquotes, I'm happy to adjust — the key fix is just not collapsing them onto the previous line.

---

🤖 Disclosure: this change was investigated and drafted with AI assistance (Claude Code). I've reviewed the diff, understand the root cause, and verified it against the repo's test suite — the test plan and reasoning are mine to defend.