### PR TITLE
fix(liquid-html-parser): support filter expressions in render named arguments

### DIFF
--- a/packages/liquid-html-parser/grammar/liquid-html.ohm
+++ b/packages/liquid-html-parser/grammar/liquid-html.ohm
@@ -143,8 +143,11 @@ Liquid <: Helpers {
   liquidTagRenderMarkup =
     snippetExpression renderVariableExpression? renderAliasExpression? renderArguments
 
-  renderArguments = (argumentSeparatorOptionalComma tagArguments) (space* ",")? space*
-  completionModeRenderArguments = (argumentSeparatorOptionalComma tagArguments) (space* ",")? space* (argumentSeparator? liquidVariableLookup<delimTag> space*)?
+  renderArguments = (argumentSeparatorOptionalComma renderTagArguments) (space* ",")? space*
+  completionModeRenderArguments = (argumentSeparatorOptionalComma renderTagArguments) (space* ",")? space* (argumentSeparator? liquidVariableLookup<delimTag> space*)?
+  renderTagArguments = listOf<renderTagNamedArgument, argumentSeparatorOptionalComma>
+  renderTagNamedArgument = variableSegment space* ":" space* renderTagArgumentValue
+  renderTagArgumentValue = liquidComplexExpression<delimTag> liquidFilter<delimTag>* space*
   snippetExpression = liquidString<delimTag> | variableSegmentAsLookup
   renderVariableExpression = space+ ("for" | "with") space+ liquidExpression<delimTag>
   renderAliasExpression = space+ "as" space+ variableSegment

--- a/packages/liquid-html-parser/src/stage-1-cst.ts
+++ b/packages/liquid-html-parser/src/stage-1-cst.ts
@@ -919,6 +919,16 @@ function toCST<T>(
       source,
     },
     renderArguments: 1,
+    renderTagArguments: 0,
+    renderTagNamedArgument: {
+      type: ConcreteNodeTypes.NamedArgument,
+      name: 0,
+      value: 4,
+      locStart,
+      locEnd,
+      source,
+    },
+    renderTagArgumentValue: 0,
     completionModeRenderArguments: function (
       _0,
       namedArguments,

--- a/packages/liquid-html-parser/src/stage-2-ast.spec.ts
+++ b/packages/liquid-html-parser/src/stage-2-ast.spec.ts
@@ -509,6 +509,13 @@ describe('Unit: Stage 2 (AST)', () => {
               { name: 'key2', valueType: 'String' },
             ],
           },
+          {
+            expression: `'snippet', for: block.id | append: '-list'`,
+            snippetType: 'String',
+            alias: null,
+            renderVariableExpression: null,
+            namedArguments: [{ name: 'for', valueType: 'VariableLookup' }],
+          },
         ].forEach(
           ({ expression, snippetType, renderVariableExpression, alias, namedArguments }) => {
             for (const { toAST, expectPath, expectPosition } of testCases) {


### PR DESCRIPTION
**Redacted to bury in search engines**