### PR TITLE
Validate section setting keys in JSON templates

### DIFF
--- a/.changeset/bright-keys-check.md
+++ b/.changeset/bright-keys-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Validate section setting keys in JSON templates.

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -62,7 +62,7 @@ import { ValidRenderSnippetArgumentTypes } from './valid-render-snippet-argument
 import { ValidSchema } from './valid-schema';
 import { ValidSchemaName } from './valid-schema-name';
 import { ValidSchemaTranslations } from './valid-schema-translations';
-import { ValidSettingsKey } from './valid-settings-key';
+import { ValidSettingsKey, ValidSettingsKeyJSON } from './valid-settings-key';
 import { ValidStaticBlockType } from './valid-static-block-type';
 import { ValidVisibleIf, ValidVisibleIfSettingsSchema } from './valid-visible-if';
 import { VariableName } from './variable-name';
@@ -133,6 +133,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   ValidRenderSnippetArgumentTypes,
   ValidSchema,
   ValidSettingsKey,
+  ValidSettingsKeyJSON,
   ValidStaticBlockType,
   ValidVisibleIf,
   ValidVisibleIfSettingsSchema,

--- a/packages/theme-check-common/src/checks/valid-settings-key/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-settings-key/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { check } from '../../test';
-import { ValidSettingsKey } from './index';
+import { ValidSettingsKey, ValidSettingsKeyJSON } from './index';
 
 describe('Module: ValidSettingsKey', () => {
   const schemaTemplate = {
@@ -112,6 +112,256 @@ describe('Module: ValidSettingsKey', () => {
       );
       expect(offenses[1].message).to.equal(
         `Setting 'non-existent-setting-2' does not exist in schema.`,
+      );
+    });
+  });
+
+  describe('template JSON section settings', () => {
+    it('does not report an error when a template JSON section setting exists in the section schema', async () => {
+      const theme = {
+        'templates/page.json': JSON.stringify({
+          sections: {
+            'main-page': {
+              type: 'main-page',
+              settings: {
+                heading_tag: 'h1',
+              },
+            },
+          },
+          order: ['main-page'],
+        }),
+        'sections/main-page.liquid': toLiquidFile({
+          name: 'Main page',
+          settings: [
+            {
+              id: 'heading_tag',
+              type: 'select',
+              label: 'Heading tag',
+              options: [
+                { value: 'h1', label: 'H1' },
+                { value: 'h2', label: 'H2' },
+              ],
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSettingsKey, ValidSettingsKeyJSON]);
+      expect(offenses).to.have.length(0);
+    });
+
+    it('reports an error when a template JSON section setting does not exist in the section schema', async () => {
+      const theme = {
+        'templates/page.json': JSON.stringify({
+          sections: {
+            'main-page': {
+              type: 'main-page',
+              settings: {
+                heading_tagg: 'h1',
+              },
+            },
+          },
+          order: ['main-page'],
+        }),
+        'sections/main-page.liquid': toLiquidFile({
+          name: 'Main page',
+          settings: [
+            {
+              id: 'heading_tag',
+              type: 'select',
+              label: 'Heading tag',
+              options: [
+                { value: 'h1', label: 'H1' },
+                { value: 'h2', label: 'H2' },
+              ],
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSettingsKey, ValidSettingsKeyJSON]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal(
+        `Setting 'heading_tagg' does not exist in 'sections/main-page.liquid'.`,
+      );
+    });
+  });
+
+  describe('template JSON block settings', () => {
+    it('does not report an error when a template JSON block setting exists in the block schema', async () => {
+      const theme = {
+        'templates/page.json': JSON.stringify({
+          sections: {
+            'main-page': {
+              type: 'main-page',
+              blocks: {
+                text: {
+                  type: 'text',
+                  settings: {
+                    heading: 'Hello',
+                  },
+                },
+              },
+              block_order: ['text'],
+            },
+          },
+          order: ['main-page'],
+        }),
+        'sections/main-page.liquid': toLiquidFile({
+          name: 'Main page',
+          blocks: [{ type: 'text' }],
+        }),
+        'blocks/text.liquid': toLiquidFile({
+          name: 'Text',
+          settings: [
+            {
+              id: 'heading',
+              type: 'text',
+              label: 'Heading',
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSettingsKey, ValidSettingsKeyJSON]);
+      expect(offenses).to.have.length(0);
+    });
+
+    it('reports an error when a template JSON block setting does not exist in the block schema', async () => {
+      const theme = {
+        'templates/page.json': JSON.stringify({
+          sections: {
+            'main-page': {
+              type: 'main-page',
+              blocks: {
+                text: {
+                  type: 'text',
+                  settings: {
+                    headingg: 'Hello',
+                  },
+                },
+              },
+              block_order: ['text'],
+            },
+          },
+          order: ['main-page'],
+        }),
+        'sections/main-page.liquid': toLiquidFile({
+          name: 'Main page',
+          blocks: [{ type: 'text' }],
+        }),
+        'blocks/text.liquid': toLiquidFile({
+          name: 'Text',
+          settings: [
+            {
+              id: 'heading',
+              type: 'text',
+              label: 'Heading',
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSettingsKey, ValidSettingsKeyJSON]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal(
+        `Setting 'headingg' does not exist in 'blocks/text.liquid'.`,
+      );
+    });
+
+    it('reports an error when a template JSON local block setting does not exist in the section schema', async () => {
+      const theme = {
+        'templates/page.json': JSON.stringify({
+          sections: {
+            'main-page': {
+              type: 'main-page',
+              blocks: {
+                foo: {
+                  type: 'foo',
+                  settings: {
+                    headingg: 'Hello',
+                  },
+                },
+              },
+              block_order: ['foo'],
+            },
+          },
+          order: ['main-page'],
+        }),
+        'sections/main-page.liquid': toLiquidFile({
+          name: 'Main page',
+          blocks: [
+            {
+              type: 'foo',
+              name: 'Foo',
+              settings: [
+                {
+                  id: 'heading',
+                  type: 'text',
+                  label: 'Heading',
+                },
+              ],
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSettingsKey, ValidSettingsKeyJSON]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal(
+        `Setting 'headingg' does not exist in 'sections/main-page.liquid'.`,
+      );
+    });
+
+    it('reports an error when a nested template JSON block setting does not exist in the nested block schema', async () => {
+      const theme = {
+        'templates/page.json': JSON.stringify({
+          sections: {
+            'main-page': {
+              type: 'main-page',
+              blocks: {
+                parent: {
+                  type: 'parent',
+                  blocks: {
+                    text: {
+                      type: 'text',
+                      settings: {
+                        headingg: 'Hello',
+                      },
+                    },
+                  },
+                  block_order: ['text'],
+                },
+              },
+              block_order: ['parent'],
+            },
+          },
+          order: ['main-page'],
+        }),
+        'sections/main-page.liquid': toLiquidFile({
+          name: 'Main page',
+          blocks: [{ type: 'parent' }],
+        }),
+        'blocks/parent.liquid': toLiquidFile({
+          name: 'Parent',
+          blocks: [{ type: 'text' }],
+        }),
+        'blocks/text.liquid': toLiquidFile({
+          name: 'Text',
+          settings: [
+            {
+              id: 'heading',
+              type: 'text',
+              label: 'Heading',
+            },
+          ],
+        }),
+      };
+
+      const offenses = await check(theme, [ValidSettingsKey, ValidSettingsKeyJSON]);
+      expect(offenses).to.have.length(1);
+      expect(offenses[0].message).to.equal(
+        `Setting 'headingg' does not exist in 'blocks/text.liquid'.`,
       );
     });
   });

--- a/packages/theme-check-common/src/checks/valid-settings-key/index.ts
+++ b/packages/theme-check-common/src/checks/valid-settings-key/index.ts
@@ -1,32 +1,35 @@
 import {
+  JSONCheckDefinition,
   LiquidCheckDefinition,
   Severity,
   SourceCodeType,
   Preset,
   Section,
   ThemeBlock,
+  Template,
   JSONNode,
   Setting,
 } from '../../types';
 import { nodeAtPath } from '../../json';
-import { getSchema, isSectionSchema } from '../../to-schema';
+import { getSchema, getSchemaFromJSON, isSectionSchema } from '../../to-schema';
 import { BlockDefNodeWithPath, getBlocks, reportWarning } from '../../utils';
 
-export const ValidSettingsKey: LiquidCheckDefinition = {
-  meta: {
-    code: 'ValidSettingsKey',
-    name: 'Validate settings key in presets',
-    docs: {
-      description:
-        'Ensures settings key only references valid settings defined in its respective schema',
-      recommended: true,
-      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-settings-key',
-    },
-    type: SourceCodeType.LiquidHtml,
-    severity: Severity.ERROR,
-    schema: {},
-    targets: [],
+const meta = {
+  code: 'ValidSettingsKey',
+  name: 'Validate settings key in presets',
+  docs: {
+    description:
+      'Ensures settings key only references valid settings defined in its respective schema',
+    recommended: true,
+    url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-settings-key',
   },
+  severity: Severity.ERROR,
+  schema: {},
+  targets: [],
+};
+
+export const ValidSettingsKey: LiquidCheckDefinition = {
+  meta: { ...meta, type: SourceCodeType.LiquidHtml },
 
   create(context) {
     return {
@@ -78,6 +81,61 @@ export const ValidSettingsKey: LiquidCheckDefinition = {
   },
 };
 
+export const ValidSettingsKeyJSON: JSONCheckDefinition = {
+  meta: { ...meta, type: SourceCodeType.JSON },
+
+  create(context) {
+    const relativePath = context.toRelativePath(context.file.uri);
+    if (!relativePath.startsWith('templates/')) return {};
+
+    return {
+      async onCodePathEnd() {
+        const schema = await getSchemaFromJSON(context);
+        const { ast } = schema ?? {};
+        if (!schema || !ast || ast instanceof Error) return;
+
+        const sections = schema.parsed.sections;
+        if (!sections) return;
+
+        await Promise.all(
+          Object.entries(sections).map(async ([sectionKey, section]) => {
+            if (!isPropertyNode(section) || !('type' in section)) {
+              return;
+            }
+
+            const sectionSchema = await context.getSectionSchema?.(section.type);
+            const { validSchema } = sectionSchema ?? {};
+            if (!validSchema || validSchema instanceof Error) return;
+
+            if ('settings' in section) {
+              const settingsNode = nodeAtPath(ast, ['sections', sectionKey, 'settings']);
+              validateSettingsKey(
+                context,
+                0,
+                settingsNode,
+                validSchema.settings,
+                undefined,
+                `'sections/${section.type}.liquid'`,
+              );
+            }
+
+            if ('blocks' in section && isPropertyNode(section.blocks)) {
+              await validateTemplateBlocksSettings(
+                context,
+                ast,
+                section.blocks,
+                validSchema,
+                ['sections', sectionKey, 'blocks'],
+                `'sections/${section.type}.liquid'`,
+              );
+            }
+          }),
+        );
+      },
+    };
+  },
+};
+
 async function validateReferencedBlock(
   context: any,
   offset: number,
@@ -104,12 +162,76 @@ async function validateReferencedBlock(
   }
 }
 
+async function validateTemplateBlocksSettings(
+  context: any,
+  ast: JSONNode,
+  blocks: Record<string, Template.Block>,
+  parentSchema: Section.Schema | ThemeBlock.Schema,
+  currentPath: string[],
+  parentSchemaPath: string,
+) {
+  await Promise.all(
+    Object.entries(blocks).map(async ([blockKey, block]) => {
+      if (!isPropertyNode(block) || !('type' in block)) return;
+
+      const currentBlockPath = currentPath.concat(blockKey);
+      const localBlock = parentSchema.blocks?.find(
+        (schemaBlock) => schemaBlock.type === block.type && 'name' in schemaBlock,
+      ) as Section.LocalBlock | undefined;
+
+      if (localBlock) {
+        const settingsNode = nodeAtPath(ast, currentBlockPath.concat('settings'));
+        validateSettingsKey(
+          context,
+          0,
+          settingsNode,
+          localBlock.settings,
+          undefined,
+          parentSchemaPath,
+        );
+
+        if ('blocks' in block && isPropertyNode(block.blocks)) {
+          await validateTemplateBlocksSettings(
+            context,
+            ast,
+            block.blocks,
+            localBlock,
+            currentBlockPath.concat('blocks'),
+            parentSchemaPath,
+          );
+        }
+
+        return;
+      }
+
+      const blockSchema = await context.getBlockSchema?.(block.type);
+      const { validSchema } = blockSchema ?? {};
+      if (!validSchema || validSchema instanceof Error) return;
+
+      const settingsNode = nodeAtPath(ast, currentBlockPath.concat('settings'));
+      validateSettingsKey(context, 0, settingsNode, validSchema.settings, block);
+
+      if ('blocks' in block && isPropertyNode(block.blocks)) {
+        await validateTemplateBlocksSettings(
+          context,
+          ast,
+          block.blocks,
+          validSchema,
+          currentBlockPath.concat('blocks'),
+          `'blocks/${block.type}.liquid'`,
+        );
+      }
+    }),
+  );
+}
+
 function validateSettingsKey(
   context: any,
   offset: number,
   settingsNode: JSONNode | undefined,
   validSettings: Setting.Any[] | undefined,
   blockNode?: Section.Block | ThemeBlock.Block | Preset.Block,
+  schemaPath = 'schema',
 ) {
   if (!settingsNode || settingsNode.type !== 'Object') return;
 
@@ -121,9 +243,13 @@ function validateSettingsKey(
     if (!settingExists) {
       const errorMessage = blockNode
         ? `Setting '${setting.key.value}' does not exist in 'blocks/${blockNode.type}.liquid'.`
-        : `Setting '${setting.key.value}' does not exist in schema.`;
+        : `Setting '${setting.key.value}' does not exist in ${schemaPath}.`;
 
       reportWarning(errorMessage, offset, setting.key, context);
     }
   }
+}
+
+function isPropertyNode(node: unknown): node is Record<string, any> {
+  return typeof node === 'object' && node !== null;
 }


### PR DESCRIPTION
## What are you adding in this PR?

Fixes #1239.

`ValidSettingsKey` already validates setting keys inside section schema presets/defaults, but template JSON section settings were not checked. That meant a template could set an unknown section setting key and Theme Check would report no offense.

This adds the JSON-template side of the same check for `templates/*.json`:

- resolve each template section's `type` to its section schema
- validate `sections.*.settings` keys against that schema's `settings`
- report the unknown key on the template JSON setting key

This covers section settings and template block settings, including nested blocks. Section group JSON files are left unchanged.

## What's next? Any followup issues?

No follow-up planned.

## What did you learn?

Template JSON checks run separately from Liquid schema checks, so this uses a JSON companion check registered under the same `ValidSettingsKey` code.

## Tophatting

- [x] `corepack pnpm exec vitest run packages/theme-check-common/src/checks/valid-settings-key/index.spec.ts`
- [x] `corepack pnpm exec vitest run packages/theme-check-common/src/index.spec.ts packages/theme-check-common/src/checks/valid-settings-key/index.spec.ts`
- [x] `corepack pnpm --dir packages/theme-check-common type-check`
- [x] `corepack pnpm exec prettier --check --ignore-unknown packages/theme-check-common/src/checks/valid-settings-key/index.ts packages/theme-check-common/src/checks/valid-settings-key/index.spec.ts packages/theme-check-common/src/checks/index.ts .changeset/bright-keys-check.md`
- [x] `corepack pnpm build` from Git Bash on Windows
- [ ] I added screenshots of the changes (before and after the changes if applicable)

## Before you deploy

- [x] This PR includes a new checks or changes the configuration of a check
  - [x] I included a minor bump `changeset`
  - [x] I ran `pnpm build` and committed the updated configuration files (no tracked config changes were produced)
  - [x] If applicable, I've updated the `theme-app-extension.yml` config (not applicable)
  - [ ] [Shopifolk] I've made a PR to update the shopify.dev theme check docs if applicable.