### PR TITLE
Add Liquid docs bundle command

### DIFF
--- a/.changeset/bright-lions-build.md
+++ b/.changeset/bright-lions-build.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-docs-updater': minor
+---
+
+Add a `theme-docs bundle` command/API for generating self-contained Liquid docs bundles.

--- a/packages/theme-check-docs-updater/package.json
+++ b/packages/theme-check-docs-updater/package.json
@@ -26,6 +26,7 @@
     "build:ci": "pnpm build",
     "build:ts": "tsc -b tsconfig.build.json",
     "postbuild": "node scripts/cli.js download data",
+    "theme-docs": "node scripts/cli.js",
     "test": "vitest",
     "type-check": "tsc --noEmit"
   },

--- a/packages/theme-check-docs-updater/scripts/cli.js
+++ b/packages/theme-check-docs-updater/scripts/cli.js
@@ -2,47 +2,77 @@
 
 const path = require('path');
 const fs = require('fs');
-const { downloadThemeLiquidDocs, root } = require(path.resolve(__dirname, '../dist'));
+const {
+  ThemeLiquidDocsManager,
+  buildThemeLiquidDocsBundle,
+  downloadThemeLiquidDocs,
+  root,
+} = require(path.resolve(__dirname, '../dist'));
 
 // Get the command line arguments
 const args = process.argv.slice(2);
 
-// Check if a command was provided
-if (args.length === 0) {
+function printUsage() {
   console.log(`
 Please provide a command.
 
 Usage:
  download <dir> \t\tDownloads all docsets and JSON Schemas to the specified directory.
+ bundle \t\t\tPrints a self-contained Liquid docs JSON bundle.
  root \tPrints the default docsets root directory.
  clear-cache \tClears the default docsets root directory.
 `);
-  process.exit(1);
 }
 
-// Handle the command
-switch (args[0]) {
-  case 'download':
-    if (args.length > 2) {
-      console.log('Please provide a directory to download docs into.');
-      process.exit(1);
-    }
-    console.log('Downloading docs...');
-
-    downloadThemeLiquidDocs(args[1], console.error.bind(console));
-
-    break;
-
-  case 'root':
-    console.log(root);
-    break;
-
-  case 'clear-cache':
-    console.log(`Removing '${root}'`);
-    fs.rmSync(root, { recursive: true });
-    break;
-
-  default:
-    console.log(`Unknown command: ${args[0]}`);
+async function main() {
+  // Check if a command was provided
+  if (args.length === 0) {
+    printUsage();
     process.exit(1);
+  }
+
+  // Handle the command
+  switch (args[0]) {
+    case 'download':
+      if (args.length > 2) {
+        console.error('Please provide a directory to download docs into.');
+        process.exit(1);
+      }
+      console.log('Downloading docs...');
+
+      await downloadThemeLiquidDocs(args[1], console.error.bind(console));
+
+      break;
+
+    case 'bundle': {
+      if (args.length > 1) {
+        console.error('The bundle command does not accept arguments.');
+        process.exit(1);
+      }
+
+      const docsManager = new ThemeLiquidDocsManager(console.error.bind(console));
+      const bundle = await buildThemeLiquidDocsBundle(docsManager);
+      process.stdout.write(`${JSON.stringify(bundle)}\n`);
+
+      break;
+    }
+
+    case 'root':
+      console.log(root);
+      break;
+
+    case 'clear-cache':
+      console.log(`Removing '${root}'`);
+      fs.rmSync(root, { recursive: true, force: true });
+      break;
+
+    default:
+      console.error(`Unknown command: ${args[0]}`);
+      process.exit(1);
+  }
 }
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/packages/theme-check-docs-updater/src/index.ts
+++ b/packages/theme-check-docs-updater/src/index.ts
@@ -1,3 +1,9 @@
+export {
+  ThemeLiquidDocsBundle,
+  ThemeLiquidDocsBundleManager,
+  ThemeLiquidDocsBundleSchemaVersion,
+  buildThemeLiquidDocsBundle,
+} from './themeLiquidDocsBundle';
 export { ThemeLiquidDocsManager } from './themeLiquidDocsManager';
 export {
   Resource,

--- a/packages/theme-check-docs-updater/src/themeLiquidDocsBundle.spec.ts
+++ b/packages/theme-check-docs-updater/src/themeLiquidDocsBundle.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { buildThemeLiquidDocsBundle } from './themeLiquidDocsBundle';
+
+const manager = {
+  revision: async () => '40f966fc7793462726d9f8573c8d522f8ab44c54',
+  tags: async () => [{ name: 'if' }],
+  filters: async () => [{ name: 'upcase' }],
+  objects: async () => [{ name: 'product' }],
+  systemTranslations: async () => ({ 'shopify.checkout.general.cart': 'Cart' }),
+  schemas: async (mode: 'theme') => [
+    {
+      uri: `https://example.com/schemas/${mode}.json`,
+      fileMatch: ['templates/*.json'],
+      schema: '{"type":"object"}',
+    },
+  ],
+};
+
+describe('Module: themeLiquidDocsBundle', () => {
+  it('builds a self-contained Liquid docs bundle', async () => {
+    await expect(buildThemeLiquidDocsBundle(manager)).resolves.toEqual({
+      schemaVersion: 1,
+      revision: '40f966fc7793462726d9f8573c8d522f8ab44c54',
+      tags: [{ name: 'if' }],
+      filters: [{ name: 'upcase' }],
+      objects: [{ name: 'product' }],
+      systemTranslations: { 'shopify.checkout.general.cart': 'Cart' },
+      schemas: [
+        {
+          uri: 'https://example.com/schemas/theme.json',
+          fileMatch: ['templates/*.json'],
+          schema: '{"type":"object"}',
+        },
+      ],
+    });
+  });
+
+  it('throws when the revision cannot be determined', async () => {
+    await expect(
+      buildThemeLiquidDocsBundle({
+        ...manager,
+        revision: async () => '',
+      }),
+    ).rejects.toThrow('Unable to determine the theme-liquid-docs revision.');
+  });
+});

--- a/packages/theme-check-docs-updater/src/themeLiquidDocsBundle.ts
+++ b/packages/theme-check-docs-updater/src/themeLiquidDocsBundle.ts
@@ -1,0 +1,56 @@
+import {
+  FilterEntry,
+  ObjectEntry,
+  SchemaDefinition,
+  TagEntry,
+  Translations,
+} from '@shopify/theme-check-common';
+import { ThemeLiquidDocsManager } from './themeLiquidDocsManager';
+
+export const ThemeLiquidDocsBundleSchemaVersion = 1;
+
+export interface ThemeLiquidDocsBundle {
+  schemaVersion: typeof ThemeLiquidDocsBundleSchemaVersion;
+  revision: string;
+  tags: TagEntry[];
+  filters: FilterEntry[];
+  objects: ObjectEntry[];
+  systemTranslations: Translations;
+  schemas: SchemaDefinition[];
+}
+
+export interface ThemeLiquidDocsBundleManager {
+  revision(): Promise<string>;
+  tags(): Promise<TagEntry[]>;
+  filters(): Promise<FilterEntry[]>;
+  objects(): Promise<ObjectEntry[]>;
+  systemTranslations(): Promise<Translations>;
+  schemas(mode: 'theme'): Promise<SchemaDefinition[]>;
+}
+
+export async function buildThemeLiquidDocsBundle(
+  docsManager: ThemeLiquidDocsBundleManager = new ThemeLiquidDocsManager(),
+): Promise<ThemeLiquidDocsBundle> {
+  const [revision, tags, filters, objects, systemTranslations, schemas] = await Promise.all([
+    docsManager.revision(),
+    docsManager.tags(),
+    docsManager.filters(),
+    docsManager.objects(),
+    docsManager.systemTranslations(),
+    docsManager.schemas('theme'),
+  ]);
+
+  if (!revision) {
+    throw new Error('Unable to determine the theme-liquid-docs revision.');
+  }
+
+  return {
+    schemaVersion: ThemeLiquidDocsBundleSchemaVersion,
+    revision,
+    tags,
+    filters,
+    objects,
+    systemTranslations,
+    schemas,
+  };
+}

--- a/packages/theme-check-docs-updater/src/themeLiquidDocsManager.ts
+++ b/packages/theme-check-docs-updater/src/themeLiquidDocsManager.ts
@@ -28,6 +28,11 @@ type JSONSchemaManifest = { schemas: { uri: string; fileMatch?: string[] }[] };
 export class ThemeLiquidDocsManager implements ThemeDocset, JsonValidationSet {
   constructor(private log: Logger = noop) {}
 
+  revision = memo(async (): Promise<string> => {
+    await this.setup();
+    return this.latestRevision();
+  });
+
   filters = memo(async (): Promise<FilterEntry[]> => {
     return findSuitableResource(this.loaders('filters'), JSON.parse, [], this.log);
   });
@@ -110,7 +115,10 @@ export class ThemeLiquidDocsManager implements ThemeDocset, JsonValidationSet {
 
   private async latestRevision(): Promise<string> {
     const latest = await findSuitableResource(
-      [loader(() => this.load('latest'), 'loadLatestRevision')],
+      [
+        loader(() => this.load('latest'), 'loadLatestRevision'),
+        loader(() => fallbackResource('latest', this.log), 'fallbackLatestRevision'),
+      ],
       JSON.parse,
       {},
       this.log,
@@ -205,7 +213,7 @@ function dataRoot() {
 }
 
 /** Returns the at-build-time path to the fallback data file. */
-async function fallbackResource(name: Resource, log: Logger): Promise<string> {
+async function fallbackResource(name: Resource | 'latest', log: Logger): Promise<string> {
   const sourcePath = path.resolve(dataRoot(), `${name}.json`);
   return fs
     .readFile(sourcePath, 'utf8')


### PR DESCRIPTION
## What are you adding in this PR?

Related issue: Shopify/developer-tools-team#783

Adds a stable Liquid docs bundle generator to `@shopify/theme-check-docs-updater`.

New package API:

```ts
import { buildThemeLiquidDocsBundle } from '@shopify/theme-check-docs-updater';

const bundle = await buildThemeLiquidDocsBundle();
```

New CLI command:

```sh
pnpm --dir packages/theme-check-docs-updater theme-docs bundle
```

The command writes a self-contained JSON bundle to stdout:

```json
{
  "schemaVersion": 1,
  "revision": "40f966fc7793462726d9f8573c8d522f8ab44c54",
  "tags": [],
  "filters": [],
  "objects": [],
  "systemTranslations": {},
  "schemas": []
}
```

Logs from docs loading go to stderr so stdout can be redirected directly into a JSON artifact.

Why: browser-based hosts need a way to publish Liquid docs updates independently from theme-tools and extension releases. This PR only adds the generator; it does not change browser extension runtime behavior.

## What's next? Any followup issues?

Follow-up PR: #1016 teaches the browser extension to fetch a published docs bundle at runtime and fall back to bundled docs if unavailable.

A separate host/CDN publisher can use this command after this package version is released, for example:

```sh
pnpm dlx @shopify/theme-check-docs-updater@<version> theme-docs bundle > liquid-docs-bundle.json
```

## Tophatting

- [x] `pnpm --dir packages/theme-check-docs-updater type-check`
- [x] `CI=1 pnpm vitest run packages/theme-check-docs-updater/src/themeLiquidDocsBundle.spec.ts packages/theme-check-docs-updater/src/themeLiquidDocsManager.spec.ts`
- [x] `pnpm --dir packages/theme-check-docs-updater build`
- [x] `pnpm --silent --dir packages/theme-check-docs-updater theme-docs bundle | jq '.revision, .schemaVersion'`
- [x] `pnpm format:check`
- [x] `git diff --check`
- [x] Screenshots are not applicable; this is CLI/package API behavior.

## Before you deploy

<!-- Public API changes, new features -->
- [x] I included a minor bump `changeset`
- [x] My feature is backward compatible
