### PR TITLE
feat: scope Liquid objects to step URIs for Flow config field LSP support

### DIFF
--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/theme-check-common",
-  "version": "3.26.1",
+  "version": "3.26.1-flow.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/theme-check-common/src/AugmentedThemeDocset.ts
+++ b/packages/theme-check-common/src/AugmentedThemeDocset.ts
@@ -103,6 +103,25 @@ export class AugmentedThemeDocset implements ThemeDocset {
 
   public isAugmented = true;
 
+  private objectsByPrefix = new Map<string, ObjectEntry[]>();
+
+  setObjectsForURI(uri: string, objects: ObjectEntry[]) {
+    this.objectsByPrefix.set(uri, objects);
+  }
+
+  getObjectsForURI(uri: string): ObjectEntry[] | undefined {
+    // Exact match first
+    const exact = this.objectsByPrefix.get(uri);
+    if (exact) return exact;
+
+    // Prefix match: allows registering by step path and matching file URIs within it
+    for (const [prefix, objects] of this.objectsByPrefix) {
+      if (uri.startsWith(prefix)) return objects;
+    }
+
+    return undefined;
+  }
+
   filters = memo(async (): Promise<FilterEntry[]> => {
     const officialFilters = await this.themeDocset.filters();
     return [

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -146,7 +146,7 @@ export const UndefinedObject: LiquidCheckDefinition = {
       },
 
       async onCodePathEnd() {
-        const objects = await globalObjects(themeDocset, relativePath, context.mode);
+        const objects = await globalObjects(themeDocset, relativePath, context.file.uri, context.mode);
 
         objects.forEach((obj) => fileScopedVariables.add(obj.name));
 
@@ -172,8 +172,9 @@ export const UndefinedObject: LiquidCheckDefinition = {
   },
 };
 
-async function globalObjects(themeDocset: ThemeDocset, relativePath: string, mode: Mode = 'theme') {
-  const objects = await themeDocset.objects();
+async function globalObjects(themeDocset: ThemeDocset, relativePath: string, uri?: string, mode: Mode = 'theme') {
+  const perURI = uri ? themeDocset.getObjectsForURI?.(uri) : undefined;
+  const objects = perURI ?? (await themeDocset.objects());
   const contextualObjects = getContextualObjects(relativePath, mode);
 
   const globalObjects = objects.filter(({ access, name }) => {

--- a/packages/theme-check-common/src/types/theme-liquid-docs.ts
+++ b/packages/theme-check-common/src/types/theme-liquid-docs.ts
@@ -21,6 +21,9 @@ export interface ThemeDocset {
 
   /** Returns system translations available on themes. */
   systemTranslations(): Promise<Translations>;
+
+  /** Returns objects scoped to a specific URI, if available. */
+  getObjectsForURI?(uri: string): ObjectEntry[] | undefined;
 }
 
 /** A URI that will uniquely describe the schema */

--- a/packages/theme-language-server-common/src/ClientCapabilities.ts
+++ b/packages/theme-language-server-common/src/ClientCapabilities.ts
@@ -43,6 +43,10 @@ export class ClientCapabilities {
     return !!this.capabilities?.window?.workDoneProgress;
   }
 
+  get supportsSetObjects(): boolean {
+    return this.initializationOption('shopify.supportsSetObjects', false);
+  }
+
   initializationOption<T>(key: string, defaultValue: T): T {
     // { 'themeCheck.checkOnSave': true }
     const direct = this.initializationOptions?.[key];

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -48,6 +48,7 @@ export class TypeSystem {
     private readonly getThemeSettingsSchemaForURI: GetThemeSettingsSchemaForURI,
     private readonly getMetafieldDefinitions: (rootUri: string) => Promise<MetafieldDefinitionMap>,
     private readonly getModeForURI: GetModeForURI = async () => 'theme',
+    private readonly isUriScopedMode: () => boolean = () => false,
   ) {}
 
   async inferType(
@@ -262,12 +263,23 @@ export class TypeSystem {
   }
 
   private async _objectMap(uri?: string): Promise<ObjectMap> {
+    if (!this.isUriScopedMode()) return this._memoObjectMap();
     const entries = await this.objectEntries(uri);
     return entries.reduce((map, entry) => {
       map[entry.name] = entry;
       return map;
     }, {} as ObjectMap);
   }
+
+  private _memoObjectEntries = memo(() => this.themeDocset.objects());
+
+  private _memoObjectMap = memo(async (): Promise<ObjectMap> => {
+    const entries = await this._memoObjectEntries();
+    return entries.reduce((map, entry) => {
+      map[entry.name] = entry;
+      return map;
+    }, {} as ObjectMap);
+  });
 
   /** An indexed representation of filters.json by name */
   public filtersMap = memo(async (): Promise<FiltersMap> => {
@@ -287,11 +299,11 @@ export class TypeSystem {
   }
 
   public async objectEntries(uri?: string): Promise<ObjectEntry[]> {
-    if (uri && this.themeDocset.getObjectsForURI) {
+    if (this.isUriScopedMode() && uri && this.themeDocset.getObjectsForURI) {
       const perURI = this.themeDocset.getObjectsForURI(uri);
       if (perURI) return perURI;
     }
-    return this.themeDocset.objects();
+    return this._memoObjectEntries();
   }
 
   private async symbolsTable(partialAst: LiquidHtmlNode, uri: string): Promise<SymbolsTable> {
@@ -324,7 +336,15 @@ export class TypeSystem {
     }, {} as SymbolsTable);
   };
 
+  private _memoGlobalVariables = memo(async () => {
+    const entries = await this._memoObjectEntries();
+    return entries.filter(
+      (entry) => !entry.access || entry.access.global === true || entry.access.template.length > 0,
+    );
+  });
+
   private globalVariables = async (uri?: string) => {
+    if (!this.isUriScopedMode()) return this._memoGlobalVariables();
     const entries = await this.objectEntries(uri);
     return entries.filter(
       (entry) => !entry.access || entry.access.global === true || entry.access.template.length > 0,

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -123,7 +123,7 @@ export class TypeSystem {
    */
   public objectMap = async (uri: string, ast: LiquidHtmlNode): Promise<ObjectMap> => {
     const [objectMap, themeSettingProperties, metafieldDefinitionsObjectMap] = await Promise.all([
-      this._objectMap(),
+      this._objectMap(uri),
       this.themeSettingProperties(uri),
       this.metafieldDefinitionsObjectMap(uri),
     ]);
@@ -261,14 +261,13 @@ export class TypeSystem {
     return result;
   }
 
-  // This is the big one we reuse (memoized)
-  private _objectMap = memo(async (): Promise<ObjectMap> => {
-    const entries = await this.objectEntries();
+  private async _objectMap(uri?: string): Promise<ObjectMap> {
+    const entries = await this.objectEntries(uri);
     return entries.reduce((map, entry) => {
       map[entry.name] = entry;
       return map;
     }, {} as ObjectMap);
-  });
+  }
 
   /** An indexed representation of filters.json by name */
   public filtersMap = memo(async (): Promise<FiltersMap> => {
@@ -283,9 +282,13 @@ export class TypeSystem {
     return this.themeDocset.filters();
   });
 
-  public objectEntries = memo(async () => {
+  public async objectEntries(uri?: string): Promise<ObjectEntry[]> {
+    if (uri && this.themeDocset.getObjectsForURI) {
+      const perURI = this.themeDocset.getObjectsForURI(uri);
+      if (perURI) return perURI;
+    }
     return this.themeDocset.objects();
-  });
+  }
 
   private async symbolsTable(partialAst: LiquidHtmlNode, uri: string): Promise<SymbolsTable> {
     const seedSymbolsTable = await this.seedSymbolsTable(uri);
@@ -303,7 +306,7 @@ export class TypeSystem {
    */
   private seedSymbolsTable = async (uri: string) => {
     const [globalVariables, contextualVariables] = await Promise.all([
-      this.globalVariables(),
+      this.globalVariables(uri),
       this.contextualVariables(uri),
     ]);
     return globalVariables.concat(contextualVariables).reduce((table, objectEntry) => {
@@ -317,15 +320,15 @@ export class TypeSystem {
     }, {} as SymbolsTable);
   };
 
-  private globalVariables = memo(async () => {
-    const entries = await this.objectEntries();
+  private globalVariables = async (uri?: string) => {
+    const entries = await this.objectEntries(uri);
     return entries.filter(
       (entry) => !entry.access || entry.access.global === true || entry.access.template.length > 0,
     );
-  });
+  };
 
   private contextualVariables = async (uri: string) => {
-    const [entries, mode] = await Promise.all([this.objectEntries(), this.getModeForURI(uri)]);
+    const [entries, mode] = await Promise.all([this.objectEntries(uri), this.getModeForURI(uri)]);
     const contextualEntries = getContextualEntries(uri, mode);
     return entries.filter((entry) => contextualEntries.includes(entry.name));
   };

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -282,6 +282,10 @@ export class TypeSystem {
     return this.themeDocset.filters();
   });
 
+  public hasObjectsForURI(uri: string): boolean {
+    return !!this.themeDocset.getObjectsForURI?.(uri);
+  }
+
   public async objectEntries(uri?: string): Promise<ObjectEntry[]> {
     if (uri && this.themeDocset.getObjectsForURI) {
       const perURI = this.themeDocset.getObjectsForURI(uri);

--- a/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
+++ b/packages/theme-language-server-common/src/completions/CompletionsProvider.ts
@@ -42,6 +42,7 @@ export interface CompletionProviderDependencies {
   getDocDefinitionForURI?: GetDocDefinitionForURI;
   getThemeBlockNames?: (rootUri: string, includePrivate: boolean) => Promise<string[]>;
   getModeForURI?: (uri: string) => Promise<Mode>;
+  isUriScopedMode?: () => boolean;
   log?: (message: string) => void;
 }
 
@@ -61,6 +62,7 @@ export class CompletionsProvider {
     getDocDefinitionForURI = async (uri, _relativePath) => ({ uri }),
     getThemeBlockNames = async (_rootUri: string, _includePrivate: boolean) => [],
     getModeForURI,
+    isUriScopedMode = () => false,
     log = () => {},
   }: CompletionProviderDependencies) {
     this.documentManager = documentManager;
@@ -71,6 +73,7 @@ export class CompletionsProvider {
       getThemeSettingsSchemaForURI,
       getMetafieldDefinitions,
       getModeForURI,
+      isUriScopedMode,
     );
 
     this.providers = [

--- a/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.ts
+++ b/packages/theme-language-server-common/src/completions/providers/ObjectAttributeCompletionProvider.ts
@@ -45,12 +45,15 @@ export class ObjectAttributeCompletionProvider implements Provider {
       partialAst,
       params.textDocument.uri,
     );
+    const hasCustomObjects = this.typeSystem.hasObjectsForURI(params.textDocument.uri);
     if (isArrayType(parentType)) {
+      if (hasCustomObjects) return [];
       return completionItems(
         ArrayCoreProperties.map((name) => ({ name })),
         partial,
       );
     } else if (parentType === 'string') {
+      if (hasCustomObjects) return [];
       return completionItems(
         StringCoreProperties.map((name) => ({ name })),
         partial,

--- a/packages/theme-language-server-common/src/hover/HoverProvider.ts
+++ b/packages/theme-language-server-common/src/hover/HoverProvider.ts
@@ -39,12 +39,14 @@ export class HoverProvider {
     readonly getSettingsSchemaForURI: GetThemeSettingsSchemaForURI = async () => [],
     readonly getDocDefinitionForURI: GetDocDefinitionForURI = async () => undefined,
     readonly getModeForURI: (uri: string) => Promise<Mode> = async () => 'theme',
+    readonly isUriScopedMode: () => boolean = () => false,
   ) {
     const typeSystem = new TypeSystem(
       themeDocset,
       getSettingsSchemaForURI,
       getMetafieldDefinitions,
       getModeForURI,
+      isUriScopedMode,
     );
     this.providers = [
       new ContentForArgumentHoverProvider(getDocDefinitionForURI),

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -342,6 +342,7 @@ export function startServer(
     getMetafieldDefinitions,
     getDocDefinitionForURI,
     getModeForURI,
+    isUriScopedMode: () => clientCapabilities.supportsSetObjects,
   });
   const hoverProvider = new HoverProvider(
     documentManager,
@@ -351,6 +352,7 @@ export function startServer(
     getThemeSettingsSchemaForURI,
     getDocDefinitionForURI,
     getModeForURI,
+    () => clientCapabilities.supportsSetObjects,
   );
 
   const executeCommandProvider = new ExecuteCommandProvider(

--- a/packages/theme-language-server-common/src/server/startServer.ts
+++ b/packages/theme-language-server-common/src/server/startServer.ts
@@ -47,6 +47,7 @@ import { RenameHandler } from '../renamed/RenameHandler';
 import { GetTranslationsForURI } from '../translations';
 import {
   Dependencies,
+  SetObjectsNotification,
   ThemeGraphDeadCodeRequest,
   ThemeGraphDependenciesRequest,
   ThemeGraphReferenceRequest,
@@ -760,6 +761,10 @@ export function startServer(
     if (!rootUri) return [];
     const deadFiles = await themeGraphManager.deadCode(rootUri);
     return deadFiles;
+  });
+
+  connection.onNotification(SetObjectsNotification.type, ({ uri, objects }) => {
+    themeDocset.setObjectsForURI(uri, objects);
   });
 
   connection.listen();

--- a/packages/theme-language-server-common/src/types.ts
+++ b/packages/theme-language-server-common/src/types.ts
@@ -2,6 +2,7 @@ import {
   AbstractFileSystem,
   Config,
   Dependencies as ThemeCheckDependencies,
+  ObjectEntry,
 } from '@shopify/theme-check-common';
 import { URI } from 'vscode-languageserver';
 import * as rpc from 'vscode-jsonrpc';
@@ -146,6 +147,15 @@ export namespace ThemeGraphDidUpdateNotification {
   export interface Params {
     uri: string;
   }
+}
+
+export namespace SetObjectsNotification {
+  export const method = 'shopify/setObjects';
+  export interface Params {
+    uri: string;
+    objects: ObjectEntry[];
+  }
+  export const type = new rpc.NotificationType<Params>(method);
 }
 
 export type AugmentedLocationWithExistence = {


### PR DESCRIPTION
## Why

Flow's Workflow Editor is a highly dynamic environment. As users build workflows, each step has its own runtime context — a step triggered by \"customer created\" has completely different Liquid objects available than one triggered by \"order created\". When a user changes a trigger or reconfigures a step, the available objects change too.

Each step can have multiple config fields, and each config field is an independently-editable Liquid snippet (a separate file). All config fields within a step share the same set of Liquid objects — the objects provided by that step's environment, fetched from the backend.

Before this PR, the Liquid LSP had no concept of per-file or per-step object scoping. It could only use the global theme object list, which meant:
- No completions for step-specific objects (event properties, step variables, etc.)
- False \"undefined object\" errors on perfectly valid Liquid
- No type-aware property traversal for Flow-specific types

This PR introduces the mechanism for clients to register custom Liquid objects scoped to a URI prefix, so the Flow UI can tell the LSP exactly which objects are valid for a given step's config fields.

## What this PR adds

- **`setObjectsForURI` / `getObjectsForURI`** on `AugmentedThemeDocset` — stores and looks up `ObjectEntry[]` by exact URI or prefix match, so all config field files under a step URI share the same registered objects.
- **`shopify/setObjects` LSP notification** — a new `SetObjectsNotification` that clients send to register custom objects for a URI. The Flow UI sends this after fetching the step's environment from the backend.
- **`shopify.supportsSetObjects` initialization flag** — clients opt in by setting this in `initializationOptions`. When `true`, `TypeSystem` bypasses memoization for object lookups (since results are now URI-dependent) and routes through per-URI objects. When `false` (the default), all existing memoization is preserved — no performance impact for theme developers.
- **URI threading through `TypeSystem`** — `objectEntries`, `_objectMap`, and `globalVariables` now receive the current file URI and use per-URI objects when the flag is on, falling back to memo'd global results otherwise.
- **Suppressed core property completions** in `ObjectAttributeCompletionProvider` when custom objects are registered for the current URI — avoids surfacing misleading array/string built-in suggestions in Flow's custom object context.

## What's next

- The Flow UI client (`useLiquidLsp`) already calls `updateObjects(stepUri, lspObjects)` — it needs to be wired to send the `shopify/setObjects` notification using this new mechanism, and pass `shopify.supportsSetObjects: true` in `initializationOptions`.
- Consider adding cleanup logic to remove URI-scoped objects when files are closed or the step is removed.