### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,15 @@
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   code-quality:


### PR DESCRIPTION
This workflow can't run on forked PRs because the "push" is happening outside of this repo. Contributions from people outside of Shopify get stuck because CI can't run on them. What we have to do is pull the branch down locally and push it back up just for CI to run. Annoying! This fixes that.