### PR TITLE
fix(JSONMissingBlock): allow app block references

### DIFF
--- a/.changeset/calm-penguins-check.md
+++ b/.changeset/calm-penguins-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Avoid reporting missing block offenses for app block references when the containing schema allows app blocks.

--- a/packages/theme-check-common/src/checks/json-missing-block/index.spec.ts
+++ b/packages/theme-check-common/src/checks/json-missing-block/index.spec.ts
@@ -80,6 +80,119 @@ describe('Module: JsonMissingBlock', () => {
       expect(offenses).to.be.empty;
     });
 
+    it('should not report an offense for an app block when the section allows @app and @theme', async () => {
+      const theme: MockTheme = {
+        'templates/product.app-block.json': `{
+          "sections": {
+            "main": {
+              "type": "main-product",
+              "blocks": {
+                "some_app_block": {
+                  "type": "shopify://apps/some-app/blocks/example/1234"
+                }
+              },
+              "block_order": ["some_app_block"]
+            }
+          },
+          "order": ["main"]
+        }`,
+        'sections/main-product.liquid': `
+          {% schema %}
+          {
+            "name": "Main product",
+            "blocks": [
+              {
+                "type": "@app"
+              },
+              {
+                "type": "@theme"
+              }
+            ]
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [JSONMissingBlock]);
+      expect(offenses).to.be.empty;
+    });
+
+    it('should not report an offense for an app block when the section allows @app', async () => {
+      const theme: MockTheme = {
+        'templates/product.app-block.json': `{
+          "sections": {
+            "main": {
+              "type": "main-product",
+              "blocks": {
+                "some_app_block": {
+                  "type": "shopify://apps/some-app/blocks/example/1234"
+                }
+              },
+              "block_order": ["some_app_block"]
+            }
+          },
+          "order": ["main"]
+        }`,
+        'sections/main-product.liquid': `
+          {% schema %}
+          {
+            "name": "Main product",
+            "blocks": [
+              {
+                "type": "@app"
+              }
+            ]
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [JSONMissingBlock]);
+      expect(offenses).to.be.empty;
+    });
+
+    it('should report an offense for a local block when the section allows only @app', async () => {
+      const theme: MockTheme = {
+        'templates/product.local-block.json': `{
+          "sections": {
+            "main": {
+              "type": "main-product",
+              "blocks": {
+                "some_local_block": {
+                  "type": "text"
+                }
+              },
+              "block_order": ["some_local_block"]
+            }
+          },
+          "order": ["main"]
+        }`,
+        'sections/main-product.liquid': `
+          {% schema %}
+          {
+            "name": "Main product",
+            "blocks": [
+              {
+                "type": "@app"
+              }
+            ]
+          }
+          {% endschema %}
+        `,
+        'blocks/text.liquid': '',
+      };
+
+      const offenses = await check(theme, [JSONMissingBlock]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal(
+        "Block type 'text' is not allowed in 'sections/main-product.liquid'.",
+      );
+
+      const content = theme['templates/product.local-block.json'];
+      const erroredContent = content.slice(offenses[0].start.index, offenses[0].end.index);
+      expect(erroredContent).to.equal('"text"');
+    });
+
     it('should report an offense when a nested block does not exist', async () => {
       const theme: MockTheme = {
         'templates/product.nested.json': `{
@@ -140,6 +253,47 @@ describe('Module: JsonMissingBlock', () => {
   });
 
   describe('Allowed block type validation', () => {
+    it('should report an offense for an app block when the section does not allow @app', async () => {
+      const theme: MockTheme = {
+        'templates/product.app-block.json': `{
+          "sections": {
+            "main": {
+              "type": "main-product",
+              "blocks": {
+                "some_app_block": {
+                  "type": "shopify://apps/some-app/blocks/example/1234"
+                }
+              },
+              "block_order": ["some_app_block"]
+            }
+          },
+          "order": ["main"]
+        }`,
+        'sections/main-product.liquid': `
+          {% schema %}
+          {
+            "name": "Main product",
+            "blocks": [
+              {
+                "type": "@theme"
+              }
+            ]
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [JSONMissingBlock]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal(
+        "Block type 'shopify://apps/some-app/blocks/example/1234' is not allowed in 'sections/main-product.liquid'.",
+      );
+
+      const content = theme['templates/product.app-block.json'];
+      const erroredContent = content.slice(offenses[0].start.index, offenses[0].end.index);
+      expect(erroredContent).to.equal('"shopify://apps/some-app/blocks/example/1234"');
+    });
+
     it('should report an offense when block exists but is not in the section liquid schema', async () => {
       const theme: MockTheme = {
         'templates/product.valid.json': `{

--- a/packages/theme-check-common/src/checks/json-missing-block/missing-block-utils.ts
+++ b/packages/theme-check-common/src/checks/json-missing-block/missing-block-utils.ts
@@ -11,6 +11,10 @@ function isNestedBlock(currentPath: string[]): boolean {
   return currentPath.filter((segment) => segment === 'blocks').length > 1;
 }
 
+function isShopifyAppBlockType(blockType: string): boolean {
+  return blockType.startsWith('shopify://apps/');
+}
+
 function reportWarning(
   message: string,
   offset: number,
@@ -28,7 +32,7 @@ async function validateBlockFileExistence(
   blockType: string,
   context: Context<SourceCodeType.JSON>,
 ): Promise<boolean> {
-  if (blockType === '@theme' || blockType === '@app') {
+  if (blockType === '@theme' || blockType === '@app' || isShopifyAppBlockType(blockType)) {
     return true;
   }
   const blockPath = `blocks/${blockType}.liquid`;
@@ -53,7 +57,7 @@ async function getThemeBlocks(
 
   if (Array.isArray(validSchema.blocks)) {
     validSchema.blocks.forEach((block) => {
-      if (!('name' in block) && block.type !== '@app') {
+      if (!('name' in block)) {
         themeBlocks.push(block.type);
       }
     });
@@ -85,13 +89,18 @@ async function validateBlock(
     // Static blocks are not required to be in the schema blocks array
     return;
   } else {
+    const isAppBlock = isShopifyAppBlockType(blockType);
     const isPrivateBlock = blockType.startsWith('_');
+    const schemaIncludesAtApp = themeBlocks.includes('@app');
     const schemaIncludesAtTheme = themeBlocks.includes('@theme');
     const schemaIncludesBlockType = themeBlocks.includes(blockType);
+    const schemaAllowsBlockType = isAppBlock
+      ? schemaIncludesAtApp
+      : !isPrivateBlock
+        ? schemaIncludesBlockType || schemaIncludesAtTheme
+        : schemaIncludesBlockType;
 
-    if (
-      !isPrivateBlock ? schemaIncludesBlockType || schemaIncludesAtTheme : schemaIncludesBlockType
-    ) {
+    if (schemaAllowsBlockType) {
       return;
     } else {
       const location = isNestedBlock(currentPath) ? 'blocks' : 'sections';


### PR DESCRIPTION
## What are you adding in this PR?

Fixes a false positive where `JSONMissingBlock` reports app block references as missing local block files when the containing schema allows `@app`.

App block references use `shopify://apps/...` types and do not map to local `blocks/*.liquid` files. This change skips local file validation for those references while still requiring the containing section or block schema to include `@app`.

Regression coverage includes schemas allowing `@app` with `@theme`, schemas allowing only `@app`, and schemas that do not allow app blocks.

Fixes #1144

## What's next? Any followup issues?

None planned.

## Tophatting

Run Theme Check against a JSON template containing a `shopify://apps/...` block reference:

- With `@app` in the containing schema, `JSONMissingBlock` does not report an offense.
- Without `@app`, `JSONMissingBlock` reports that the block type is not allowed.
- Local block validation continues to report missing or disallowed local blocks.

Validation completed:

- `pnpm build`
- `CI=true pnpm exec vitest run`
- `pnpm type-check`
- `pnpm format:check`

## Before you deploy

- [x] I included a patch bump `changeset`
