### PR TITLE
Fix theme-check-disable-next-line inside tags

### DIFF
--- a/.changeset/fix-disable-next-line-raw-tags.md
+++ b/.changeset/fix-disable-next-line-raw-tags.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Fix `theme-check-disable-next-line` not suppressing offenses when the following tag is nested inside a raw HTML tag (`<style>`, `<script>`, `<svg>`). Previously, the sibling-node lookup only checked for a `children` array, but nodes inside raw HTML tags are stored under a `nodes` property on the `RawMarkup` body, so the disable comment was silently ineffective in that context.

--- a/packages/theme-check-common/src/disabled-checks/index.spec.ts
+++ b/packages/theme-check-common/src/disabled-checks/index.spec.ts
@@ -281,6 +281,20 @@ ${buildComment('theme-check-enable')}
         expect(offenses).to.have.length(0);
       });
 
+      it('should disable the next line when nested inside a raw HTML tag like <style> or <script>', async () => {
+        for (const rawTag of ['style', 'script']) {
+          const file = `<${rawTag}>
+  {% # theme-check-disable-next-line %}
+  {% render 'something' %}
+  {% render 'other-thing' %}
+</${rawTag}>`;
+
+          const offenses = await check({ 'code.liquid': file }, checks);
+          expect(offenses).to.have.length(1);
+          expectRenderMarkupOffense(offenses, 'other-thing.liquid');
+        }
+      });
+
       it('should still report offenses in doc tags when disable-next-line is not present', async () => {
         const file = `{% doc %}
   @param baz - first param

--- a/packages/theme-check-common/src/disabled-checks/index.ts
+++ b/packages/theme-check-common/src/disabled-checks/index.ts
@@ -185,6 +185,8 @@ function getNextNode(
     siblingNodes = parentNode.markup;
   } else if ('children' in parentNode) {
     siblingNodes = parentNode.children || [];
+  } else if ('nodes' in parentNode) {
+    siblingNodes = parentNode.nodes || [];
   }
 
   const currentNodeIdx = siblingNodes.findIndex((c) => c === node);


### PR DESCRIPTION
## Summary
- `theme-check-disable-next-line` silently had no effect when the tag it targeted was nested inside a raw HTML tag (`<style>`, `<script>`, `<svg>`) — e.g. disabling `PaginationSize` on a `{% paginate %}` tag used to generate CSS custom properties inside a `<style>` block.
- Root cause: `getNextNode()` in `disabled-checks/index.ts` looks for the disable comment's next sibling via a `children` array on the parent node. Liquid nodes nested inside raw HTML tags aren't stored under `children` — they live under `RawMarkup.nodes` (see `HtmlRawNode.body: RawMarkup` / `RawMarkup.nodes` in `liquid-html-parser/src/ast.ts`). Since `'children' in parentNode` was `false` for a `RawMarkup` parent, `getNextNode` returned `undefined`, so `findNextLinePosition` never registered a disabled range at all, and the offense was reported as if no disable comment existed.
- Fix: add a fallback branch that reads `parentNode.nodes` when present, mirroring the existing `children`/`markup` handling.

Reported by a user hitting this with:
```liquid
<style>
  ...
  {%- # theme-check-disable-next-line PaginationSize -%}
  {%- paginate metaobjects.swatch.values by 9999 -%}
    ...
  {%- endpaginate -%}
</style>
```
Confirmed via `shopify theme check --output json` against a real theme file, then reduced to a minimal repro and traced to the AST-shape mismatch above.

## Test plan
- [x] Added a regression test covering `disable-next-line` nested in both `<style>` and `<script>`.
- [x] `disabled-checks/index.spec.ts` — all 19 tests pass.
- [x] Full `theme-check-common` suite — 1251 tests pass.
- [x] `tsc --noEmit` clean.
- [x] Added a changeset (`patch` bump for `@shopify/theme-check-common`).