### PR TITLE
fix(RemoteAsset): ignore base64 data URI images

### DIFF
--- a/.changeset/cool-mangos-hide.md
+++ b/.changeset/cool-mangos-hide.md
@@ -1,0 +1,5 @@
+---
+"@shopify/theme-check-node": patch
+---
+
+Fix RemoteAsset check incorrectly flagging base64 data URIs as external assets

--- a/packages/theme-check-common/src/checks/remote-asset/index.spec.ts
+++ b/packages/theme-check-common/src/checks/remote-asset/index.spec.ts
@@ -242,6 +242,15 @@ describe('Module: RemoteAsset', () => {
     );
   });
 
+  it('should not report an offense for data URIs used with img_tag filter', async () => {
+    const sourceCode = `
+      {{ 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==' | img_tag }}
+    `;
+
+    const offenses = await runLiquidCheck(RemoteAsset, sourceCode);
+    expect(offenses).to.be.empty;
+  });
+
   it('should still report an offense for string literals without asset_url filter', async () => {
     const sourceCode = `
       <img src="{{ 'image.png' }}" />

--- a/packages/theme-check-common/src/checks/remote-asset/index.spec.ts
+++ b/packages/theme-check-common/src/checks/remote-asset/index.spec.ts
@@ -206,6 +206,42 @@ describe('Module: RemoteAsset', () => {
     expect(offenses).to.be.empty;
   });
 
+  it('should not report an offense for base64 encoded data URIs', async () => {
+    const sourceCode = `
+      <img
+        src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+      />
+    `;
+
+    const offenses = await runLiquidCheck(RemoteAsset, sourceCode);
+    expect(offenses).to.be.empty;
+  });
+
+  it('should not report an offense for various base64 data URI image formats', async () => {
+    const sourceCode = `
+      <img src="data:image/png;base64,iVBORw0KGgo=" />
+      <img src="data:image/jpeg;base64,/9j/4AAQSkZJRgAB" />
+      <img src="data:image/svg+xml;base64,PHN2Zy8+" />
+      <img src="data:image/webp;base64,UklGRlYA" />
+    `;
+
+    const offenses = await runLiquidCheck(RemoteAsset, sourceCode);
+    expect(offenses).to.be.empty;
+  });
+
+  it('should still report an offense for remote images alongside base64 images', async () => {
+    const sourceCode = `
+      <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />
+      <img src="https://example.com/remote-image.png" />
+    `;
+
+    const offenses = await runLiquidCheck(RemoteAsset, sourceCode);
+    expect(offenses).to.have.length(1);
+    expect(offenses[0].message).to.equal(
+      'Asset should be served by the Shopify CDN for better performance.',
+    );
+  });
+
   it('should still report an offense for string literals without asset_url filter', async () => {
     const sourceCode = `
       <img src="{{ 'image.png' }}" />

--- a/packages/theme-check-common/src/checks/remote-asset/index.ts
+++ b/packages/theme-check-common/src/checks/remote-asset/index.ts
@@ -47,6 +47,10 @@ function isHashUrl(url: string): boolean {
   return url.startsWith('#');
 }
 
+function isDataUri(url: string): boolean {
+  return url.startsWith('data:');
+}
+
 /**
  * Checks if the attribute value starts with a variable lookup.
  * When a value starts with a VariableLookup (e.g., {{ source.url }}, {{ image }}),
@@ -184,6 +188,7 @@ export const RemoteAsset: LiquidCheckDefinition<typeof schema> = {
         (node): node is TextNode => node.type === NodeTypes.TextNode,
       );
       if (firstTextNode && isHashUrl(firstTextNode.value)) return;
+      if (firstTextNode && isDataUri(firstTextNode.value)) return;
 
       if (startsWithVariableLookup(urlAttribute)) return;
 

--- a/packages/theme-check-common/src/checks/remote-asset/index.ts
+++ b/packages/theme-check-common/src/checks/remote-asset/index.ts
@@ -240,6 +240,9 @@ export const RemoteAsset: LiquidCheckDefinition<typeof schema> = {
       if (hasAsset) return;
 
       const urlNode = parentNode.expression;
+
+      if (urlNode.type === NodeTypes.String && isDataUri(urlNode.value)) return;
+
       if (
         urlNode.type === NodeTypes.String &&
         !isUrlHostedbyShopify(urlNode.value, allowedDomains)

--- a/packages/theme-check-common/src/checks/remote-asset/index.ts
+++ b/packages/theme-check-common/src/checks/remote-asset/index.ts
@@ -48,7 +48,7 @@ function isHashUrl(url: string): boolean {
 }
 
 function isDataUri(url: string): boolean {
-  return url.startsWith('data:');
+  return /^data:/i.test(url);
 }
 
 /**


### PR DESCRIPTION
## Summary

- The `RemoteAsset` check was incorrectly flagging `src` attributes containing base64-encoded data URIs (e.g. `src="data:image/gif;base64,..."`) as needing to be served via the Shopify CDN.
- Data URIs are fully self-contained — they embed the image bytes directly in the attribute value and create **no external HTTP connections**, so the check's performance concern does not apply.
- Added an `isDataUri` helper (mirrors the existing `isHashUrl` helper) and an early-return guard in `checkHtmlNode` so data URIs are silently skipped.

## Example

```liquid
{{! Before: this was incorrectly reported as an offense }}
<img
  src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
/>
```

## Test plan

- [x] `should not report an offense for base64 encoded data URIs` — single GIF data URI passes
- [x] `should not report an offense for various base64 data URI image formats` — PNG, JPEG, SVG, WebP data URIs all pass
- [x] `should still report an offense for remote images alongside base64 images` — mixed case: base64 is ignored, remote URL is still caught
- [x] All 22 tests in `remote-asset/index.spec.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)