### PR TITLE
Add code actions to disable a check for a line or the whole file

### DIFF
--- a/.changeset/add-disable-check-code-action.md
+++ b/.changeset/add-disable-check-code-action.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-language-server-common': minor
+---
+
+Add code actions to disable a theme-check check for the current line or the entire file. When a theme-check diagnostic is under the cursor, two quick-fixes are offered that insert the corresponding `theme-check-disable-next-line` / `theme-check-disable` magic comment for you.

--- a/packages/theme-language-server-common/src/codeActions/CodeActionsProvider.ts
+++ b/packages/theme-language-server-common/src/codeActions/CodeActionsProvider.ts
@@ -1,11 +1,21 @@
 import { CodeAction, CodeActionParams, Command } from 'vscode-languageserver';
 import { DiagnosticsManager } from '../diagnostics';
 import { DocumentManager } from '../documents';
-import { FixAllProvider, FixProvider, SuggestionProvider } from './providers';
+import {
+  DisableCheckProvider,
+  FixAllProvider,
+  FixProvider,
+  SuggestionProvider,
+} from './providers';
 import { BaseCodeActionsProvider } from './BaseCodeActionsProvider';
 
 export const CodeActionKinds = Array.from(
-  new Set([FixAllProvider.kind, FixProvider.kind, SuggestionProvider.kind]),
+  new Set([
+    FixAllProvider.kind,
+    FixProvider.kind,
+    SuggestionProvider.kind,
+    DisableCheckProvider.kind,
+  ]),
 );
 
 export class CodeActionsProvider {
@@ -16,6 +26,7 @@ export class CodeActionsProvider {
       new FixAllProvider(documentManager, diagnosticsManager),
       new FixProvider(documentManager, diagnosticsManager),
       new SuggestionProvider(documentManager, diagnosticsManager),
+      new DisableCheckProvider(documentManager, diagnosticsManager),
     ];
   }
 

--- a/packages/theme-language-server-common/src/codeActions/CodeActionsProvider.ts
+++ b/packages/theme-language-server-common/src/codeActions/CodeActionsProvider.ts
@@ -1,12 +1,7 @@
 import { CodeAction, CodeActionParams, Command } from 'vscode-languageserver';
 import { DiagnosticsManager } from '../diagnostics';
 import { DocumentManager } from '../documents';
-import {
-  DisableCheckProvider,
-  FixAllProvider,
-  FixProvider,
-  SuggestionProvider,
-} from './providers';
+import { DisableCheckProvider, FixAllProvider, FixProvider, SuggestionProvider } from './providers';
 import { BaseCodeActionsProvider } from './BaseCodeActionsProvider';
 
 export const CodeActionKinds = Array.from(

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
@@ -1,0 +1,93 @@
+import { Offense, Severity, SourceCodeType, path } from '@shopify/theme-check-common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+import { DiagnosticsManager } from '../../diagnostics';
+import { DocumentManager } from '../../documents';
+import { DisableCheckProvider } from './DisableCheckProvider';
+
+describe('Unit: DisableCheckProvider', () => {
+  const uri = path.normalize(URI.file('/path/to/file.liquid'));
+  const contents = `
+    {% assign x = 1 %}
+    <script src="2.js"></script>
+    <script src="3.js"></script>
+  `;
+  const version = 0;
+  const document = TextDocument.create(uri, 'liquid', version, contents);
+  let documentManager: DocumentManager;
+  let diagnosticsManager: DiagnosticsManager;
+  let provider: DisableCheckProvider;
+
+  function makeOffense(
+    checkName: string,
+    needle: string,
+  ): Offense<SourceCodeType.LiquidHtml> {
+    const start = contents.indexOf(needle);
+    const end = start + needle.length;
+    return {
+      type: SourceCodeType.LiquidHtml,
+      check: checkName,
+      message: `${checkName} problem`,
+      uri: 'file:///path/to/file.liquid',
+      severity: Severity.ERROR,
+      start: { ...document.positionAt(start), index: start },
+      end: { ...document.positionAt(end), index: end },
+    } as Offense<SourceCodeType.LiquidHtml>;
+  }
+
+  function cursorAt(needle: string) {
+    return {
+      textDocument: { uri },
+      range: {
+        start: document.positionAt(contents.indexOf(needle)),
+        end: document.positionAt(contents.indexOf(needle)),
+      },
+      context: { diagnostics: [] },
+    };
+  }
+
+  beforeEach(() => {
+    documentManager = new DocumentManager();
+    diagnosticsManager = new DiagnosticsManager({ sendDiagnostics: vi.fn() } as any);
+    documentManager.open(uri, contents, version);
+    provider = new DisableCheckProvider(documentManager, diagnosticsManager);
+  });
+
+  it('offers "disable for this line" inserting a disable-next-line comment above the offense, indent-matched', () => {
+    diagnosticsManager.set(uri, version, [makeOffense('UnusedAssign', '{% assign x = 1 %}')]);
+
+    const codeActions = provider.codeActions(cursorAt('assign x = 1'));
+    const action = codeActions.find((a) => a.title === 'Disable UnusedAssign for this line');
+
+    expect(action).toEqual({
+      title: 'Disable UnusedAssign for this line',
+      kind: 'quickfix',
+      diagnostics: expect.any(Array),
+      isPreferred: false,
+      edit: {
+        changes: {
+          [uri]: [
+            {
+              range: {
+                start: { line: 1, character: 0 },
+                end: { line: 1, character: 0 },
+              },
+              newText: '    {% # theme-check-disable-next-line UnusedAssign %}\n',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('offers no actions when the cursor does not overlap any offense', () => {
+    diagnosticsManager.set(uri, version, [
+      makeOffense('ParserBlockingScript', '<script src="2.js"></script>'),
+    ]);
+
+    const codeActions = provider.codeActions(cursorAt('assign x = 1'));
+
+    expect(codeActions.length).toBe(0);
+  });
+});

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
@@ -47,6 +47,17 @@ describe('Unit: DisableCheckProvider', () => {
     };
   }
 
+  function rangeFromTo(startNeedle: string, endNeedle: string) {
+    return {
+      textDocument: { uri },
+      range: {
+        start: document.positionAt(contents.indexOf(startNeedle)),
+        end: document.positionAt(contents.indexOf(endNeedle) + endNeedle.length),
+      },
+      context: { diagnostics: [] },
+    };
+  }
+
   beforeEach(() => {
     documentManager = new DocumentManager();
     diagnosticsManager = new DiagnosticsManager({ sendDiagnostics: vi.fn() } as any);
@@ -116,5 +127,39 @@ describe('Unit: DisableCheckProvider', () => {
     const codeActions = provider.codeActions(cursorAt('assign x = 1'));
 
     expect(codeActions.length).toBe(0);
+  });
+
+  it('emits only one action pair per check when several offenses of the same check are selected', () => {
+    diagnosticsManager.set(uri, version, [
+      makeOffense('ParserBlockingScript', '<script src="2.js"></script>'),
+      makeOffense('ParserBlockingScript', '<script src="3.js"></script>'),
+    ]);
+
+    const codeActions = provider.codeActions(rangeFromTo('2.js', '3.js'));
+
+    expect(codeActions.length).toBe(2);
+    expect(codeActions.map((a) => a.title)).toEqual([
+      'Disable ParserBlockingScript for this line',
+      'Disable ParserBlockingScript for entire file',
+    ]);
+  });
+
+  it('emits one action pair per distinct check when multiple checks are selected', () => {
+    diagnosticsManager.set(uri, version, [
+      makeOffense('UnusedAssign', '{% assign x = 1 %}'),
+      makeOffense('ParserBlockingScript', '<script src="2.js"></script>'),
+    ]);
+
+    const codeActions = provider.codeActions(rangeFromTo('assign x = 1', '2.js'));
+
+    expect(codeActions.length).toBe(4);
+    expect(codeActions.map((a) => a.title).sort()).toEqual(
+      [
+        'Disable ParserBlockingScript for entire file',
+        'Disable ParserBlockingScript for this line',
+        'Disable UnusedAssign for entire file',
+        'Disable UnusedAssign for this line',
+      ].sort(),
+    );
   });
 });

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
@@ -163,3 +163,51 @@ describe('Unit: DisableCheckProvider', () => {
     );
   });
 });
+
+describe('Unit: DisableCheckProvider — {% liquid %} blocks', () => {
+  const uri = path.normalize(URI.file('/path/to/file.liquid'));
+  const contents = `{% liquid
+  assign x = 1
+%}`;
+  const version = 0;
+  const document = TextDocument.create(uri, 'liquid', version, contents);
+  let documentManager: DocumentManager;
+  let diagnosticsManager: DiagnosticsManager;
+  let provider: DisableCheckProvider;
+
+  function makeOffense(checkName: string, needle: string): Offense<SourceCodeType.LiquidHtml> {
+    const start = contents.indexOf(needle);
+    const end = start + needle.length;
+    return {
+      type: SourceCodeType.LiquidHtml,
+      check: checkName,
+      message: `${checkName} problem`,
+      uri: 'file:///path/to/file.liquid',
+      severity: Severity.ERROR,
+      start: { ...document.positionAt(start), index: start },
+      end: { ...document.positionAt(end), index: end },
+    };
+  }
+
+  beforeEach(() => {
+    documentManager = new DocumentManager();
+    diagnosticsManager = new DiagnosticsManager({ sendDiagnostics: vi.fn() } as any);
+    documentManager.open(uri, contents, version);
+    provider = new DisableCheckProvider(documentManager, diagnosticsManager);
+  });
+
+  it('does not offer "this line" inside a {% liquid %} block, but still offers "entire file"', () => {
+    diagnosticsManager.set(uri, version, [makeOffense('UnusedAssign', 'assign x = 1')]);
+
+    const codeActions = provider.codeActions({
+      textDocument: { uri },
+      range: {
+        start: document.positionAt(contents.indexOf('assign x = 1')),
+        end: document.positionAt(contents.indexOf('assign x = 1')),
+      },
+      context: { diagnostics: [] },
+    });
+
+    expect(codeActions.map((a) => a.title)).toEqual(['Disable UnusedAssign for entire file']);
+  });
+});

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
@@ -81,6 +81,33 @@ describe('Unit: DisableCheckProvider', () => {
     });
   });
 
+  it('offers "disable for entire file" inserting a disable comment at the top of the file', () => {
+    diagnosticsManager.set(uri, version, [makeOffense('UnusedAssign', '{% assign x = 1 %}')]);
+
+    const codeActions = provider.codeActions(cursorAt('assign x = 1'));
+    const action = codeActions.find((a) => a.title === 'Disable UnusedAssign for entire file');
+
+    expect(action).toEqual({
+      title: 'Disable UnusedAssign for entire file',
+      kind: 'quickfix',
+      diagnostics: expect.any(Array),
+      isPreferred: false,
+      edit: {
+        changes: {
+          [uri]: [
+            {
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 0 },
+              },
+              newText: '{% # theme-check-disable UnusedAssign %}\n',
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('offers no actions when the cursor does not overlap any offense', () => {
     diagnosticsManager.set(uri, version, [
       makeOffense('ParserBlockingScript', '<script src="2.js"></script>'),

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
@@ -19,10 +19,7 @@ describe('Unit: DisableCheckProvider', () => {
   let diagnosticsManager: DiagnosticsManager;
   let provider: DisableCheckProvider;
 
-  function makeOffense(
-    checkName: string,
-    needle: string,
-  ): Offense<SourceCodeType.LiquidHtml> {
+  function makeOffense(checkName: string, needle: string): Offense<SourceCodeType.LiquidHtml> {
     const start = contents.indexOf(needle);
     const end = start + needle.length;
     return {

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
@@ -33,7 +33,7 @@ describe('Unit: DisableCheckProvider', () => {
       severity: Severity.ERROR,
       start: { ...document.positionAt(start), index: start },
       end: { ...document.positionAt(end), index: end },
-    } as Offense<SourceCodeType.LiquidHtml>;
+    };
   }
 
   function cursorAt(needle: string) {

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.spec.ts
@@ -168,7 +168,8 @@ describe('Unit: DisableCheckProvider — {% liquid %} blocks', () => {
   const uri = path.normalize(URI.file('/path/to/file.liquid'));
   const contents = `{% liquid
   assign x = 1
-%}`;
+%}
+{% assign y = 2 %}`;
   const version = 0;
   const document = TextDocument.create(uri, 'liquid', version, contents);
   let documentManager: DocumentManager;
@@ -209,5 +210,23 @@ describe('Unit: DisableCheckProvider — {% liquid %} blocks', () => {
     });
 
     expect(codeActions.map((a) => a.title)).toEqual(['Disable UnusedAssign for entire file']);
+  });
+
+  it('still offers "this line" for an offense outside the {% liquid %} block in the same file', () => {
+    diagnosticsManager.set(uri, version, [makeOffense('UnusedAssign', 'assign y = 2')]);
+
+    const codeActions = provider.codeActions({
+      textDocument: { uri },
+      range: {
+        start: document.positionAt(contents.indexOf('assign y = 2')),
+        end: document.positionAt(contents.indexOf('assign y = 2')),
+      },
+      context: { diagnostics: [] },
+    });
+
+    expect(codeActions.map((a) => a.title)).toEqual([
+      'Disable UnusedAssign for this line',
+      'Disable UnusedAssign for entire file',
+    ]);
   });
 });

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
@@ -38,8 +38,19 @@ export class DisableCheckProvider extends BaseCodeActionsProvider {
         [diagnostic],
         DisableCheckProvider.kind,
       ),
+      toEditCodeAction(
+        `Disable ${check} for entire file`,
+        disableFileEdit(uri, check),
+        [diagnostic],
+        DisableCheckProvider.kind,
+      ),
     ];
   }
+}
+
+function disableFileEdit(uri: string, check: string): WorkspaceEdit {
+  const newText = `{% # theme-check-disable ${check} %}\n`;
+  return { changes: { [uri]: [TextEdit.insert({ line: 0, character: 0 }, newText)] } };
 }
 
 function disableNextLineEdit(

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
@@ -1,9 +1,10 @@
-import { SourceCodeType } from '@shopify/theme-check-common';
+import { Offense, SourceCodeType } from '@shopify/theme-check-common';
 import {
   CodeAction,
   CodeActionKind,
   CodeActionParams,
   Command,
+  Diagnostic,
   TextEdit,
   WorkspaceEdit,
 } from 'vscode-languageserver';
@@ -28,23 +29,35 @@ export class DisableCheckProvider extends BaseCodeActionsProvider {
     const anomaliesUnderCursor = anomalies.filter((anomaly) => isInRange(anomaly, start, end));
     if (anomaliesUnderCursor.length === 0) return [];
 
-    const { offense, diagnostic } = anomaliesUnderCursor[0];
-    const check = offense.check;
+    const byCheck = new Map<string, { offense: Offense; diagnostics: Diagnostic[] }>();
+    for (const { offense, diagnostic } of anomaliesUnderCursor) {
+      const existing = byCheck.get(offense.check);
+      if (existing) {
+        existing.diagnostics.push(diagnostic);
+      } else {
+        byCheck.set(offense.check, { offense, diagnostics: [diagnostic] });
+      }
+    }
 
-    return [
-      toEditCodeAction(
-        `Disable ${check} for this line`,
-        disableNextLineEdit(uri, textDocument, offense.start.line, check),
-        [diagnostic],
-        DisableCheckProvider.kind,
-      ),
-      toEditCodeAction(
-        `Disable ${check} for entire file`,
-        disableFileEdit(uri, check),
-        [diagnostic],
-        DisableCheckProvider.kind,
-      ),
-    ];
+    const actions: CodeAction[] = [];
+    for (const [check, { offense, diagnostics: groupDiagnostics }] of byCheck) {
+      actions.push(
+        toEditCodeAction(
+          `Disable ${check} for this line`,
+          disableNextLineEdit(uri, textDocument, offense.start.line, check),
+          groupDiagnostics,
+          DisableCheckProvider.kind,
+        ),
+        toEditCodeAction(
+          `Disable ${check} for entire file`,
+          disableFileEdit(uri, check),
+          groupDiagnostics,
+          DisableCheckProvider.kind,
+        ),
+      );
+    }
+
+    return actions;
   }
 }
 

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
@@ -1,4 +1,5 @@
-import { Offense, SourceCodeType } from '@shopify/theme-check-common';
+import { Offense, SourceCodeType, findCurrentNode, isError } from '@shopify/theme-check-common';
+import { LiquidHtmlNode, NodeTypes } from '@shopify/liquid-html-parser';
 import {
   CodeAction,
   CodeActionKind,
@@ -41,13 +42,17 @@ export class DisableCheckProvider extends BaseCodeActionsProvider {
 
     const actions: CodeAction[] = [];
     for (const [check, { offense, diagnostics: groupDiagnostics }] of byCheck) {
+      if (!isInsideLiquidTag(document.ast, offense.start.index)) {
+        actions.push(
+          toEditCodeAction(
+            `Disable ${check} for this line`,
+            disableNextLineEdit(uri, textDocument, offense.start.line, check),
+            groupDiagnostics,
+            DisableCheckProvider.kind,
+          ),
+        );
+      }
       actions.push(
-        toEditCodeAction(
-          `Disable ${check} for this line`,
-          disableNextLineEdit(uri, textDocument, offense.start.line, check),
-          groupDiagnostics,
-          DisableCheckProvider.kind,
-        ),
         toEditCodeAction(
           `Disable ${check} for entire file`,
           disableFileEdit(uri, check),
@@ -79,4 +84,12 @@ function disableNextLineEdit(
   const indent = lineText.match(/^[ \t]*/)?.[0] ?? '';
   const newText = `${indent}{% # theme-check-disable-next-line ${check} %}\n`;
   return { changes: { [uri]: [TextEdit.insert({ line, character: 0 }, newText)] } };
+}
+
+function isInsideLiquidTag(ast: LiquidHtmlNode | Error, index: number): boolean {
+  if (isError(ast)) return false;
+  const [currentNode, ancestors] = findCurrentNode(ast, index);
+  return [currentNode, ...ancestors].some(
+    (node) => node.type === NodeTypes.LiquidTag && node.name === 'liquid',
+  );
 }

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
@@ -1,0 +1,58 @@
+import { SourceCodeType } from '@shopify/theme-check-common';
+import {
+  CodeAction,
+  CodeActionKind,
+  CodeActionParams,
+  Command,
+  TextEdit,
+  WorkspaceEdit,
+} from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { BaseCodeActionsProvider } from '../BaseCodeActionsProvider';
+import { isInRange, toEditCodeAction } from './utils';
+
+export class DisableCheckProvider extends BaseCodeActionsProvider {
+  static kind = CodeActionKind.QuickFix;
+
+  codeActions(params: CodeActionParams): (Command | CodeAction)[] {
+    const { uri } = params.textDocument;
+    const document = this.documentManager.get(uri);
+    const diagnostics = this.diagnosticsManager.get(uri);
+    if (!document || !diagnostics || document.type !== SourceCodeType.LiquidHtml) return [];
+
+    const { textDocument } = document;
+    const { anomalies } = diagnostics;
+    const start = textDocument.offsetAt(params.range.start);
+    const end = textDocument.offsetAt(params.range.end);
+
+    const anomaliesUnderCursor = anomalies.filter((anomaly) => isInRange(anomaly, start, end));
+    if (anomaliesUnderCursor.length === 0) return [];
+
+    const { offense, diagnostic } = anomaliesUnderCursor[0];
+    const check = offense.check;
+
+    return [
+      toEditCodeAction(
+        `Disable ${check} for this line`,
+        disableNextLineEdit(uri, textDocument, offense.start.line, check),
+        [diagnostic],
+        DisableCheckProvider.kind,
+      ),
+    ];
+  }
+}
+
+function disableNextLineEdit(
+  uri: string,
+  textDocument: TextDocument,
+  line: number,
+  check: string,
+): WorkspaceEdit {
+  const lineText = textDocument.getText({
+    start: { line, character: 0 },
+    end: { line: line + 1, character: 0 },
+  });
+  const indent = lineText.match(/^[ \t]*/)?.[0] ?? '';
+  const newText = `${indent}{% # theme-check-disable-next-line ${check} %}\n`;
+  return { changes: { [uri]: [TextEdit.insert({ line, character: 0 }, newText)] } };
+}

--- a/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/DisableCheckProvider.ts
@@ -1,5 +1,5 @@
 import { Offense, SourceCodeType, findCurrentNode, isError } from '@shopify/theme-check-common';
-import { LiquidHtmlNode, NodeTypes } from '@shopify/liquid-html-parser';
+import { LiquidHtmlNode, NamedTags, NodeTypes } from '@shopify/liquid-html-parser';
 import {
   CodeAction,
   CodeActionKind,
@@ -42,7 +42,7 @@ export class DisableCheckProvider extends BaseCodeActionsProvider {
 
     const actions: CodeAction[] = [];
     for (const [check, { offense, diagnostics: groupDiagnostics }] of byCheck) {
-      if (!isInsideLiquidTag(document.ast, offense.start.index)) {
+      if (!isInsideLiquidLiquidTag(document.ast, offense.start.index)) {
         actions.push(
           toEditCodeAction(
             `Disable ${check} for this line`,
@@ -86,10 +86,10 @@ function disableNextLineEdit(
   return { changes: { [uri]: [TextEdit.insert({ line, character: 0 }, newText)] } };
 }
 
-function isInsideLiquidTag(ast: LiquidHtmlNode | Error, index: number): boolean {
+function isInsideLiquidLiquidTag(ast: LiquidHtmlNode | Error, index: number): boolean {
   if (isError(ast)) return false;
   const [currentNode, ancestors] = findCurrentNode(ast, index);
   return [currentNode, ...ancestors].some(
-    (node) => node.type === NodeTypes.LiquidTag && node.name === 'liquid',
+    (node) => node.type === NodeTypes.LiquidTag && node.name === NamedTags.liquid,
   );
 }

--- a/packages/theme-language-server-common/src/codeActions/providers/index.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/index.ts
@@ -1,4 +1,4 @@
-export { DisableCheckProvider } from './DisableCheckProvider';
 export { FixProvider } from './FixProvider';
 export { FixAllProvider } from './FixAllProvider';
 export { SuggestionProvider } from './SuggestionProvider';
+export { DisableCheckProvider } from './DisableCheckProvider';

--- a/packages/theme-language-server-common/src/codeActions/providers/index.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/index.ts
@@ -1,3 +1,4 @@
+export { DisableCheckProvider } from './DisableCheckProvider';
 export { FixProvider } from './FixProvider';
 export { FixAllProvider } from './FixAllProvider';
 export { SuggestionProvider } from './SuggestionProvider';

--- a/packages/theme-language-server-common/src/codeActions/providers/utils.ts
+++ b/packages/theme-language-server-common/src/codeActions/providers/utils.ts
@@ -1,5 +1,11 @@
 import { Offense, SourceCodeType, WithRequired } from '@shopify/theme-check-common';
-import { CodeAction, CodeActionKind, Command, Diagnostic } from 'vscode-languageserver';
+import {
+  CodeAction,
+  CodeActionKind,
+  Command,
+  Diagnostic,
+  WorkspaceEdit,
+} from 'vscode-languageserver';
 import { Anomaly } from '../../diagnostics';
 
 // They have an awkard API for creating them, so we have this helper here
@@ -12,6 +18,22 @@ export function toCodeAction(
   isPreferred: boolean = false,
 ): CodeAction {
   const codeAction = CodeAction.create(title, command, kind);
+  codeAction.diagnostics = diagnostics;
+  codeAction.isPreferred = isPreferred;
+  return codeAction;
+}
+
+// Edit-based sibling of toCodeAction: the action carries a WorkspaceEdit
+// directly instead of a server command.
+export function toEditCodeAction(
+  title: string,
+  edit: WorkspaceEdit,
+  diagnostics: Diagnostic[],
+  kind: CodeActionKind,
+  isPreferred: boolean = false,
+): CodeAction {
+  const codeAction = CodeAction.create(title, kind);
+  codeAction.edit = edit;
   codeAction.diagnostics = diagnostics;
   codeAction.isPreferred = isPreferred;
   return codeAction;


### PR DESCRIPTION
## What are you adding in this PR?

ESLint-style quick-fixes for theme-check diagnostics, as requested in #432. When a theme-check offense is under the cursor, two code actions are offered:

- **Disable `<Check>` for this line** — inserts `{% # theme-check-disable-next-line <Check> %}` on the line above, indentation-matched
- **Disable `<Check>` for entire file** — inserts `{% # theme-check-disable <Check> %}` at the top of the file

Actions are grouped by check name, so selecting a range containing several offenses of the same check yields a single pair (not one per offense).

The disable-comment *consumer* already lives in `theme-check-common/disabled-checks`; this PR only adds the *producer* — the code action that writes the comment for you — matching the scope @charlespwd clarified when reopening #432 ("the right click code transformation vs supporting it in code").

Implemented as a new `DisableCheckProvider` in `theme-language-server-common`, mirroring `SuggestionProvider`. Unlike `FixProvider`/`SuggestionProvider` (which dispatch a server command to run an offense's fix function), this provider carries the `WorkspaceEdit` directly, since the inserted text is known and needs no server-side computation. A small `toEditCodeAction` helper was added next to `toCodeAction` for that.

`fixes #432`

### `{% liquid %}` blocks
Inside a `{% liquid %}` tag, comments are bare `#` lines rather than `{% # %}`, so a `{% # %}` insertion would be invalid there. For now the **for this line** action is suppressed when the offense is inside a `{% liquid %}` block (detected via `findCurrentNode`); **for entire file** is still offered (it inserts at the top of the file, always valid).

## What's next? Any followup issues?

- Emit the bare-`#` `theme-check-disable-next-line` form for offenses inside `{% liquid %}` blocks (currently the line-level action is skipped there).
- When a single check has offenses both inside and outside a `{% liquid %}` block within one selection, the first-seen offense decides whether the line-level action is offered and where the comment lands. Happy to refine to per-offense handling if you prefer.

## What did you learn?

`theme-check-disable` (no `-next-line`) disables from the comment to EOF, so the file-level action just inserts at the top — no need to track an end marker.

## Tophatting

Manually tophatted in a real extension host (vscode-test-web against a Dawn clone, with planted `UnusedAssign` offenses), plus unit tests.

To reproduce:

```
cd packages/vscode-extension
pnpm build
git clone --depth 1 https://github.com/Shopify/dawn.git .tmp/dawn
# plant an offense, e.g. an unused {% assign %} in a snippet
pnpm exec vscode-test-web --quality=stable --extensionDevelopmentPath=. .tmp/dawn
```

1. Cursor on an offense → quick fix menu offers both new actions alongside the existing suggestion:

   ![Code action menu showing Disable UnusedAssign for this line / entire file](https://raw.githubusercontent.com/ryandiginomad/theme-tools/assets-pr-1217-tophat/code-action-menu.png)

2. **Disable for this line** → inserts `{% # theme-check-disable-next-line UnusedAssign %}` above the offense, indentation-matched; the diagnostic clears:

   ![Disable-next-line comment inserted, diagnostic gone](https://raw.githubusercontent.com/ryandiginomad/theme-tools/assets-pr-1217-tophat/disable-line-applied.png)

3. **Disable for entire file** → inserts `{% # theme-check-disable UnusedAssign %}` at the top of the file:

   ![File-level disable comment inserted at top of file](https://raw.githubusercontent.com/ryandiginomad/theme-tools/assets-pr-1217-tophat/disable-file-applied.png)

4. Offense **inside a `{% liquid %}` block** → only the file-level action is offered (line-level correctly suppressed, as described above):

   ![Inside liquid block only entire-file action offered](https://raw.githubusercontent.com/ryandiginomad/theme-tools/assets-pr-1217-tophat/liquid-block-suppression.png)

Unit tests (mirroring `SuggestionProvider.spec.ts`) assert the exact `WorkspaceEdit` for both variants, grouping/dedup, multiple distinct checks, the no-offense case, and the `{% liquid %}` skip + outside-`{% liquid %}` cases. `pnpm test` for the package: 440 passed, type-check and prettier clean.

- [x] I added screenshots of the changes (no actions existed before this change; screenshots show the new flow)

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible

---

🤖 **AI assistance disclosure** — this PR was written with AI assistance (Claude Code). I directed the design (edit-based approach, the `{% liquid %}` v1 skip), reviewed every change, and it follows TDD with unit tests verified locally. I understand the code and can explain why it's correct.

Open to feedback on: (1) edit-based vs command-based (chose edit-based as there's nothing to compute server-side); (2) the `{% liquid %}` v1 skip vs emitting bare `#`; (3) the representative-offense behavior noted above.
