### PR TITLE
Add changeset for hand-written liquid-html-parser

### DIFF
--- a/.changeset/hand-written-liquid-html-parser.md
+++ b/.changeset/hand-written-liquid-html-parser.md
@@ -1,0 +1,16 @@
+---
+'@shopify/liquid-html-parser': minor
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-check-common': minor
+'@shopify/prettier-plugin-liquid': minor
+'@shopify/theme-graph': minor
+---
+
+Adopt the hand-written `liquid-html-parser` for performance
+
+Replace the parser-combinator-based Liquid/HTML parser with a hand-written
+recursive-descent parser. The new parser is significantly faster, adds
+resilient parsing (it recovers from malformed input instead of bailing), and is
+adapted to the theme-tools source model. `theme-language-server-common`,
+`theme-check-common`, `prettier-plugin-liquid`, and `theme-graph` are updated to
+consume the new parser.


### PR DESCRIPTION
Adds a changeset (minor bump) for the packages affected by adopting the new parser.

Part 7 of 7 in the stacked series, based on PR 6. This is the only commit that changes anything beyond the six byte-identical reorg commits.
