### PR TITLE
Allow section and block objects in theme-mode snippets

### DIFF
--- a/.changeset/undefined-object-section-block-snippets.md
+++ b/.changeset/undefined-object-section-block-snippets.md
@@ -1,0 +1,11 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+`UndefinedObject` no longer reports `section` and `block` as undefined in theme-mode snippets.
+
+Snippets are commonly rendered from a section or block, which pass `section` and `block` down into scope. Treating them as contextual objects in theme-mode snippets (alongside `app`) avoids false positives such as:
+
+```
+[UndefinedObject] Unknown object 'section' used.
+```

--- a/.changeset/undefined-object-section-block-snippets.md
+++ b/.changeset/undefined-object-section-block-snippets.md
@@ -2,10 +2,6 @@
 '@shopify/theme-check-common': patch
 ---
 
-`UndefinedObject` no longer reports `section` and `block` as undefined in theme-mode snippets.
+`UndefinedObject` no longer reports `section` and `block` objects as undefined in theme snippet files.
 
-Snippets are commonly rendered from a section or block, which pass `section` and `block` down into scope. Treating them as contextual objects in theme-mode snippets (alongside `app`) avoids false positives such as:
-
-```
-[UndefinedObject] Unknown object 'section' used.
-```
+When snippets are rendered in a section or block, the `section` and `block` context is already available without needing to be passed as a parameter. Treating these objects as defined contextual objects in theme snippets avoids false positives from the check.

--- a/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.spec.ts
@@ -343,8 +343,21 @@ describe('Module: UndefinedObject', () => {
     }
   });
 
-  it('should still flag block-level objects in snippets when in theme mode', async () => {
-    const blockOnlyObjects = ['section', 'block', 'recommendations'];
+  it('should allow app, section, and block in snippets when in theme mode', async () => {
+    const allowedObjects = ['app', 'section', 'block'];
+    for (const object of allowedObjects) {
+      const sourceCode = `{% doc %} @param {string} x - x {% enddoc %}{{ ${object} }}`;
+      const offenses = await runLiquidCheck(
+        UndefinedObject,
+        sourceCode,
+        'snippets/my-snippet.liquid',
+      );
+      expect(offenses, `Expected no offense for '${object}' in theme mode snippet`).toHaveLength(0);
+    }
+  });
+
+  it('should still flag block-only objects in snippets when in theme mode', async () => {
+    const blockOnlyObjects = ['recommendations'];
     for (const object of blockOnlyObjects) {
       const sourceCode = `{% doc %} @param {string} x - x {% enddoc %}{{ ${object} }}`;
       const offenses = await runLiquidCheck(

--- a/packages/theme-check-common/src/checks/undefined-object/index.ts
+++ b/packages/theme-check-common/src/checks/undefined-object/index.ts
@@ -220,7 +220,10 @@ function getContextualObjects(relativePath: string, mode: Mode = 'theme'): strin
     // In a theme app extension, snippets can only be rendered from blocks,
     // so they have access to the same contextual objects as blocks.
     if (mode === 'app') return BLOCK_CONTEXTUAL_OBJECTS;
-    return ['app'];
+    // In a theme, a snippet is commonly rendered from a section or block, which
+    // pass `section` and `block` down into scope, so they should not be reported
+    // as undefined here.
+    return ['app', 'section', 'block'];
   }
 
   return [];


### PR DESCRIPTION
### What

`UndefinedObject` no longer reports `section` and `block` as undefined in theme-mode **snippets**. It adds them (alongside `app`) to the contextual objects returned for `snippets/` in theme mode.

Issue of false positive warning

<img width="1324" height="514" alt="Screenshot 2026-07-31 at 3 34 01 PM" src="https://github.com/user-attachments/assets/c7ca89d2-cbe2-4bd5-b567-9139bdec0210" />


### Why

Snippets are commonly rendered from a section or block, which pass `section` and `block` down into scope. Referencing them in a snippet is valid, but the check flagged them:

```
[UndefinedObject] Unknown object 'section' used.
```

This was a false positive. App-mode snippets already had access to the full block-level object set; this brings `section` and `block` into theme-mode snippets too. `recommendations` stays section/block-only and is still flagged in theme-mode snippets.

### How

- `getContextualObjects` returns `['app', 'section', 'block']` for theme-mode `snippets/`.
- Updated tests: `section`/`block` are now allowed in theme-mode snippets; `recommendations` is still flagged.
- Added a changeset (patch).

Co-Authored by AI
