### PR TITLE
Support placeholder on color settings

### DIFF
--- a/.changeset/color-placeholder-alpha.md
+++ b/.changeset/color-placeholder-alpha.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Allow `placeholder` and `alpha` on `color` settings in theme schemas.

--- a/.changeset/color-placeholder-i18n.md
+++ b/.changeset/color-placeholder-i18n.md
@@ -1,6 +1,0 @@
----
-'@shopify/theme-check-common': patch
-'@shopify/theme-language-server-common': patch
----
-
-Allow `placeholder` on `color` settings in theme schemas.

--- a/.changeset/color-placeholder-i18n.md
+++ b/.changeset/color-placeholder-i18n.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': patch
+'@shopify/theme-language-server-common': patch
+---
+
+Allow `placeholder` on `color` settings in theme schemas.

--- a/packages/theme-check-common/src/types/schemas/setting.ts
+++ b/packages/theme-check-common/src/types/schemas/setting.ts
@@ -196,7 +196,10 @@ export declare namespace Setting {
     default?: string;
   }
 
-  export interface Color extends ColorBase<Type.Color> {}
+  export interface Color extends ColorBase<Type.Color> {
+    placeholder?: string;
+  }
+  
   export interface ColorBackground extends ColorBase<Type.ColorBackground> {}
   export interface ColorScheme extends Base<Type.ColorScheme> {
     default?: string;

--- a/packages/theme-check-common/src/types/schemas/setting.ts
+++ b/packages/theme-check-common/src/types/schemas/setting.ts
@@ -200,7 +200,7 @@ export declare namespace Setting {
     placeholder?: string;
     alpha?: boolean;
   }
-  
+
   export interface ColorBackground extends ColorBase<Type.ColorBackground> {}
   export interface ColorScheme extends Base<Type.ColorScheme> {
     default?: string;

--- a/packages/theme-check-common/src/types/schemas/setting.ts
+++ b/packages/theme-check-common/src/types/schemas/setting.ts
@@ -198,6 +198,7 @@ export declare namespace Setting {
 
   export interface Color extends ColorBase<Type.Color> {
     placeholder?: string;
+    alpha?: boolean;
   }
   
   export interface ColorBackground extends ColorBase<Type.ColorBackground> {}


### PR DESCRIPTION
## What are you adding in this PR?

This PR wires up support for `placeholder` on `color` settings. 

Extending `Color` as `placeholder` is not available to all `ColorBase` extensions

## What's next? Any followup issues?

Related PR in theme-liquid-docs: https://github.com/Shopify/theme-liquid-docs/pull/1709

## Before you deploy

- [x] I included a patch bump `changeset`
