### PR TITLE
Refresh pnpm lockfile in release PRs

### DIFF
--- a/packages/release-orchestrator/src/steps/changeset.spec.ts
+++ b/packages/release-orchestrator/src/steps/changeset.spec.ts
@@ -36,13 +36,18 @@ describe('changeset', () => {
   });
 
   it('changesetVersion should call run with correct arguments', async () => {
-    (run as Mock).mockResolvedValueOnce('test output');
+    (run as Mock)
+      .mockResolvedValueOnce('changeset version output')
+      .mockResolvedValueOnce('lockfile output');
 
     await changesetVersion();
 
     expect(run).toHaveBeenCalledWith('pnpm exec changeset version');
+    expect(run).toHaveBeenCalledWith('pnpm install --lockfile-only');
     expect(console.log).toHaveBeenCalledWith('Running `changeset version`...');
-    expect(console.log).toHaveBeenCalledWith('test output');
+    expect(console.log).toHaveBeenCalledWith('changeset version output');
+    expect(console.log).toHaveBeenCalledWith('Updating `pnpm-lock.yaml`...');
+    expect(console.log).toHaveBeenCalledWith('lockfile output');
   });
 
   it('changesetStatus should call run with correct arguments and return changeset status', async () => {

--- a/packages/release-orchestrator/src/steps/changesetVersion.ts
+++ b/packages/release-orchestrator/src/steps/changesetVersion.ts
@@ -3,4 +3,7 @@ import { run } from '../utils';
 export const changesetVersion = async () => {
   console.log('Running `changeset version`...');
   console.log(await run('pnpm exec changeset version'));
+
+  console.log('Updating `pnpm-lock.yaml`...');
+  console.log(await run('pnpm install --lockfile-only'));
 };


### PR DESCRIPTION
## Summary

Updates the release orchestrator so generated Changesets release PRs refresh `pnpm-lock.yaml` after `changeset version`.

## Why

The first release attempt after the pnpm migration bumped package manifests but left `pnpm-lock.yaml` with old workspace specifiers, so `pnpm install --frozen-lockfile` failed after merge. pnpm stores workspace dependency specifiers in the lockfile, so the generated release PR needs to include that diff too.