### PR TITLE
Fix VS Code F5 build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,18 +6,12 @@
       "command": "pnpm --dir packages/vscode-extension run build:extension:dev",
       "group": "build",
       "label": "vscode dev",
-      "dependsOrder": "parallel",
+      "dependsOrder": "sequence",
       "problemMatcher": "$ts-checker-webpack",
       "dependsOn": [
-        "language-config",
-        "parser pre build",
-        "theme check build"
+        "theme check build",
+        "language-config"
       ],
-    },
-    {
-      "label": "parser pre build",
-      "type": "shell",
-      "command": "pnpm --dir packages/liquid-html-parser run prebuild:ts"
     },
     {
       "label": "language-config",


### PR DESCRIPTION
## Summary

- remove the obsolete `liquid-html-parser` prebuild task
- run the existing Theme Check build before language-config generation, since its TypeScript project references already build the parser
- restore F5 launches for the Node and web Extension Development Hosts without a redundant parser build

## Testing

Starting without `packages/liquid-html-parser/dist`:

- `pnpm --dir packages/theme-check-node run build:ts`
- `pnpm --dir packages/vscode-extension run build:language-config`
- `pnpm --dir packages/vscode-extension run build:extension:dev`