### PR TITLE
Drop end-of-life Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
 
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
 
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: [18, 20]
+        node-version: [22, 24]
 
     name: Tests / OS ${{ matrix.os }} / NodeJS ${{ matrix.node-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24 # Needed for npm@11 for Trusted Publishing
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
 

--- a/dev.yml
+++ b/dev.yml
@@ -4,5 +4,5 @@ dev.edition: 2024
 
 up:
   - node:
-      version: v22.14.0
+      version: v24.16.0
       package_manager: pnpm@10.16.1

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
   },
   "packageManager": "pnpm@10.16.1",
   "pnpm": {
+    "overrides": {
+      "@playwright/browser-chromium": "1.60.0",
+      "playwright": "1.60.0",
+      "playwright-core": "1.60.0"
+    },
     "onlyBuiltDependencies": [
       "@playwright/browser-chromium",
       "@vscode/vsce-sign",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@playwright/browser-chromium': 1.60.0
+  playwright: 1.60.0
+  playwright-core: 1.60.0
+
 importers:
 
   .:
@@ -1305,8 +1310,8 @@ packages:
     resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
     engines: {node: '>=20.0.0'}
 
-  '@playwright/browser-chromium@1.58.0':
-    resolution: {integrity: sha512-nWvMnhcux/fTzlzCBcJZicrsPEKNSaJ9Ad3Ve3sEf5BJY6l1TkYBLcRNx0VlNlziERNvpQBYW8r5xY+zpMPuCw==}
+  '@playwright/browser-chromium@1.60.0':
+    resolution: {integrity: sha512-0ND2pbNWKJYwhlA1LNaDC3DP2x7eguQkQF7Ga7XAlJV0AFieqYNRw/E+gaY9BpSFr1TYwfwXQv1bHq5AK9nbvA==}
     engines: {node: '>=18'}
 
   '@replit/codemirror-vim@6.2.1':
@@ -4214,13 +4219,13 @@ packages:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.58.0:
-    resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.0:
-    resolution: {integrity: sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6491,9 +6496,9 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
-  '@playwright/browser-chromium@1.58.0':
+  '@playwright/browser-chromium@1.60.0':
     dependencies:
-      playwright-core: 1.58.0
+      playwright-core: 1.60.0
 
   '@replit/codemirror-vim@6.2.1(@codemirror/commands@6.3.0)(@codemirror/language@6.9.1)(@codemirror/search@6.5.4)(@codemirror/state@6.3.0)(@codemirror/view@6.21.3)':
     dependencies:
@@ -7087,7 +7092,7 @@ snapshots:
     dependencies:
       '@koa/cors': 5.0.0
       '@koa/router': 15.3.0(koa@3.1.2)
-      '@playwright/browser-chromium': 1.58.0
+      '@playwright/browser-chromium': 1.60.0
       gunzip-maybe: 1.4.2
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -7096,7 +7101,7 @@ snapshots:
       koa-mount: 4.2.0
       koa-static: 5.0.0
       minimist: 1.2.8
-      playwright: 1.58.0
+      playwright: 1.60.0
       tar-fs: 3.1.1
       tinyglobby: 0.2.15
       vscode-uri: 3.1.0
@@ -9838,11 +9843,11 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  playwright-core@1.58.0: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.58.0:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.58.0
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Summary

Updates the repo's Node versions now that Node 18 and 20 are end-of-life:

- runs CI on Node 22 and 24 instead of 18 and 20
- moves the release workflows and local dev environment to Node 24
- overrides Playwright packages to 1.60.0 to avoid the Node 24 browser archive extraction hang in https://github.com/microsoft/playwright/issues/40724

This should unblock dependency updates like https://github.com/Shopify/theme-tools/pull/1219 without keeping CI on unsupported Node versions.