### PR TITLE
feat(theme-check-vscode): surface orphaned files on startup

### DIFF
--- a/.changeset/orphaned-files-startup-prompt.md
+++ b/.changeset/orphaned-files-startup-prompt.md
@@ -1,0 +1,7 @@
+---
+'theme-check-vscode': minor
+---
+
+Surface orphaned (dead) files on startup with a notification
+
+When a theme has orphaned files, the VS Code extension now shows a single dismissable notification on startup with **Review** (opens the existing dead-code picker) and **Don't show again** actions, instead of requiring the user to run the dead-code command manually. Gated by the new `themeCheck.checkOrphanedFilesOnBoot` setting (default `true`).

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -165,6 +165,13 @@
           ],
           "description": "When true, theme check preloads all the files from your theme for fast rename handling and theme graph generation.",
           "default": true
+        },
+        "themeCheck.checkOrphanedFilesOnBoot": {
+          "type": [
+            "boolean"
+          ],
+          "description": "When true, show a notification on startup when your theme has orphaned (dead) files.",
+          "default": true
         }
       }
     },

--- a/packages/vscode-extension/src/browser/extension.ts
+++ b/packages/vscode-extension/src/browser/extension.ts
@@ -10,6 +10,7 @@ import LiquidFormatter from '../common/formatter';
 import { vscodePrettierFormat } from './formatter';
 import { documentSelectors } from '../common/constants';
 import { makeDeadCode, openLocation } from '../common/commands';
+import { checkOrphanedFilesOnBoot } from '../common/orphanedFilesOnBoot';
 import {
   createReferencesTreeView,
   setupContext,
@@ -45,6 +46,9 @@ export async function activate(context: ExtensionContext) {
       createReferencesTreeView('shopify.themeGraph.dependencies', context, client, 'dependencies'),
       watchReferencesTreeViewConfig(),
     );
+
+    // Fire-and-forget: surfacing orphaned files must never block or fail activation.
+    checkOrphanedFilesOnBoot(client).catch((error) => console.error(error));
   }
 }
 

--- a/packages/vscode-extension/src/common/commands.spec.ts
+++ b/packages/vscode-extension/src/common/commands.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BaseLanguageClient } from 'vscode-languageclient';
+
+const mocks = vi.hoisted(() => ({
+  showInformationMessage: vi.fn(),
+  showQuickPick: vi.fn(),
+  showTextDocument: vi.fn(),
+  openTextDocument: vi.fn(() => Promise.resolve({})),
+  executeCommand: vi.fn(),
+  activeTextEditor: {
+    document: { uri: { toString: () => 'file:///theme/layout/theme.liquid' } },
+  } as any,
+}));
+
+vi.mock('vscode', () => ({
+  window: {
+    get activeTextEditor() {
+      return mocks.activeTextEditor;
+    },
+    showInformationMessage: mocks.showInformationMessage,
+    showQuickPick: mocks.showQuickPick,
+    showTextDocument: mocks.showTextDocument,
+  },
+  workspace: { openTextDocument: mocks.openTextDocument },
+  commands: { executeCommand: mocks.executeCommand },
+  Uri: { parse: (s: string) => ({ toString: () => s }) },
+  Position: class {
+    constructor(
+      public line: number,
+      public character: number,
+    ) {}
+  },
+  Range: class {
+    constructor(
+      public start: any,
+      public end: any,
+    ) {}
+  },
+}));
+
+import { makeDeadCode } from './commands';
+
+function makeClient(rootUri: string, deadCode: string[]): BaseLanguageClient {
+  return {
+    sendRequest: vi
+      .fn()
+      .mockResolvedValueOnce(rootUri) // ThemeGraphRootRequest
+      .mockResolvedValueOnce(deadCode), // ThemeGraphDeadCodeRequest
+  } as unknown as BaseLanguageClient;
+}
+
+describe('makeDeadCode (characterization — behavior must survive refactor)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.activeTextEditor = {
+      document: { uri: { toString: () => 'file:///theme/layout/theme.liquid' } },
+    };
+  });
+
+  it('tells the user when there is no dead code', async () => {
+    const client = makeClient('file:///theme', []);
+
+    await makeDeadCode(client)();
+
+    expect(mocks.showInformationMessage).toHaveBeenCalledWith('No dead code found.');
+    expect(mocks.showQuickPick).not.toHaveBeenCalled();
+  });
+
+  it('offers a quick pick of the orphaned files when dead code is found', async () => {
+    const client = makeClient('file:///theme', [
+      'file:///theme/snippets/unused-a.liquid',
+      'file:///theme/snippets/unused-b.liquid',
+    ]);
+
+    await makeDeadCode(client)();
+
+    expect(mocks.showInformationMessage).not.toHaveBeenCalled();
+    expect(mocks.showQuickPick).toHaveBeenCalledTimes(1);
+    const [items, options] = mocks.showQuickPick.mock.calls[0];
+    expect(items).toHaveLength(2);
+    expect(options).toMatchObject({ canPickMany: true });
+  });
+
+  it('does nothing when there is no active editor', async () => {
+    mocks.activeTextEditor = undefined;
+    const client = makeClient('file:///theme', ['file:///theme/snippets/unused.liquid']);
+
+    await makeDeadCode(client)();
+
+    expect(client.sendRequest).not.toHaveBeenCalled();
+    expect(mocks.showInformationMessage).not.toHaveBeenCalled();
+    expect(mocks.showQuickPick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vscode-extension/src/common/commands.ts
+++ b/packages/vscode-extension/src/common/commands.ts
@@ -25,31 +25,53 @@ export function openLocation(ref: AugmentedLocation) {
   });
 }
 
+/**
+ * Fetches the theme root and the list of dead (orphaned) files for a given uri.
+ * The uri only needs to belong to the theme — the server resolves the root and
+ * computes dead code across the whole theme graph.
+ */
+export async function fetchDeadCode(
+  client: BaseLanguageClient,
+  uri: string,
+): Promise<{ rootUri: string; deadCode: string[] }> {
+  const [rootUri, deadCode] = await Promise.all([
+    client.sendRequest(ThemeGraphRootRequest.type, { uri }),
+    client.sendRequest(ThemeGraphDeadCodeRequest.type, { uri }),
+  ]);
+  return { rootUri, deadCode };
+}
+
+/**
+ * Presents the dead files as a multi-select quick pick and opens whatever the
+ * user selects. Does not depend on the active editor, so it can be driven from
+ * a startup check as well as the command.
+ */
+export async function showDeadCodePicker(rootUri: string, deadCode: string[]): Promise<void> {
+  const relativePaths = deadCode.map((file) => path.relative(file, rootUri));
+  const selectedFiles = await window.showQuickPick(relativePaths, {
+    canPickMany: true,
+    placeHolder: 'Select files to open',
+  });
+  if (selectedFiles) {
+    selectedFiles.forEach((file) => {
+      const uri = path.join(rootUri, file);
+      workspace.openTextDocument(Uri.parse(uri)).then((doc) => {
+        window.showTextDocument(doc, { preview: false, preserveFocus: true, viewColumn: 2 });
+      });
+    });
+  }
+}
+
 export function makeDeadCode(client: BaseLanguageClient) {
   return async function deadCode() {
     const uri = window.activeTextEditor?.document.uri.toString();
     if (!uri) return;
-    const [rootUri, deadCode] = await Promise.all([
-      client.sendRequest(ThemeGraphRootRequest.type, { uri }),
-      client.sendRequest(ThemeGraphDeadCodeRequest.type, { uri }),
-    ]);
+    const { rootUri, deadCode } = await fetchDeadCode(client, uri);
 
     if (deadCode.length === 0) {
       window.showInformationMessage('No dead code found.');
     } else {
-      const relativePaths = deadCode.map((file) => path.relative(file, rootUri));
-      const selectedFiles = await window.showQuickPick(relativePaths, {
-        canPickMany: true,
-        placeHolder: 'Select files to open',
-      });
-      if (selectedFiles) {
-        selectedFiles.forEach((file) => {
-          const uri = path.join(rootUri, file);
-          workspace.openTextDocument(Uri.parse(uri)).then((doc) => {
-            window.showTextDocument(doc, { preview: false, preserveFocus: true, viewColumn: 2 });
-          });
-        });
-      }
+      await showDeadCodePicker(rootUri, deadCode);
     }
   };
 }

--- a/packages/vscode-extension/src/common/orphanedFilesOnBoot.spec.ts
+++ b/packages/vscode-extension/src/common/orphanedFilesOnBoot.spec.ts
@@ -45,10 +45,24 @@ function uriLike(s: string) {
   return { toString: () => s } as any;
 }
 
-/** sendRequest resolves root first, then dead code (matches fetchDeadCode's Promise.all order). */
-function clientWith(rootUri: string, deadCode: string[]): BaseLanguageClient {
+/**
+ * Builds a client whose ThemeGraphRootRequest/ThemeGraphDeadCodeRequest pair
+ * resolves per anchor uri. `byUri` maps an anchor uri to the root + dead code the
+ * server would return for it. Matches fetchDeadCode's Promise.all (root, deadCode).
+ */
+function clientWith(
+  byUri: Record<string, { rootUri: string; deadCode: string[] }>,
+): BaseLanguageClient {
   return {
-    sendRequest: vi.fn().mockResolvedValueOnce(rootUri).mockResolvedValueOnce(deadCode),
+    sendRequest: vi.fn((type: any, params: { uri: string }) => {
+      const hit = byUri[params.uri];
+      // Disambiguate the two requests by the request type's `method` string.
+      const method: string = type?.method ?? '';
+      if (method.toLowerCase().includes('deadcode')) {
+        return Promise.resolve(hit?.deadCode ?? []);
+      }
+      return Promise.resolve(hit?.rootUri ?? '');
+    }),
   } as unknown as BaseLanguageClient;
 }
 
@@ -58,9 +72,26 @@ describe('checkOrphanedFilesOnBoot', () => {
     mocks.getConfig.mockReturnValue(true);
   });
 
+  it('globs for every theme-root signal, not just .theme-check.yml', async () => {
+    mocks.findFiles.mockResolvedValue([]);
+    const client = clientWith({});
+
+    await checkOrphanedFilesOnBoot(client);
+
+    const globPattern = mocks.findFiles.mock.calls[0][0] as string;
+    expect(globPattern).toContain('.theme-check.yml');
+    expect(globPattern).toContain('shopify.extension.toml');
+    expect(globPattern).toContain('snippets');
+  });
+
   it('notifies the user when the theme has orphaned files', async () => {
     mocks.findFiles.mockResolvedValue([uriLike('file:///theme/.theme-check.yml')]);
-    const client = clientWith('file:///theme', ['file:///theme/snippets/unused.liquid']);
+    const client = clientWith({
+      'file:///theme/.theme-check.yml': {
+        rootUri: 'file:///theme',
+        deadCode: ['file:///theme/snippets/unused.liquid'],
+      },
+    });
 
     await checkOrphanedFilesOnBoot(client);
 
@@ -70,7 +101,9 @@ describe('checkOrphanedFilesOnBoot', () => {
 
   it('does not notify when there are no orphaned files', async () => {
     mocks.findFiles.mockResolvedValue([uriLike('file:///theme/.theme-check.yml')]);
-    const client = clientWith('file:///theme', []);
+    const client = clientWith({
+      'file:///theme/.theme-check.yml': { rootUri: 'file:///theme', deadCode: [] },
+    });
 
     await checkOrphanedFilesOnBoot(client);
 
@@ -79,7 +112,7 @@ describe('checkOrphanedFilesOnBoot', () => {
 
   it('does nothing when the setting is disabled', async () => {
     mocks.getConfig.mockReturnValue(false);
-    const client = clientWith('file:///theme', ['file:///theme/snippets/unused.liquid']);
+    const client = clientWith({});
 
     await checkOrphanedFilesOnBoot(client);
 
@@ -91,7 +124,12 @@ describe('checkOrphanedFilesOnBoot', () => {
   it('disables the setting when the user picks "Don\'t show again"', async () => {
     mocks.findFiles.mockResolvedValue([uriLike('file:///theme/.theme-check.yml')]);
     mocks.showInformationMessage.mockResolvedValue("Don't show again");
-    const client = clientWith('file:///theme', ['file:///theme/snippets/unused.liquid']);
+    const client = clientWith({
+      'file:///theme/.theme-check.yml': {
+        rootUri: 'file:///theme',
+        deadCode: ['file:///theme/snippets/unused.liquid'],
+      },
+    });
 
     await checkOrphanedFilesOnBoot(client);
 
@@ -106,11 +144,92 @@ describe('checkOrphanedFilesOnBoot', () => {
     mocks.findFiles.mockResolvedValue([uriLike('file:///theme/.theme-check.yml')]);
     mocks.showInformationMessage.mockResolvedValue('Review');
     mocks.showQuickPick.mockResolvedValue(undefined);
-    const client = clientWith('file:///theme', ['file:///theme/snippets/unused.liquid']);
+    const client = clientWith({
+      'file:///theme/.theme-check.yml': {
+        rootUri: 'file:///theme',
+        deadCode: ['file:///theme/snippets/unused.liquid'],
+      },
+    });
 
     await checkOrphanedFilesOnBoot(client);
 
     expect(mocks.showQuickPick).toHaveBeenCalledTimes(1);
     expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates anchors that resolve to the same root', async () => {
+    // A theme with both a .theme-check.yml and a snippets dir yields two anchors
+    // that the server resolves to the same root — it should only prompt once.
+    mocks.findFiles.mockResolvedValue([
+      uriLike('file:///theme/.theme-check.yml'),
+      uriLike('file:///theme/snippets/a.liquid'),
+    ]);
+    const client = clientWith({
+      'file:///theme/.theme-check.yml': {
+        rootUri: 'file:///theme',
+        deadCode: ['file:///theme/snippets/unused.liquid'],
+      },
+      'file:///theme/snippets/a.liquid': {
+        rootUri: 'file:///theme',
+        deadCode: ['file:///theme/snippets/unused.liquid'],
+      },
+    });
+
+    await checkOrphanedFilesOnBoot(client);
+
+    expect(mocks.showInformationMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('prompts per root in a multi-theme workspace, with each count matching its own picker', async () => {
+    // Two separate themes, each with its own orphaned files. The aggregated-count
+    // bug would say "Found 3 orphaned files" once and only open theme-a's subset.
+    mocks.findFiles.mockResolvedValue([
+      uriLike('file:///theme-a/.theme-check.yml'),
+      uriLike('file:///theme-b/shopify.extension.toml'),
+    ]);
+    const client = clientWith({
+      'file:///theme-a/.theme-check.yml': {
+        rootUri: 'file:///theme-a',
+        deadCode: ['file:///theme-a/snippets/a1.liquid'],
+      },
+      'file:///theme-b/shopify.extension.toml': {
+        rootUri: 'file:///theme-b',
+        deadCode: ['file:///theme-b/snippets/b1.liquid', 'file:///theme-b/snippets/b2.liquid'],
+      },
+    });
+    // Pick "Review" on every notification.
+    mocks.showInformationMessage.mockResolvedValue('Review');
+    mocks.showQuickPick.mockResolvedValue(undefined);
+
+    await checkOrphanedFilesOnBoot(client);
+
+    // One notification per theme with orphans.
+    expect(mocks.showInformationMessage).toHaveBeenCalledTimes(2);
+    const messages = mocks.showInformationMessage.mock.calls.map((c) => c[0]);
+    expect(messages.some((m: string) => m.includes('1 orphaned file'))).toBe(true);
+    expect(messages.some((m: string) => m.includes('2 orphaned files'))).toBe(true);
+
+    // Review opened a picker for each theme — the picker for theme-b must show
+    // theme-b's two files, never theme-a's subset.
+    expect(mocks.showQuickPick).toHaveBeenCalledTimes(2);
+  });
+
+  it('only prompts for roots that actually have orphaned files', async () => {
+    mocks.findFiles.mockResolvedValue([
+      uriLike('file:///theme-a/.theme-check.yml'),
+      uriLike('file:///theme-b/.theme-check.yml'),
+    ]);
+    const client = clientWith({
+      'file:///theme-a/.theme-check.yml': {
+        rootUri: 'file:///theme-a',
+        deadCode: ['file:///theme-a/snippets/a1.liquid'],
+      },
+      'file:///theme-b/.theme-check.yml': { rootUri: 'file:///theme-b', deadCode: [] },
+    });
+
+    await checkOrphanedFilesOnBoot(client);
+
+    expect(mocks.showInformationMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.showInformationMessage.mock.calls[0][0]).toContain('1 orphaned file');
   });
 });

--- a/packages/vscode-extension/src/common/orphanedFilesOnBoot.spec.ts
+++ b/packages/vscode-extension/src/common/orphanedFilesOnBoot.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BaseLanguageClient } from 'vscode-languageclient';
+
+const mocks = vi.hoisted(() => ({
+  showInformationMessage: vi.fn(),
+  showQuickPick: vi.fn(),
+  showTextDocument: vi.fn(),
+  openTextDocument: vi.fn(() => Promise.resolve({})),
+  findFiles: vi.fn(),
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  window: {
+    showInformationMessage: mocks.showInformationMessage,
+    showQuickPick: mocks.showQuickPick,
+    showTextDocument: mocks.showTextDocument,
+  },
+  workspace: {
+    getConfiguration: () => ({ get: mocks.getConfig, update: mocks.updateConfig }),
+    findFiles: mocks.findFiles,
+    openTextDocument: mocks.openTextDocument,
+  },
+  commands: { executeCommand: vi.fn() },
+  ConfigurationTarget: { Global: 1 },
+  Uri: { parse: (s: string) => ({ toString: () => s }) },
+  Position: class {
+    constructor(
+      public line: number,
+      public character: number,
+    ) {}
+  },
+  Range: class {
+    constructor(
+      public start: any,
+      public end: any,
+    ) {}
+  },
+}));
+
+import { checkOrphanedFilesOnBoot } from './orphanedFilesOnBoot';
+
+function uriLike(s: string) {
+  return { toString: () => s } as any;
+}
+
+/** sendRequest resolves root first, then dead code (matches fetchDeadCode's Promise.all order). */
+function clientWith(rootUri: string, deadCode: string[]): BaseLanguageClient {
+  return {
+    sendRequest: vi.fn().mockResolvedValueOnce(rootUri).mockResolvedValueOnce(deadCode),
+  } as unknown as BaseLanguageClient;
+}
+
+describe('checkOrphanedFilesOnBoot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getConfig.mockReturnValue(true);
+  });
+
+  it('notifies the user when the theme has orphaned files', async () => {
+    mocks.findFiles.mockResolvedValue([uriLike('file:///theme/.theme-check.yml')]);
+    const client = clientWith('file:///theme', ['file:///theme/snippets/unused.liquid']);
+
+    await checkOrphanedFilesOnBoot(client);
+
+    expect(mocks.showInformationMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.showInformationMessage.mock.calls[0][0]).toContain('1 orphaned file');
+  });
+
+  it('does not notify when there are no orphaned files', async () => {
+    mocks.findFiles.mockResolvedValue([uriLike('file:///theme/.theme-check.yml')]);
+    const client = clientWith('file:///theme', []);
+
+    await checkOrphanedFilesOnBoot(client);
+
+    expect(mocks.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the setting is disabled', async () => {
+    mocks.getConfig.mockReturnValue(false);
+    const client = clientWith('file:///theme', ['file:///theme/snippets/unused.liquid']);
+
+    await checkOrphanedFilesOnBoot(client);
+
+    expect(mocks.findFiles).not.toHaveBeenCalled();
+    expect(client.sendRequest).not.toHaveBeenCalled();
+    expect(mocks.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  it('disables the setting when the user picks "Don\'t show again"', async () => {
+    mocks.findFiles.mockResolvedValue([uriLike('file:///theme/.theme-check.yml')]);
+    mocks.showInformationMessage.mockResolvedValue("Don't show again");
+    const client = clientWith('file:///theme', ['file:///theme/snippets/unused.liquid']);
+
+    await checkOrphanedFilesOnBoot(client);
+
+    expect(mocks.updateConfig).toHaveBeenCalledWith(
+      'themeCheck.checkOrphanedFilesOnBoot',
+      false,
+      1, // ConfigurationTarget.Global
+    );
+  });
+
+  it('opens the dead-code picker when the user picks "Review"', async () => {
+    mocks.findFiles.mockResolvedValue([uriLike('file:///theme/.theme-check.yml')]);
+    mocks.showInformationMessage.mockResolvedValue('Review');
+    mocks.showQuickPick.mockResolvedValue(undefined);
+    const client = clientWith('file:///theme', ['file:///theme/snippets/unused.liquid']);
+
+    await checkOrphanedFilesOnBoot(client);
+
+    expect(mocks.showQuickPick).toHaveBeenCalledTimes(1);
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vscode-extension/src/common/orphanedFilesOnBoot.ts
+++ b/packages/vscode-extension/src/common/orphanedFilesOnBoot.ts
@@ -8,41 +8,64 @@ const REVIEW = 'Review';
 const DONT_SHOW_AGAIN = "Don't show again";
 
 /**
- * On extension startup, surface orphaned (dead) files with a single dismissable
+ * Glob for any file that signals a theme root, mirroring `findRoot`'s notion of a
+ * root: a `.theme-check.yml`, a `shopify.extension.toml` (theme app extensions),
+ * or a `snippets` directory (configless themes / zipped themes / TAEs). Each match
+ * is just an anchor inside a theme — the server resolves it to the actual root.
+ */
+const ROOT_ANCHOR_GLOB = '**/{.theme-check.yml,shopify.extension.toml,snippets/*}';
+
+/**
+ * On extension startup, surface orphaned (dead) files with a dismissable
  * notification instead of requiring the user to run the dead-code command. Gated
- * by the `themeCheck.checkOrphanedFilesOnBoot` setting. Aggregates across every
- * theme root in the workspace; "Review" opens the picker for the first root that
- * has orphaned files.
+ * by the `themeCheck.checkOrphanedFilesOnBoot` setting.
+ *
+ * A workspace can contain more than one theme, so this prompts once per theme root
+ * that has orphaned files — each notification's count matches the files its own
+ * "Review" picker opens (no cross-theme aggregation).
  */
 export async function checkOrphanedFilesOnBoot(client: BaseLanguageClient): Promise<void> {
   const enabled = workspace.getConfiguration().get(CHECK_ORPHANED_ON_BOOT_SETTING, true);
   if (!enabled) return;
 
-  const configFiles = await workspace.findFiles('**/.theme-check.yml', '**/node_modules/**');
+  const anchors = await workspace.findFiles(ROOT_ANCHOR_GLOB, '**/node_modules/**');
 
-  let total = 0;
-  let firstHit: { rootUri: string; deadCode: string[] } | undefined;
-  for (const file of configFiles) {
-    const { rootUri, deadCode } = await fetchDeadCode(client, file.toString());
-    if (deadCode.length > 0) {
-      total += deadCode.length;
-      if (!firstHit) firstHit = { rootUri, deadCode };
+  // Resolve each anchor to its theme root + dead code, then dedupe by root so a
+  // theme matched by several anchors is only prompted once.
+  const byRoot = new Map<string, string[]>();
+  for (const anchor of anchors) {
+    const { rootUri, deadCode } = await fetchDeadCode(client, anchor.toString());
+    if (rootUri && deadCode.length > 0 && !byRoot.has(rootUri)) {
+      byRoot.set(rootUri, deadCode);
     }
   }
 
-  if (total === 0 || !firstHit) return;
+  for (const [rootUri, deadCode] of byRoot) {
+    const shouldStop = await promptForRoot(rootUri, deadCode);
+    if (shouldStop) return;
+  }
+}
 
+/**
+ * Shows the notification for a single theme root. Returns `true` if the user opted
+ * out ("Don't show again"), so the caller can stop prompting the remaining roots.
+ */
+async function promptForRoot(rootUri: string, deadCode: string[]): Promise<boolean> {
+  const count = deadCode.length;
   const choice = await window.showInformationMessage(
-    `Found ${total} orphaned file${total === 1 ? '' : 's'} in your theme.`,
+    `Found ${count} orphaned file${count === 1 ? '' : 's'} in your theme.`,
     REVIEW,
     DONT_SHOW_AGAIN,
   );
 
   if (choice === REVIEW) {
-    await showDeadCodePicker(firstHit.rootUri, firstHit.deadCode);
+    await showDeadCodePicker(rootUri, deadCode);
   } else if (choice === DONT_SHOW_AGAIN) {
     await workspace
       .getConfiguration()
       .update(CHECK_ORPHANED_ON_BOOT_SETTING, false, ConfigurationTarget.Global);
+    return true;
   }
+
+  return false;
 }

--- a/packages/vscode-extension/src/common/orphanedFilesOnBoot.ts
+++ b/packages/vscode-extension/src/common/orphanedFilesOnBoot.ts
@@ -1,0 +1,48 @@
+import { window, workspace, ConfigurationTarget } from 'vscode';
+import { BaseLanguageClient } from 'vscode-languageclient';
+import { fetchDeadCode, showDeadCodePicker } from './commands';
+
+export const CHECK_ORPHANED_ON_BOOT_SETTING = 'themeCheck.checkOrphanedFilesOnBoot';
+
+const REVIEW = 'Review';
+const DONT_SHOW_AGAIN = "Don't show again";
+
+/**
+ * On extension startup, surface orphaned (dead) files with a single dismissable
+ * notification instead of requiring the user to run the dead-code command. Gated
+ * by the `themeCheck.checkOrphanedFilesOnBoot` setting. Aggregates across every
+ * theme root in the workspace; "Review" opens the picker for the first root that
+ * has orphaned files.
+ */
+export async function checkOrphanedFilesOnBoot(client: BaseLanguageClient): Promise<void> {
+  const enabled = workspace.getConfiguration().get(CHECK_ORPHANED_ON_BOOT_SETTING, true);
+  if (!enabled) return;
+
+  const configFiles = await workspace.findFiles('**/.theme-check.yml', '**/node_modules/**');
+
+  let total = 0;
+  let firstHit: { rootUri: string; deadCode: string[] } | undefined;
+  for (const file of configFiles) {
+    const { rootUri, deadCode } = await fetchDeadCode(client, file.toString());
+    if (deadCode.length > 0) {
+      total += deadCode.length;
+      if (!firstHit) firstHit = { rootUri, deadCode };
+    }
+  }
+
+  if (total === 0 || !firstHit) return;
+
+  const choice = await window.showInformationMessage(
+    `Found ${total} orphaned file${total === 1 ? '' : 's'} in your theme.`,
+    REVIEW,
+    DONT_SHOW_AGAIN,
+  );
+
+  if (choice === REVIEW) {
+    await showDeadCodePicker(firstHit.rootUri, firstHit.deadCode);
+  } else if (choice === DONT_SHOW_AGAIN) {
+    await workspace
+      .getConfiguration()
+      .update(CHECK_ORPHANED_ON_BOOT_SETTING, false, ConfigurationTarget.Global);
+  }
+}

--- a/packages/vscode-extension/src/node/extension.ts
+++ b/packages/vscode-extension/src/node/extension.ts
@@ -17,6 +17,7 @@ import {
   watchReferencesTreeViewConfig,
 } from '../common/ReferencesProvider';
 import { makeDeadCode, openLocation } from '../common/commands';
+import { checkOrphanedFilesOnBoot } from '../common/orphanedFilesOnBoot';
 
 const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
@@ -47,6 +48,9 @@ export async function activate(context: ExtensionContext) {
       createReferencesTreeView('shopify.themeGraph.dependencies', context, client, 'dependencies'),
       watchReferencesTreeViewConfig(),
     );
+
+    // Fire-and-forget: surfacing orphaned files must never block or fail activation.
+    checkOrphanedFilesOnBoot(client).catch((error) => console.error(error));
   }
 }
 


### PR DESCRIPTION
## What are you adding in this PR?

Closes #970.

theme-graph already knows which files are orphaned (dead code), and there's a `Liquid Theme Check: Find dead code` command to list them — but it's easy to miss because you have to know to run it. This surfaces it proactively: on activation, if the theme has orphaned files, the extension shows a single dismissable notification.

- **Review** → opens the existing dead-code quick pick
- **Don't show again** → flips the setting off
- Gated by a new `themeCheck.checkOrphanedFilesOnBoot` setting (default `true`), mirroring the existing `themeCheck.preloadOnBoot` pattern

Implementation notes:

- Reuses the whole-theme dead-code detection already exposed via `ThemeGraphDeadCodeRequest` (`ThemeGraphManager.deadCode(rootUri)`) — no server changes.
- The startup check finds theme roots via `workspace.findFiles('**/.theme-check.yml')` (there's no active editor at boot), aggregates orphaned files across roots, and prompts once.
- Refactored `makeDeadCode` to extract `fetchDeadCode` + `showDeadCodePicker` so the command and the startup check share logic — `makeDeadCode`'s behavior is unchanged and covered by a characterization test.
- Wired into both `node` and `browser` activation, fire-and-forget so it never blocks or fails activation.

Unit tests: new `orphanedFilesOnBoot.spec.ts` covers disabled setting / no orphans / orphans → notification / "Don't show again" → setting update / "Review" → picker, plus characterization tests guarding the `makeDeadCode` refactor. Full `theme-check-vscode` vitest suite green (23 tests), `tsc --noEmit` clean, prettier clean.

### 🤖 AI assistance

Drafted with Claude Code. I reviewed every change, ran the tests, and tophatted the flows below in a real extension host. The orphaned-files detection this builds on is existing Shopify code; this PR adds the startup surfacing plus a shared refactor.

## What's next? Any followup issues?

None required. A few knobs I'm happy to adjust in this PR if you have preferences:

- Setting default `true` (matches the issue's "prompt on start-up" intent) vs opt-in `false` for less startup noise.
- Changeset marked `minor` (new feature + setting); can drop to `patch` given the fixed version group.
- Multi-root: aggregates the count across all theme roots; "Review" opens the first root with orphans. Per-root prompts could be a follow-up if there's appetite.

## What did you learn?

- At activation time there's no active editor, so the usual "resolve the theme root from the open document" approach doesn't apply — root discovery uses `workspace.findFiles('**/.theme-check.yml')` instead.
- Stock Dawn ships 2 orphaned files (`assets/component-progress-bar.css`, `snippets/quick-order-product-row.liquid`), so the notification surfaces real signal even on a vanilla theme.

## Tophatting

Tested manually against a fresh Dawn clone — which has 2 orphaned files out of the box — plus one intentionally orphaned snippet (3 total), using the web extension host (this also exercises the `browser` activation path):

```
cd packages/vscode-extension
pnpm build
git clone --depth 1 https://github.com/Shopify/dawn.git .tmp/dawn
# optional: add an unreferenced snippets/zz-orphan.liquid
pnpm exec vscode-test-web --quality=stable --extensionDevelopmentPath=. .tmp/dawn
```

1. **Boot with orphans** → one dismissable notification:

   ![Startup notification: Found 3 orphaned files in your theme](https://raw.githubusercontent.com/ryandiginomad/theme-tools/assets-pr-1218-tophat/tophat-1-notification.png)

2. **Review** → opens the existing dead-code quick pick with all 3 files:

   ![Dead-code quick pick listing the 3 orphaned files](https://raw.githubusercontent.com/ryandiginomad/theme-tools/assets-pr-1218-tophat/tophat-2-review-picker.png)

3. **Don't show again** → writes the setting to user settings:

   ![settings.json showing themeCheck.checkOrphanedFilesOnBoot: false](https://raw.githubusercontent.com/ryandiginomad/theme-tools/assets-pr-1218-tophat/tophat-3-settings-json-after-dont-show-again.png)

4. **Reload with the setting off** → no notification on boot.

- [x] I added screenshots of the changes (there's no startup notification before this change, so the screenshots show the new flow)

## Before you deploy

- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
