### PR TITLE
Add Ruby Liquid parity test suite for LiquidSyntaxError

### DIFF
--- a/packages/theme-check-common/package.json
+++ b/packages/theme-check-common/package.json
@@ -43,6 +43,7 @@
     "@types/lodash": "^4.17.20",
     "@types/node": "^22.18.8",
     "@types/postcss-safe-parser": "^5.0.4",
-    "@vitest/expect": "4.1.0"
+    "@vitest/expect": "4.1.0",
+    "yaml": "^2.8.3"
   }
 }

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/lint-liquid.ts
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/lint-liquid.ts
@@ -1,0 +1,28 @@
+import { runLiquidCheck } from '../../../test';
+import { LiquidSyntaxError } from '../index';
+
+export interface LintDiagnostic {
+  message: string;
+  line: number;
+}
+
+const DEFAULT_PATH = 'templates/template.liquid';
+
+/**
+ * `themeDocset: undefined` drives tag-name recognition through the real
+ * `builtinTags` fallback in base.ts (the test harness would otherwise inject
+ * a docset whose `tags()` returns `[]`).
+ */
+const NO_DOCSET = { themeDocset: undefined } as const;
+
+export async function lintLiquid(
+  template: string,
+  filePath: string = DEFAULT_PATH,
+): Promise<LintDiagnostic[]> {
+  const fileName = filePath.replace(/^\/+/, '');
+  const offenses = await runLiquidCheck(LiquidSyntaxError, template, fileName, NO_DOCSET);
+  return offenses.map((offense) => ({
+    message: offense.message,
+    line: offense.start.line,
+  }));
+}

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/loader.ts
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/loader.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse } from 'yaml';
+
+export interface Scenario {
+  id: string;
+  template: string;
+  error_path: string;
+  file_path?: string;
+}
+
+export interface SnapshotEntry {
+  id: string;
+  error: string | null;
+  type: string | null;
+}
+
+export function loadScenarios(tag: string): Scenario[] {
+  const path = resolve(__dirname, 'scenarios', `${tag}.yml`);
+  const content = readFileSync(path, 'utf-8');
+  return parse(content) as Scenario[];
+}
+
+export function loadSnapshots(tag: string): SnapshotEntry[] {
+  const path = resolve(__dirname, 'snapshots', `${tag}.snap.yml`);
+  const content = readFileSync(path, 'utf-8');
+  return parse(content) as SnapshotEntry[];
+}

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/normalize.ts
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/normalize.ts
@@ -1,0 +1,44 @@
+import type { LintDiagnostic } from './lint-liquid';
+
+export interface NormalizedError {
+  detected: boolean;
+  line: number | null;
+  coreMessage: string;
+}
+
+export function normalizeSnapshot(snap: {
+  error: string | null;
+  type: string | null;
+}): NormalizedError {
+  if (!snap.error) {
+    return { detected: false, line: null, coreMessage: '' };
+  }
+
+  return {
+    detected: true,
+    line: null,
+    coreMessage: snap.error.toLowerCase().trim(),
+  };
+}
+
+export function normalizeThemeCheck(diagnostics: LintDiagnostic[]): NormalizedError {
+  if (diagnostics.length === 0) {
+    return { detected: false, line: null, coreMessage: '' };
+  }
+
+  let msg = diagnostics[0].message.toLowerCase().trim();
+
+  if (msg.startsWith('liquidhtmlsyntaxerror: ')) {
+    msg = msg.slice('liquidhtmlsyntaxerror: '.length).trim();
+  }
+
+  if (msg.startsWith('syntax error: ')) {
+    msg = msg.slice('syntax error: '.length).trim();
+  }
+
+  return {
+    detected: true,
+    line: diagnostics[0].line,
+    coreMessage: msg,
+  };
+}

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/parity.spec.ts
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/parity.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, afterAll, expect } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { lintLiquid } from './lint-liquid';
+import { type Scenario, loadScenarios, loadSnapshots } from './loader';
+import { normalizeSnapshot, normalizeThemeCheck } from './normalize';
+import { Outcome, ParityReport } from './report';
+
+const report = new ParityReport();
+
+const scenariosDir = resolve(__dirname, 'scenarios');
+const tags = readdirSync(scenariosDir)
+  .filter((f) => f.endsWith('.yml'))
+  .map((f) => f.replace('.yml', ''));
+
+/*
+ * Scenarios where Ruby Liquid reports an error that LiquidSyntaxError does
+ * not. Each entry is asserted to STILL miss, so the day the gap closes this
+ * suite fails and the entry gets deleted rather than quietly masking a
+ * re-introduced regression.
+ *
+ *   section-themecheck-bare-bracket-arg — `{% section 'header', foo: [0] %}`.
+ *     The section syntax check skips BlockArrayLiteral argument values,
+ *     which @shopify/liquid-html-parser produces for `[0]`, so the bare
+ *     bracket never reaches the bare-array-access test. Ruby rejects named
+ *     arguments on {% section %} outright.
+ */
+const KNOWN_GAPS = new Set(['section-themecheck-bare-bracket-arg']);
+
+async function runParityScenario(
+  tag: string,
+  scenario: Scenario,
+  snapshots: ReturnType<typeof loadSnapshots>,
+) {
+  const snap = snapshots.find((s) => s.id === scenario.id);
+  expect(snap, `No snapshot for ${scenario.id}`).toBeDefined();
+
+  const diagnostics = await lintLiquid(scenario.template, scenario.file_path);
+  const snapshotNorm = normalizeSnapshot(snap!);
+  const themeCheckNorm = normalizeThemeCheck(diagnostics);
+
+  if (KNOWN_GAPS.has(scenario.id)) {
+    expect(
+      themeCheckNorm.detected,
+      `[${scenario.id}] is listed in KNOWN_GAPS but theme-check now reports it — remove the entry`,
+    ).toBe(false);
+    return;
+  }
+
+  if (snapshotNorm.detected && themeCheckNorm.detected) {
+    report.record(Outcome.MATCH, { tag, scenarioId: scenario.id });
+    return;
+  }
+
+  if (snapshotNorm.detected && !themeCheckNorm.detected) {
+    report.record(Outcome.UNEXPECTED_MISS, {
+      tag,
+      scenarioId: scenario.id,
+      message: snapshotNorm.coreMessage,
+    });
+    expect.fail(
+      `UNEXPECTED_MISS [${scenario.id}]: snapshot detects error but theme-check does not`,
+    );
+    return;
+  }
+
+  if (!snapshotNorm.detected && themeCheckNorm.detected) {
+    report.record(Outcome.FALSE_POSITIVE, {
+      tag,
+      scenarioId: scenario.id,
+      message: themeCheckNorm.coreMessage,
+    });
+    expect.fail(`FALSE_POSITIVE [${scenario.id}]: theme-check reports error but snapshot has none`);
+    return;
+  }
+
+  report.record(Outcome.AGREE_NO_ERROR, { tag, scenarioId: scenario.id });
+}
+
+for (const tag of tags) {
+  const scenarios = loadScenarios(tag);
+  const snapshots = loadSnapshots(tag);
+
+  describe(`Parity: ${tag}`, () => {
+    it.each(scenarios)('$id', async (scenario) => {
+      await runParityScenario(tag, scenario, snapshots);
+    });
+  });
+}
+
+afterAll(() => {
+  if (process.env.PARITY_REPORT === '1') {
+    report.print();
+  }
+});

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/report.ts
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/report.ts
@@ -1,0 +1,82 @@
+export const Outcome = {
+  MATCH: 'MATCH',
+  EXPECTED_MISS: 'EXPECTED_MISS',
+  UNEXPECTED_MISS: 'UNEXPECTED_MISS',
+  FALSE_POSITIVE: 'FALSE_POSITIVE',
+  AGREE_NO_ERROR: 'AGREE_NO_ERROR',
+} as const;
+export type Outcome = (typeof Outcome)[keyof typeof Outcome];
+
+export interface RecordEntry {
+  tag: string;
+  scenarioId: string;
+  outcome: Outcome;
+  message?: string;
+}
+
+export class ParityReport {
+  private entries: RecordEntry[] = [];
+
+  record(outcome: Outcome, details: { tag: string; scenarioId: string; message?: string }): void {
+    this.entries.push({
+      tag: details.tag,
+      scenarioId: details.scenarioId,
+      outcome,
+      message: details.message,
+    });
+  }
+
+  print(): void {
+    const counts: Record<Outcome, number> = {
+      [Outcome.MATCH]: 0,
+      [Outcome.EXPECTED_MISS]: 0,
+      [Outcome.UNEXPECTED_MISS]: 0,
+      [Outcome.FALSE_POSITIVE]: 0,
+      [Outcome.AGREE_NO_ERROR]: 0,
+    };
+
+    for (const entry of this.entries) {
+      counts[entry.outcome]++;
+    }
+
+    const total = this.entries.length;
+    const detected = counts[Outcome.MATCH];
+    const coverage = total > 0 ? ((detected / total) * 100).toFixed(1) : '0.0';
+
+    console.log('');
+    console.log('=== Syntax Error Parity Report ===');
+    console.log('');
+    console.log(`Total scenarios: ${total}`);
+    console.log(`  MATCH (both detect):     ${String(counts[Outcome.MATCH]).padStart(3)}`);
+    console.log(`  EXPECTED MISS (known):   ${String(counts[Outcome.EXPECTED_MISS]).padStart(3)}`);
+    console.log(
+      `  UNEXPECTED MISS:         ${String(counts[Outcome.UNEXPECTED_MISS]).padStart(3)}`,
+    );
+    console.log(`  FALSE POSITIVE:          ${String(counts[Outcome.FALSE_POSITIVE]).padStart(3)}`);
+    console.log(`  AGREE NO ERROR:          ${String(counts[Outcome.AGREE_NO_ERROR]).padStart(3)}`);
+    console.log('');
+    console.log(`Coverage: ${coverage}% (${detected}/${total} detected)`);
+
+    const unexpectedMisses = this.entries.filter((e) => e.outcome === Outcome.UNEXPECTED_MISS);
+    if (unexpectedMisses.length > 0) {
+      console.log('');
+      console.log('Unexpected misses (need investigation):');
+      for (const entry of unexpectedMisses) {
+        const suffix = entry.message ? `: ${entry.message}` : '';
+        console.log(`  - ${entry.scenarioId}${suffix}`);
+      }
+    }
+
+    const falsePositives = this.entries.filter((e) => e.outcome === Outcome.FALSE_POSITIVE);
+    if (falsePositives.length > 0) {
+      console.log('');
+      console.log('False positives (theme-check wrong):');
+      for (const entry of falsePositives) {
+        const suffix = entry.message ? `: ${entry.message}` : '';
+        console.log(`  - ${entry.scenarioId}${suffix}`);
+      }
+    }
+
+    console.log('');
+  }
+}

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/assign.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/assign.yml
@@ -1,0 +1,1034 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: assign-mut-pregate-000
+  template: "{% assign  = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-001
+  template: "{% assign = = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-002
+  template: "{% assign ? = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-003
+  template: '{% assign "hi" = x %}'
+  error_path: pre_gate
+- id: assign-mut-pregate-004
+  template: "{% assign @ = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-005
+  template: "{% assign # = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-006
+  template: "{% assign $ = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-007
+  template: "{% assign ^ = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-008
+  template: "{% assign & = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-009
+  template: "{% assign * = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-010
+  template: "{% assign ~ = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-011
+  template: "{% assign ; = x %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-012
+  template: "{% assign | = x %}"
+  error_path: pre_gate
+- id: assign-mut-lhs_id-eos
+  template: "{% assign  = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-number
+  template: "{% assign 42 = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-at
+  template: "{% assign @ = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-hash
+  template: "{% assign # = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-dollar
+  template: "{% assign $ = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-caret
+  template: "{% assign ^ = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-ampersand
+  template: "{% assign & = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-asterisk
+  template: "{% assign * = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-tilde
+  template: "{% assign ~ = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-backtick
+  template: "{% assign ` = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-backslash
+  template: "{% assign \\ = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-semicolon
+  template: "{% assign ; = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-unclosed_double_quote
+  template: '{% assign "hello = x %}'
+  error_path: lhs_id
+- id: assign-mut-lhs_id-lexerr-unclosed_single_quote
+  template: "{% assign 'hello = x %}"
+  error_path: lhs_id
+- id: assign-mut-lhs_eos-trail-id
+  template: "{% assign x extra = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-number
+  template: "{% assign x 42 = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-string
+  template: "{% assign x 'hi' = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-pipe
+  template: "{% assign x | = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-colon
+  template: "{% assign x : = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-comma
+  template: "{% assign x , = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-open_square
+  template: "{% assign x [ = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-close_square
+  template: "{% assign x ] = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-open_round
+  template: "{% assign x ( = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-close_round
+  template: "{% assign x ) = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-question
+  template: "{% assign x ? = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-dot
+  template: "{% assign x . = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-comparison
+  template: "{% assign x == = x %}"
+  error_path: lhs_eos
+- id: assign-mut-lhs_eos-trail-dash
+  template: "{% assign x - = x %}"
+  error_path: lhs_eos
+- id: assign-mut-valid-lhs-000
+  template: "{% assign my_var = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-001
+  template: "{% assign my-var = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-002
+  template: "{% assign _private = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-003
+  template: "{% assign item1 = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-004
+  template: "{% assign IF = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-005
+  template: "{% assign For = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-006
+  template: "{% assign TRUE = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-007
+  template: "{% assign false = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-008
+  template: "{% assign NIL = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-009
+  template: "{% assign Blank = x %}"
+  error_path: valid
+- id: assign-mut-valid-lhs-010
+  template: "{% assign Empty = x %}"
+  error_path: valid
+- id: assign-mut-pregate-000-2
+  template: "{% assign x =  %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-001-2
+  template: "{% assign x = = %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-002-2
+  template: "{% assign x = ? %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-003-2
+  template: '{% assign x = "hi" %}'
+  error_path: pre_gate
+- id: assign-mut-pregate-004-2
+  template: "{% assign x = @ %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-005-2
+  template: "{% assign x = # %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-006-2
+  template: "{% assign x = $ %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-007-2
+  template: "{% assign x = ^ %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-008-2
+  template: "{% assign x = & %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-009-2
+  template: "{% assign x = * %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-010-2
+  template: "{% assign x = ~ %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-011-2
+  template: "{% assign x = ; %}"
+  error_path: pre_gate
+- id: assign-mut-pregate-012-2
+  template: "{% assign x = | %}"
+  error_path: pre_gate
+- id: assign-mut-value-pipe-000
+  template: "{% assign x = | %}"
+  error_path: value/bad_start
+- id: assign-mut-value-comma-001
+  template: "{% assign x = , %}"
+  error_path: value/bad_start
+- id: assign-mut-value-colon-002
+  template: "{% assign x = : %}"
+  error_path: value/bad_start
+- id: assign-mut-value-close_square-003
+  template: "{% assign x = ] %}"
+  error_path: value/bad_start
+- id: assign-mut-value-close_round-004
+  template: "{% assign x = ) %}"
+  error_path: value/bad_start
+- id: assign-mut-value-question-005
+  template: "{% assign x = ? %}"
+  error_path: value/bad_start
+- id: assign-mut-value-dash-006
+  template: "{% assign x = - %}"
+  error_path: value/bad_start
+- id: assign-mut-value-dot-007
+  template: "{% assign x = . %}"
+  error_path: value/bad_start
+- id: assign-mut-value-dotdot-008
+  template: "{% assign x = .. %}"
+  error_path: value/bad_start
+- id: assign-mut-value-comparison-009
+  template: "{% assign x = == %}"
+  error_path: value/bad_start
+- id: assign-mut-value-comparison-010
+  template: "{% assign x = != %}"
+  error_path: value/bad_start
+- id: assign-mut-value-comparison-011
+  template: "{% assign x = < %}"
+  error_path: value/bad_start
+- id: assign-mut-value-comparison-012
+  template: "{% assign x = > %}"
+  error_path: value/bad_start
+- id: assign-mut-value-comparison-013
+  template: "{% assign x = <= %}"
+  error_path: value/bad_start
+- id: assign-mut-value-comparison-014
+  template: "{% assign x = >= %}"
+  error_path: value/bad_start
+- id: assign-mut-value-comparison-015
+  template: "{% assign x = contains %}"
+  error_path: value/bad_start
+- id: assign-mut-value-eos-016
+  template: "{% assign x =  %}"
+  error_path: value/bad_start
+- id: assign-mut-value-bare_bracket
+  template: "{% assign x = [0] %}"
+  error_path: value/bad_start
+- id: assign-mut-value-lookup-trailing_dot
+  template: "{% assign x = x. %}"
+  error_path: value/lookup
+- id: assign-mut-value-lookup-dot_number
+  template: "{% assign x = x.123 %}"
+  error_path: value/lookup
+- id: assign-mut-value-lookup-dot_string
+  template: '{% assign x = x."y" %}'
+  error_path: value/lookup
+- id: assign-mut-value-lookup-unclosed_bracket
+  template: "{% assign x = x[0 %}"
+  error_path: value/lookup
+- id: assign-mut-value-lookup-bracket_wrong_content
+  template: "{% assign x = x[,] %}"
+  error_path: value/lookup
+- id: assign-mut-value-lookup-unclosed_range
+  template: "{% assign x = (1..5 %}"
+  error_path: value/lookup
+- id: assign-mut-value-lookup-range_bad_separator
+  template: "{% assign x = (1, 5) %}"
+  error_path: value/lookup
+- id: assign-mut-value-lookup-range_missing_end
+  template: "{% assign x = (1..) %}"
+  error_path: value/lookup
+- id: assign-mut-value-lexerr-at
+  template: "{% assign x = @ %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-hash
+  template: "{% assign x = # %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-dollar
+  template: "{% assign x = $ %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-caret
+  template: "{% assign x = ^ %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-ampersand
+  template: "{% assign x = & %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-asterisk
+  template: "{% assign x = * %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-tilde
+  template: "{% assign x = ~ %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-backtick
+  template: "{% assign x = ` %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-backslash
+  template: "{% assign x = \\ %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-semicolon
+  template: "{% assign x = ; %}"
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-unclosed_double_quote
+  template: '{% assign x = "hello %}'
+  error_path: value/lexer
+- id: assign-mut-value-lexerr-unclosed_single_quote
+  template: "{% assign x = 'hello %}"
+  error_path: value/lexer
+- id: assign-mut-filter_name-eos
+  template: "{% assign x = x | %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-number
+  template: "{% assign x = x | 42 %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-at
+  template: "{% assign x = x | @ %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-hash
+  template: "{% assign x = x | # %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-dollar
+  template: "{% assign x = x | $ %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-caret
+  template: "{% assign x = x | ^ %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-ampersand
+  template: "{% assign x = x | & %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-asterisk
+  template: "{% assign x = x | * %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-tilde
+  template: "{% assign x = x | ~ %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-backtick
+  template: "{% assign x = x | ` %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-backslash
+  template: "{% assign x = x | \\ %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-semicolon
+  template: "{% assign x = x | ; %}"
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-unclosed_double_quote
+  template: '{% assign x = x | "hello %}'
+  error_path: filter_name
+- id: assign-mut-filter_name-lexerr-unclosed_single_quote
+  template: "{% assign x = x | 'hello %}"
+  error_path: filter_name
+- id: assign-mut-filter_first_arg-pipe-000
+  template: "{% assign x = x | x : | %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-comma-001
+  template: "{% assign x = x | x : , %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-colon-002
+  template: "{% assign x = x | x : : %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-close_square-003
+  template: "{% assign x = x | x : ] %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-close_round-004
+  template: "{% assign x = x | x : ) %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-question-005
+  template: "{% assign x = x | x : ? %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-dash-006
+  template: "{% assign x = x | x : - %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-dot-007
+  template: "{% assign x = x | x : . %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-dotdot-008
+  template: "{% assign x = x | x : .. %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-comparison-009
+  template: "{% assign x = x | x : == %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-comparison-010
+  template: "{% assign x = x | x : != %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-comparison-011
+  template: "{% assign x = x | x : < %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-comparison-012
+  template: "{% assign x = x | x : > %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-comparison-013
+  template: "{% assign x = x | x : <= %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-comparison-014
+  template: "{% assign x = x | x : >= %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-comparison-015
+  template: "{% assign x = x | x : contains %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-eos-016
+  template: "{% assign x = x | x : %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-bare_bracket
+  template: "{% assign x = x | x : [0] %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-mut-filter_first_arg-lookup-trailing_dot
+  template: "{% assign x = x | x : x. %}"
+  error_path: filter_first_arg/lookup
+- id: assign-mut-filter_first_arg-lookup-dot_number
+  template: "{% assign x = x | x : x.123 %}"
+  error_path: filter_first_arg/lookup
+- id: assign-mut-filter_first_arg-lookup-dot_string
+  template: '{% assign x = x | x : x."y" %}'
+  error_path: filter_first_arg/lookup
+- id: assign-mut-filter_first_arg-lookup-unclosed_bracket
+  template: "{% assign x = x | x : x[0 %}"
+  error_path: filter_first_arg/lookup
+- id: assign-mut-filter_first_arg-lookup-bracket_wrong_content
+  template: "{% assign x = x | x : x[,] %}"
+  error_path: filter_first_arg/lookup
+- id: assign-mut-filter_first_arg-lookup-unclosed_range
+  template: "{% assign x = x | x : (1..5 %}"
+  error_path: filter_first_arg/lookup
+- id: assign-mut-filter_first_arg-lookup-range_bad_separator
+  template: "{% assign x = x | x : (1, 5) %}"
+  error_path: filter_first_arg/lookup
+- id: assign-mut-filter_first_arg-lookup-range_missing_end
+  template: "{% assign x = x | x : (1..) %}"
+  error_path: filter_first_arg/lookup
+- id: assign-mut-filter_first_arg-lexerr-at
+  template: "{% assign x = x | x : @ %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-hash
+  template: "{% assign x = x | x : # %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-dollar
+  template: "{% assign x = x | x : $ %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-caret
+  template: "{% assign x = x | x : ^ %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-ampersand
+  template: "{% assign x = x | x : & %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-asterisk
+  template: "{% assign x = x | x : * %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-tilde
+  template: "{% assign x = x | x : ~ %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-backtick
+  template: "{% assign x = x | x : ` %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-backslash
+  template: "{% assign x = x | x : \\ %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-semicolon
+  template: "{% assign x = x | x : ; %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-unclosed_double_quote
+  template: '{% assign x = x | x : "hello %}'
+  error_path: filter_first_arg/lexer
+- id: assign-mut-filter_first_arg-lexerr-unclosed_single_quote
+  template: "{% assign x = x | x : 'hello %}"
+  error_path: filter_first_arg/lexer
+- id: assign-mut-kwarg_colon-eos
+  template: "{% assign x = x | x : x , , x %}"
+  error_path: kwarg_colon
+- id: assign-mut-kwarg_colon-number
+  template: "{% assign x = x | x : x , , x 42 %}"
+  error_path: kwarg_colon
+- id: assign-mut-kwarg_value-pipe-000
+  template: "{% assign x = x | x : x , , x : | %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-comma-001
+  template: "{% assign x = x | x : x , , x : , %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-colon-002
+  template: "{% assign x = x | x : x , , x : : %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-close_square-003
+  template: "{% assign x = x | x : x , , x : ] %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-close_round-004
+  template: "{% assign x = x | x : x , , x : ) %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-question-005
+  template: "{% assign x = x | x : x , , x : ? %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-dash-006
+  template: "{% assign x = x | x : x , , x : - %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-dot-007
+  template: "{% assign x = x | x : x , , x : . %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-dotdot-008
+  template: "{% assign x = x | x : x , , x : .. %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-comparison-009
+  template: "{% assign x = x | x : x , , x : == %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-comparison-010
+  template: "{% assign x = x | x : x , , x : != %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-comparison-011
+  template: "{% assign x = x | x : x , , x : < %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-comparison-012
+  template: "{% assign x = x | x : x , , x : > %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-comparison-013
+  template: "{% assign x = x | x : x , , x : <= %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-comparison-014
+  template: "{% assign x = x | x : x , , x : >= %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-comparison-015
+  template: "{% assign x = x | x : x , , x : contains %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-eos-016
+  template: "{% assign x = x | x : x , , x : %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-bare_bracket
+  template: "{% assign x = x | x : x , , x : [0] %}"
+  error_path: kwarg_value/bad_start
+- id: assign-mut-kwarg_value-lookup-trailing_dot
+  template: "{% assign x = x | x : x , , x : x. %}"
+  error_path: kwarg_value/lookup
+- id: assign-mut-kwarg_value-lookup-dot_number
+  template: "{% assign x = x | x : x , , x : x.123 %}"
+  error_path: kwarg_value/lookup
+- id: assign-mut-kwarg_value-lookup-dot_string
+  template: '{% assign x = x | x : x , , x : x."y" %}'
+  error_path: kwarg_value/lookup
+- id: assign-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% assign x = x | x : x , , x : x[0 %}"
+  error_path: kwarg_value/lookup
+- id: assign-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% assign x = x | x : x , , x : x[,] %}"
+  error_path: kwarg_value/lookup
+- id: assign-mut-kwarg_value-lookup-unclosed_range
+  template: "{% assign x = x | x : x , , x : (1..5 %}"
+  error_path: kwarg_value/lookup
+- id: assign-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% assign x = x | x : x , , x : (1, 5) %}"
+  error_path: kwarg_value/lookup
+- id: assign-mut-kwarg_value-lookup-range_missing_end
+  template: "{% assign x = x | x : x , , x : (1..) %}"
+  error_path: kwarg_value/lookup
+- id: assign-mut-kwarg_value-lexerr-at
+  template: "{% assign x = x | x : x , , x : @ %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-hash
+  template: "{% assign x = x | x : x , , x : # %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-dollar
+  template: "{% assign x = x | x : x , , x : $ %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-caret
+  template: "{% assign x = x | x : x , , x : ^ %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-ampersand
+  template: "{% assign x = x | x : x , , x : & %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-asterisk
+  template: "{% assign x = x | x : x , , x : * %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-tilde
+  template: "{% assign x = x | x : x , , x : ~ %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-backtick
+  template: "{% assign x = x | x : x , , x : ` %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-backslash
+  template: "{% assign x = x | x : x , , x : \\ %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-semicolon
+  template: "{% assign x = x | x : x , , x : ; %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% assign x = x | x : x , , x : "hello %}'
+  error_path: kwarg_value/lexer
+- id: assign-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% assign x = x | x : x , , x : 'hello %}"
+  error_path: kwarg_value/lexer
+- id: assign-mut-filter_arg_value-pipe-000
+  template: "{% assign x = x | x : x , , | %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-comma-001
+  template: "{% assign x = x | x : x , , , %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-colon-002
+  template: "{% assign x = x | x : x , , : %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-close_square-003
+  template: "{% assign x = x | x : x , , ] %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-close_round-004
+  template: "{% assign x = x | x : x , , ) %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-question-005
+  template: "{% assign x = x | x : x , , ? %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-dash-006
+  template: "{% assign x = x | x : x , , - %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-dot-007
+  template: "{% assign x = x | x : x , , . %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-dotdot-008
+  template: "{% assign x = x | x : x , , .. %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-comparison-009
+  template: "{% assign x = x | x : x , , == %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-comparison-010
+  template: "{% assign x = x | x : x , , != %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-comparison-011
+  template: "{% assign x = x | x : x , , < %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-comparison-012
+  template: "{% assign x = x | x : x , , > %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-comparison-013
+  template: "{% assign x = x | x : x , , <= %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-comparison-014
+  template: "{% assign x = x | x : x , , >= %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-comparison-015
+  template: "{% assign x = x | x : x , , contains %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-eos-016
+  template: "{% assign x = x | x : x , , %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-bare_bracket
+  template: "{% assign x = x | x : x , , [0] %}"
+  error_path: filter_arg_value/bad_start
+- id: assign-mut-filter_arg_value-lookup-trailing_dot
+  template: "{% assign x = x | x : x , , x. %}"
+  error_path: filter_arg_value/lookup
+- id: assign-mut-filter_arg_value-lookup-dot_number
+  template: "{% assign x = x | x : x , , x.123 %}"
+  error_path: filter_arg_value/lookup
+- id: assign-mut-filter_arg_value-lookup-dot_string
+  template: '{% assign x = x | x : x , , x."y" %}'
+  error_path: filter_arg_value/lookup
+- id: assign-mut-filter_arg_value-lookup-unclosed_bracket
+  template: "{% assign x = x | x : x , , x[0 %}"
+  error_path: filter_arg_value/lookup
+- id: assign-mut-filter_arg_value-lookup-bracket_wrong_content
+  template: "{% assign x = x | x : x , , x[,] %}"
+  error_path: filter_arg_value/lookup
+- id: assign-mut-filter_arg_value-lookup-unclosed_range
+  template: "{% assign x = x | x : x , , (1..5 %}"
+  error_path: filter_arg_value/lookup
+- id: assign-mut-filter_arg_value-lookup-range_bad_separator
+  template: "{% assign x = x | x : x , , (1, 5) %}"
+  error_path: filter_arg_value/lookup
+- id: assign-mut-filter_arg_value-lookup-range_missing_end
+  template: "{% assign x = x | x : x , , (1..) %}"
+  error_path: filter_arg_value/lookup
+- id: assign-mut-filter_arg_value-lexerr-at
+  template: "{% assign x = x | x : x , , @ %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-hash
+  template: "{% assign x = x | x : x , , # %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-dollar
+  template: "{% assign x = x | x : x , , $ %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-caret
+  template: "{% assign x = x | x : x , , ^ %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-ampersand
+  template: "{% assign x = x | x : x , , & %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-asterisk
+  template: "{% assign x = x | x : x , , * %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-tilde
+  template: "{% assign x = x | x : x , , ~ %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-backtick
+  template: "{% assign x = x | x : x , , ` %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-backslash
+  template: "{% assign x = x | x : x , , \\ %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-semicolon
+  template: "{% assign x = x | x : x , , ; %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-unclosed_double_quote
+  template: '{% assign x = x | x : x , , "hello %}'
+  error_path: filter_arg_value/lexer
+- id: assign-mut-filter_arg_value-lexerr-unclosed_single_quote
+  template: "{% assign x = x | x : x , , 'hello %}"
+  error_path: filter_arg_value/lexer
+- id: assign-mut-end-trail-id
+  template: "{% assign x = x extra %}"
+  error_path: end
+- id: assign-mut-end-trail-number
+  template: "{% assign x = x 42 %}"
+  error_path: end
+- id: assign-mut-end-trail-string
+  template: "{% assign x = x 'hi' %}"
+  error_path: end
+- id: assign-mut-end-trail-pipe
+  template: "{% assign x = x | %}"
+  error_path: end
+- id: assign-mut-end-trail-colon
+  template: "{% assign x = x : %}"
+  error_path: end
+- id: assign-mut-end-trail-comma
+  template: "{% assign x = x , %}"
+  error_path: end
+- id: assign-mut-end-trail-open_square
+  template: "{% assign x = x [ %}"
+  error_path: end
+- id: assign-mut-end-trail-close_square
+  template: "{% assign x = x ] %}"
+  error_path: end
+- id: assign-mut-end-trail-open_round
+  template: "{% assign x = x ( %}"
+  error_path: end
+- id: assign-mut-end-trail-close_round
+  template: "{% assign x = x ) %}"
+  error_path: end
+- id: assign-mut-end-trail-question
+  template: "{% assign x = x ? %}"
+  error_path: end
+- id: assign-mut-end-trail-dot
+  template: "{% assign x = x . %}"
+  error_path: end
+- id: assign-mut-end-trail-comparison
+  template: "{% assign x = x == %}"
+  error_path: end
+- id: assign-mut-end-trail-dash
+  template: "{% assign x = x - %}"
+  error_path: end
+- id: assign-mut-valid-000
+  template: "{% assign x = x %}"
+  error_path: valid
+- id: assign-mut-valid-001
+  template: "{% assign x = 42 %}"
+  error_path: valid
+- id: assign-mut-valid-002
+  template: "{% assign x = 3.14 %}"
+  error_path: valid
+- id: assign-mut-valid-003
+  template: "{% assign x = -5 %}"
+  error_path: valid
+- id: assign-mut-valid-004
+  template: "{% assign x = 'hello' %}"
+  error_path: valid
+- id: assign-mut-valid-005
+  template: "{% assign x = true %}"
+  error_path: valid
+- id: assign-mut-valid-006
+  template: "{% assign x = false %}"
+  error_path: valid
+- id: assign-mut-valid-007
+  template: "{% assign x = nil %}"
+  error_path: valid
+- id: assign-mut-valid-008
+  template: "{% assign x = blank %}"
+  error_path: valid
+- id: assign-mut-valid-009
+  template: "{% assign x = empty %}"
+  error_path: valid
+- id: assign-mut-valid-010
+  template: "{% assign x = product.title %}"
+  error_path: valid
+- id: assign-mut-valid-011
+  template: "{% assign x = products[0] %}"
+  error_path: valid
+- id: assign-mut-valid-012
+  template: "{% assign x = a.b.c %}"
+  error_path: valid
+- id: assign-mut-valid-013
+  template: "{% assign x = a[0].b %}"
+  error_path: valid
+- id: assign-mut-valid-014
+  template: "{% assign x = (1..5) %}"
+  error_path: valid
+- id: assign-mut-valid-filter-015
+  template: "{% assign x = x | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-016
+  template: "{% assign x = x | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-017
+  template: '{% assign x = x | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-018
+  template: "{% assign x = x | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-019
+  template: '{% assign x = x | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-020
+  template: "{% assign x = 42 | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-021
+  template: "{% assign x = 42 | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-022
+  template: '{% assign x = 42 | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-023
+  template: "{% assign x = 42 | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-024
+  template: '{% assign x = 42 | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-025
+  template: "{% assign x = 3.14 | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-026
+  template: "{% assign x = 3.14 | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-027
+  template: '{% assign x = 3.14 | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-028
+  template: "{% assign x = 3.14 | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-029
+  template: '{% assign x = 3.14 | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-030
+  template: "{% assign x = -5 | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-031
+  template: "{% assign x = -5 | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-032
+  template: '{% assign x = -5 | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-033
+  template: "{% assign x = -5 | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-034
+  template: '{% assign x = -5 | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-035
+  template: "{% assign x = 'hello' | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-036
+  template: "{% assign x = 'hello' | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-037
+  template: '{% assign x = ''hello'' | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-038
+  template: "{% assign x = 'hello' | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-039
+  template: '{% assign x = ''hello'' | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-040
+  template: "{% assign x = true | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-041
+  template: "{% assign x = true | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-042
+  template: '{% assign x = true | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-043
+  template: "{% assign x = true | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-044
+  template: '{% assign x = true | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-045
+  template: "{% assign x = false | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-046
+  template: "{% assign x = false | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-047
+  template: '{% assign x = false | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-048
+  template: "{% assign x = false | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-049
+  template: '{% assign x = false | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-050
+  template: "{% assign x = nil | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-051
+  template: "{% assign x = nil | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-052
+  template: '{% assign x = nil | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-053
+  template: "{% assign x = nil | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-054
+  template: '{% assign x = nil | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-055
+  template: "{% assign x = blank | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-056
+  template: "{% assign x = blank | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-057
+  template: '{% assign x = blank | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-058
+  template: "{% assign x = blank | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-059
+  template: '{% assign x = blank | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-060
+  template: "{% assign x = empty | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-061
+  template: "{% assign x = empty | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-062
+  template: '{% assign x = empty | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-063
+  template: "{% assign x = empty | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-064
+  template: '{% assign x = empty | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-065
+  template: "{% assign x = product.title | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-066
+  template: "{% assign x = product.title | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-067
+  template: '{% assign x = product.title | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-068
+  template: "{% assign x = product.title | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-069
+  template: '{% assign x = product.title | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-070
+  template: "{% assign x = products[0] | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-071
+  template: "{% assign x = products[0] | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-072
+  template: '{% assign x = products[0] | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-073
+  template: "{% assign x = products[0] | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-074
+  template: '{% assign x = products[0] | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-075
+  template: "{% assign x = a.b.c | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-076
+  template: "{% assign x = a.b.c | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-077
+  template: '{% assign x = a.b.c | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-078
+  template: "{% assign x = a.b.c | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-079
+  template: '{% assign x = a.b.c | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-080
+  template: "{% assign x = a[0].b | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-081
+  template: "{% assign x = a[0].b | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-082
+  template: '{% assign x = a[0].b | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-083
+  template: "{% assign x = a[0].b | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-084
+  template: '{% assign x = a[0].b | default: "bar" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-085
+  template: "{% assign x = (1..5) | upcase %}"
+  error_path: valid
+- id: assign-mut-valid-filter-086
+  template: "{% assign x = (1..5) | slice: 1 %}"
+  error_path: valid
+- id: assign-mut-valid-filter-087
+  template: '{% assign x = (1..5) | replace: "a", "b" %}'
+  error_path: valid
+- id: assign-mut-valid-filter-088
+  template: "{% assign x = (1..5) | upcase | strip %}"
+  error_path: valid
+- id: assign-mut-valid-filter-089
+  template: '{% assign x = (1..5) | default: "bar" %}'
+  error_path: valid
+- id: assign-themecheck-dotted-lhs
+  template: "{% assign x.y = 1 %}"
+  error_path: lhs_eos
+- id: assign-themecheck-filter-separator-trailing-comma-before-pipe
+  template: "{% assign out = n | filter: 1, 2, 3, | filter2: k1: 1, k2: 2 %}"
+  error_path: valid
+- id: assign-themecheck-filter-separator-mixed-positional-keyword
+  template: "{% assign out = n | filter: 'a', 'b', key1: 1, key2: 2, 'c' %}"
+  error_path: valid
+- id: assign-themecheck-filter-separator-leading-comma
+  template: "{% assign out = n | f1: , %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-themecheck-filter-separator-leading-comma-before-pipe
+  template: "{% assign out = n | f1: , | f2 %}"
+  error_path: filter_first_arg/bad_start
+- id: assign-themecheck-filter-separator-missing-comma
+  template: "{% assign out = n | filter: 1 2, 3 %}"
+  error_path: end
+- id: assign-themecheck-filter-separator-adjacent-colon
+  template: "{% assign out = n | pluralize: 'comment': 'comments' %}"
+  error_path: end

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/block.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/block.yml
@@ -1,0 +1,56 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: block-valid-basic
+  template: "{% block 'hero' %}{% endblock %}"
+  error_path: valid
+- id: block-valid-all-properties
+  template: "{% block '_hero', title: product.title, block.content: section.settings.body, block.settings.heading: 'Welcome', block.name: 'Hero' %}{% endblock %}"
+  error_path: valid
+- id: block-mut-file_name-eos
+  template: "{% block  %}{% endblock %}"
+  error_path: file_name
+- id: block-mut-file_name-id
+  template: "{% block x %}{% endblock %}"
+  error_path: file_name
+- id: block-mut-file_name-invalid
+  template: "{% block '../hero' %}{% endblock %}"
+  error_path: file_name_validation
+- id: block-themecheck-dotted-file-name
+  template: "{% block 'block.evil' %}{% endblock %}"
+  error_path: file_name_validation
+- id: block-mut-end-trail-id
+  template: "{% block 'hero' extra %}{% endblock %}"
+  error_path: end
+- id: block-mut-attr_colon-eos
+  template: "{% block 'hero', title %}{% endblock %}"
+  error_path: attr_colon
+- id: block-mut-attr_value-pipe-000
+  template: "{% block 'hero', title: | %}{% endblock %}"
+  error_path: attr_value/bad_start
+- id: block-mut-block_property-invalid
+  template: "{% block 'hero', block %}{% endblock %}"
+  error_path: block_property
+- id: block-mut-block_content_property-invalid
+  template: "{% block 'hero', block.content.title: body %}{% endblock %}"
+  error_path: block_content_property
+- id: block-mut-block_content_value-pipe-000
+  template: "{% block 'hero', block.content: | %}{% endblock %}"
+  error_path: block_content_value/bad_start
+- id: block-mut-block_settings_property-invalid
+  template: "{% block 'hero', block.settings %}{% endblock %}"
+  error_path: block_settings_property
+- id: block-mut-block_setting_property-invalid
+  template: "{% block 'hero', block.settings.heading.label: 'Heading' %}{% endblock %}"
+  error_path: block_setting_property
+- id: block-mut-block_setting_value-pipe-000
+  template: "{% block 'hero', block.settings.heading: | %}{% endblock %}"
+  error_path: block_setting_value/bad_start
+- id: block-mut-block_name-string
+  template: "{% block 'hero', block.name: x %}{% endblock %}"
+  error_path: block_name
+- id: block-mut-block_unknown_property-invalid
+  template: "{% block 'hero', block.unknown: 'x' %}{% endblock %}"
+  error_path: block_unknown_property
+- id: block-mut-unclosed
+  template: "{% block 'hero' %}"
+  error_path: unclosed

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/break.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/break.yml
@@ -1,0 +1,66 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: break-100
+  template: "{% for i in (1..5) %}{% break %}{% endfor %}"
+  error_path: 0
+- id: break-101
+  template: "{% for i in (1..5) %}{%- break %}{% endfor %}"
+  error_path: 0
+- id: break-102
+  template: "{% for i in (1..5) %}{% break -%}{% endfor %}"
+  error_path: 0
+- id: break-103
+  template: "{% for i in (1..5) %}{%- break -%}{% endfor %}"
+  error_path: 0
+- id: break-104
+  template: "{% for i in (1..5) %}{%  break   %}{% endfor %}"
+  error_path: 0
+- id: break-200
+  template: "{% for i in (1..5) %}{% break x %}{% endfor %}"
+  error_path: 0
+- id: break-201
+  template: "{% for i in (1..5) %}{% break 123 %}{% endfor %}"
+  error_path: 0
+- id: break-202
+  template: "{% for i in (1..5) %}{% break 'hello' %}{% endfor %}"
+  error_path: 0
+- id: break-203
+  template: "{% for i in (1..5) %}{% break i | plus: 1 %}{% endfor %}"
+  error_path: 0
+- id: break-204
+  template: "{% for i in (1..5) %}{% break == %}{% endfor %}"
+  error_path: 0
+- id: break-205
+  template: "{% for i in (1..5) %}{% break x y z %}{% endfor %}"
+  error_path: 0
+- id: break-206
+  template: "{% for i in (1..5) %}{% break @ # $ %}{% endfor %}"
+  error_path: 0
+- id: break-207
+  template: "{% for i in (1..5) %}{% break | %}{% endfor %}"
+  error_path: 0
+- id: break-208
+  template: "{% for i in (1..5) %}{% break . %}{% endfor %}"
+  error_path: 0
+- id: break-209
+  template: "{% for i in (1..5) %}{% break [0] %}{% endfor %}"
+  error_path: 0
+- id: break-300
+  template: "{% break %}"
+  error_path: 0
+- id: break-301
+  template: "{% break garbage %}"
+  error_path: 0
+- id: break-302
+  template: "{% for i in (1..5) %}{% break %}{% break %}{% endfor %}"
+  error_path: 0
+- id: break-303
+  template: "{% for i in (1..3) %}{% for j in (1..3) %}{% break %}{% endfor %}{% endfor
+    %}"
+  error_path: 0
+- id: break-304
+  template: "{{ shop.name }}"
+  error_path: 0
+- id: break-themecheck-tablerow-interrupt
+  template: "{% tablerow product in collection.products cols: 2 %}{% break %}{% endtablerow %}"
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/capture.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/capture.yml
@@ -1,0 +1,89 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: capture-mut-variable_name-eos
+  template: "{% capture  %}{% endcapture %}"
+  error_path: variable_name
+- id: capture-mut-variable_name-number
+  template: "{% capture 42 %}{% endcapture %}"
+  error_path: variable_name
+- id: capture-themecheck-bare-bracket
+  template: "{% capture [0] %}{% endcapture %}"
+  error_path: variable_name
+- id: capture-mut-variable_name-lexerr-at
+  template: "{% capture @ %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-hash
+  template: "{% capture # %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-dollar
+  template: "{% capture $ %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-caret
+  template: "{% capture ^ %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-ampersand
+  template: "{% capture & %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-asterisk
+  template: "{% capture * %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-tilde
+  template: "{% capture ~ %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-backtick
+  template: "{% capture ` %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-backslash
+  template: "{% capture \\ %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-semicolon
+  template: "{% capture ; %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% capture "hello %}{% endcapture %}'
+  error_path: variable_name/lexer
+- id: capture-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% capture 'hello %}{% endcapture %}"
+  error_path: variable_name/lexer
+- id: capture-mut-end-trail-id
+  template: "{% capture x extra %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-number
+  template: "{% capture x 42 %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-string
+  template: "{% capture x 'hi' %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-pipe
+  template: "{% capture x | %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-colon
+  template: "{% capture x : %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-comma
+  template: "{% capture x , %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-open_square
+  template: "{% capture x [ %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-close_square
+  template: "{% capture x ] %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-open_round
+  template: "{% capture x ( %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-close_round
+  template: "{% capture x ) %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-question
+  template: "{% capture x ? %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-dot
+  template: "{% capture x . %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-comparison
+  template: "{% capture x == %}{% endcapture %}"
+  error_path: end
+- id: capture-mut-end-trail-dash
+  template: "{% capture x - %}{% endcapture %}"
+  error_path: end

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/case.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/case.yml
@@ -1,0 +1,527 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: case-mut-case_expression-pipe-000
+  template: "{% case | %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-comma-001
+  template: "{% case , %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-colon-002
+  template: "{% case : %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-close_square-003
+  template: "{% case ] %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-close_round-004
+  template: "{% case ) %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-question-005
+  template: "{% case ? %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-dash-006
+  template: "{% case - %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-dot-007
+  template: "{% case . %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-dotdot-008
+  template: "{% case .. %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-comparison-009
+  template: "{% case == %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-comparison-010
+  template: "{% case != %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-comparison-011
+  template: "{% case < %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-comparison-012
+  template: "{% case > %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-comparison-013
+  template: "{% case <= %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-comparison-014
+  template: "{% case >= %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-comparison-015
+  template: "{% case contains %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-eos-016
+  template: "{% case  %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-bare_bracket
+  template: "{% case [0] %}{% endcase %}"
+  error_path: case_expression/bad_start
+- id: case-mut-case_expression-lookup-trailing_dot
+  template: "{% case x. %}{% endcase %}"
+  error_path: case_expression/lookup
+- id: case-mut-case_expression-lookup-dot_number
+  template: "{% case x.123 %}{% endcase %}"
+  error_path: case_expression/lookup
+- id: case-mut-case_expression-lookup-dot_string
+  template: '{% case x."y" %}{% endcase %}'
+  error_path: case_expression/lookup
+- id: case-mut-case_expression-lookup-unclosed_bracket
+  template: "{% case x[0 %}{% endcase %}"
+  error_path: case_expression/lookup
+- id: case-mut-case_expression-lookup-bracket_wrong_content
+  template: "{% case x[,] %}{% endcase %}"
+  error_path: case_expression/lookup
+- id: case-mut-case_expression-lookup-unclosed_range
+  template: "{% case (1..5 %}{% endcase %}"
+  error_path: case_expression/lookup
+- id: case-mut-case_expression-lookup-range_bad_separator
+  template: "{% case (1, 5) %}{% endcase %}"
+  error_path: case_expression/lookup
+- id: case-mut-case_expression-lookup-range_missing_end
+  template: "{% case (1..) %}{% endcase %}"
+  error_path: case_expression/lookup
+- id: case-mut-case_expression-lexerr-at
+  template: "{% case @ %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-hash
+  template: "{% case # %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-dollar
+  template: "{% case $ %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-caret
+  template: "{% case ^ %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-ampersand
+  template: "{% case & %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-asterisk
+  template: "{% case * %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-tilde
+  template: "{% case ~ %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-backtick
+  template: "{% case ` %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-backslash
+  template: "{% case \\ %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-semicolon
+  template: "{% case ; %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-unclosed_double_quote
+  template: '{% case "hello %}{% endcase %}'
+  error_path: case_expression/lexer
+- id: case-mut-case_expression-lexerr-unclosed_single_quote
+  template: "{% case 'hello %}{% endcase %}"
+  error_path: case_expression/lexer
+- id: case-mut-end-trail-id
+  template: "{% case x extra %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-number
+  template: "{% case x 42 %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-string
+  template: "{% case x 'hi' %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-pipe
+  template: "{% case x | %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-colon
+  template: "{% case x : %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-comma
+  template: "{% case x , %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-open_square
+  template: "{% case x [ %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-close_square
+  template: "{% case x ] %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-open_round
+  template: "{% case x ( %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-close_round
+  template: "{% case x ) %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-question
+  template: "{% case x ? %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-dot
+  template: "{% case x . %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-comparison
+  template: "{% case x == %}{% endcase %}"
+  error_path: end
+- id: case-mut-end-trail-dash
+  template: "{% case x - %}{% endcase %}"
+  error_path: end
+- id: case-mut-valid-000
+  template: "{% case x %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-001
+  template: "{% case 42 %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-002
+  template: "{% case 3.14 %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-003
+  template: "{% case -5 %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-004
+  template: "{% case 'hello' %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-005
+  template: "{% case true %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-006
+  template: "{% case false %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-007
+  template: "{% case nil %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-008
+  template: "{% case blank %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-009
+  template: "{% case empty %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-010
+  template: "{% case product.title %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-011
+  template: "{% case products[0] %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-012
+  template: "{% case a.b.c %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-013
+  template: "{% case a[0].b %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-014
+  template: "{% case (1..5) %}{% endcase %}"
+  error_path: valid
+- id: case-mut-when_value-pipe-000
+  template: "{% case x %}{% when | %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-comma-001
+  template: "{% case x %}{% when , %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-colon-002
+  template: "{% case x %}{% when : %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-close_square-003
+  template: "{% case x %}{% when ] %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-close_round-004
+  template: "{% case x %}{% when ) %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-question-005
+  template: "{% case x %}{% when ? %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-dash-006
+  template: "{% case x %}{% when - %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-dot-007
+  template: "{% case x %}{% when . %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-dotdot-008
+  template: "{% case x %}{% when .. %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-comparison-009
+  template: "{% case x %}{% when == %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-comparison-010
+  template: "{% case x %}{% when != %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-comparison-011
+  template: "{% case x %}{% when < %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-comparison-012
+  template: "{% case x %}{% when > %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-comparison-013
+  template: "{% case x %}{% when <= %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-comparison-014
+  template: "{% case x %}{% when >= %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-comparison-015
+  template: "{% case x %}{% when contains %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-eos-016
+  template: "{% case x %}{% when  %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-bare_bracket
+  template: "{% case x %}{% when [0] %}{% endcase %}"
+  error_path: when_value/bad_start
+- id: case-mut-when_value-lookup-trailing_dot
+  template: "{% case x %}{% when x. %}{% endcase %}"
+  error_path: when_value/lookup
+- id: case-mut-when_value-lookup-dot_number
+  template: "{% case x %}{% when x.123 %}{% endcase %}"
+  error_path: when_value/lookup
+- id: case-mut-when_value-lookup-dot_string
+  template: '{% case x %}{% when x."y" %}{% endcase %}'
+  error_path: when_value/lookup
+- id: case-mut-when_value-lookup-unclosed_bracket
+  template: "{% case x %}{% when x[0 %}{% endcase %}"
+  error_path: when_value/lookup
+- id: case-mut-when_value-lookup-bracket_wrong_content
+  template: "{% case x %}{% when x[,] %}{% endcase %}"
+  error_path: when_value/lookup
+- id: case-mut-when_value-lookup-unclosed_range
+  template: "{% case x %}{% when (1..5 %}{% endcase %}"
+  error_path: when_value/lookup
+- id: case-mut-when_value-lookup-range_bad_separator
+  template: "{% case x %}{% when (1, 5) %}{% endcase %}"
+  error_path: when_value/lookup
+- id: case-mut-when_value-lookup-range_missing_end
+  template: "{% case x %}{% when (1..) %}{% endcase %}"
+  error_path: when_value/lookup
+- id: case-mut-when_value-lexerr-at
+  template: "{% case x %}{% when @ %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-hash
+  template: "{% case x %}{% when # %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-dollar
+  template: "{% case x %}{% when $ %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-caret
+  template: "{% case x %}{% when ^ %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-ampersand
+  template: "{% case x %}{% when & %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-asterisk
+  template: "{% case x %}{% when * %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-tilde
+  template: "{% case x %}{% when ~ %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-backtick
+  template: "{% case x %}{% when ` %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-backslash
+  template: "{% case x %}{% when \\ %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-semicolon
+  template: "{% case x %}{% when ; %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-unclosed_double_quote
+  template: '{% case x %}{% when "hello %}{% endcase %}'
+  error_path: when_value/lexer
+- id: case-mut-when_value-lexerr-unclosed_single_quote
+  template: "{% case x %}{% when 'hello %}{% endcase %}"
+  error_path: when_value/lexer
+- id: case-mut-when_next_value-pipe-000
+  template: "{% case x %}{% when x , , | %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-comma-001
+  template: "{% case x %}{% when x , , , %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-colon-002
+  template: "{% case x %}{% when x , , : %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-close_square-003
+  template: "{% case x %}{% when x , , ] %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-close_round-004
+  template: "{% case x %}{% when x , , ) %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-question-005
+  template: "{% case x %}{% when x , , ? %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-dash-006
+  template: "{% case x %}{% when x , , - %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-dot-007
+  template: "{% case x %}{% when x , , . %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-dotdot-008
+  template: "{% case x %}{% when x , , .. %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-comparison-009
+  template: "{% case x %}{% when x , , == %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-comparison-010
+  template: "{% case x %}{% when x , , != %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-comparison-011
+  template: "{% case x %}{% when x , , < %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-comparison-012
+  template: "{% case x %}{% when x , , > %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-comparison-013
+  template: "{% case x %}{% when x , , <= %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-comparison-014
+  template: "{% case x %}{% when x , , >= %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-comparison-015
+  template: "{% case x %}{% when x , , contains %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-eos-016
+  template: "{% case x %}{% when x , , %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-bare_bracket
+  template: "{% case x %}{% when x , , [0] %}{% endcase %}"
+  error_path: when_next_value/bad_start
+- id: case-mut-when_next_value-lookup-trailing_dot
+  template: "{% case x %}{% when x , , x. %}{% endcase %}"
+  error_path: when_next_value/lookup
+- id: case-mut-when_next_value-lookup-dot_number
+  template: "{% case x %}{% when x , , x.123 %}{% endcase %}"
+  error_path: when_next_value/lookup
+- id: case-mut-when_next_value-lookup-dot_string
+  template: '{% case x %}{% when x , , x."y" %}{% endcase %}'
+  error_path: when_next_value/lookup
+- id: case-mut-when_next_value-lookup-unclosed_bracket
+  template: "{% case x %}{% when x , , x[0 %}{% endcase %}"
+  error_path: when_next_value/lookup
+- id: case-mut-when_next_value-lookup-bracket_wrong_content
+  template: "{% case x %}{% when x , , x[,] %}{% endcase %}"
+  error_path: when_next_value/lookup
+- id: case-mut-when_next_value-lookup-unclosed_range
+  template: "{% case x %}{% when x , , (1..5 %}{% endcase %}"
+  error_path: when_next_value/lookup
+- id: case-mut-when_next_value-lookup-range_bad_separator
+  template: "{% case x %}{% when x , , (1, 5) %}{% endcase %}"
+  error_path: when_next_value/lookup
+- id: case-mut-when_next_value-lookup-range_missing_end
+  template: "{% case x %}{% when x , , (1..) %}{% endcase %}"
+  error_path: when_next_value/lookup
+- id: case-mut-when_next_value-lexerr-at
+  template: "{% case x %}{% when x , , @ %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-hash
+  template: "{% case x %}{% when x , , # %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-dollar
+  template: "{% case x %}{% when x , , $ %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-caret
+  template: "{% case x %}{% when x , , ^ %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-ampersand
+  template: "{% case x %}{% when x , , & %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-asterisk
+  template: "{% case x %}{% when x , , * %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-tilde
+  template: "{% case x %}{% when x , , ~ %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-backtick
+  template: "{% case x %}{% when x , , ` %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-backslash
+  template: "{% case x %}{% when x , , \\ %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-semicolon
+  template: "{% case x %}{% when x , , ; %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-unclosed_double_quote
+  template: '{% case x %}{% when x , , "hello %}{% endcase %}'
+  error_path: when_next_value/lexer
+- id: case-mut-when_next_value-lexerr-unclosed_single_quote
+  template: "{% case x %}{% when x , , 'hello %}{% endcase %}"
+  error_path: when_next_value/lexer
+- id: case-mut-when_end-trail-id
+  template: "{% case x %}{% when x extra %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-number
+  template: "{% case x %}{% when x 42 %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-string
+  template: "{% case x %}{% when x 'hi' %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-pipe
+  template: "{% case x %}{% when x | %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-colon
+  template: "{% case x %}{% when x : %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-comma
+  template: "{% case x %}{% when x , %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-open_square
+  template: "{% case x %}{% when x [ %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-close_square
+  template: "{% case x %}{% when x ] %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-open_round
+  template: "{% case x %}{% when x ( %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-close_round
+  template: "{% case x %}{% when x ) %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-question
+  template: "{% case x %}{% when x ? %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-dot
+  template: "{% case x %}{% when x . %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-comparison
+  template: "{% case x %}{% when x == %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-when_end-trail-dash
+  template: "{% case x %}{% when x - %}{% endcase %}"
+  error_path: when_end
+- id: case-mut-valid-000-2
+  template: "{% case x %}{% when x %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-001-2
+  template: "{% case x %}{% when 42 %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-002-2
+  template: "{% case x %}{% when 3.14 %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-003-2
+  template: "{% case x %}{% when -5 %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-004-2
+  template: "{% case x %}{% when 'hello' %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-005-2
+  template: "{% case x %}{% when true %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-006-2
+  template: "{% case x %}{% when false %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-007-2
+  template: "{% case x %}{% when nil %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-008-2
+  template: "{% case x %}{% when blank %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-009-2
+  template: "{% case x %}{% when empty %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-010-2
+  template: "{% case x %}{% when product.title %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-011-2
+  template: "{% case x %}{% when products[0] %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-012-2
+  template: "{% case x %}{% when a.b.c %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-013-2
+  template: "{% case x %}{% when a[0].b %}{% endcase %}"
+  error_path: valid
+- id: case-mut-valid-014-2
+  template: "{% case x %}{% when (1..5) %}{% endcase %}"
+  error_path: valid
+- id: case-branch-else-valid
+  template: "{% case x %}{% when x %}{% else %}{% endcase %}"
+  error_path: valid
+- id: case-themecheck-unclosed-when-string
+  template: "{% case product.type %}{% when ' shirt %}Shirt{% endcase %}"
+  error_path: when_value/lexer
+- id: case-parity-elsif-in-case
+  template: "{% case x %}{% elsif %}{% endcase %}"
+  error_path: unknown_tag

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/comment.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/comment.yml
@@ -1,0 +1,109 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: comment-001
+  template: "{% comment %}hello"
+  error_path: 1
+- id: comment-002
+  template: "{% comment foo %}hello"
+  error_path: 1
+- id: comment-003
+  template: "{% comment %}{% comment %}inner{% endcomment %}"
+  error_path: 1
+- id: comment-004
+  template: "{% comment %}"
+  error_path: 1
+- id: comment-005
+  template: "{%- comment -%}hello"
+  error_path: 1
+- id: comment-020
+  template: "{% comment %}{% raw %}hello{% endcomment %}"
+  error_path: 2
+- id: comment-021
+  template: "{% comment %}{% raw %}hello"
+  error_path: 2
+- id: comment-100
+  template: "{% comment %}hello{% endcomment %}"
+  error_path: 0
+- id: comment-101
+  template: "{% comment %}{% endcomment %}"
+  error_path: 0
+- id: comment-102
+  template: "{% comment foo %}hello{% endcomment %}"
+  error_path: 0
+- id: comment-103
+  template: "{% comment foo bar baz %}hello{% endcomment %}"
+  error_path: 0
+- id: comment-104
+  template: "{% comment | filter %}hello{% endcomment %}"
+  error_path: 0
+- id: comment-105
+  template: "{% comment 123 %}hello{% endcomment %}"
+  error_path: 0
+- id: comment-106
+  template: '{% comment "hello" %}hello{% endcomment %}'
+  error_path: 0
+- id: comment-107
+  template: "{% comment = + - %}hello{% endcomment %}"
+  error_path: 0
+- id: comment-108
+  template: "{%- comment %}hello{% endcomment %}"
+  error_path: 0
+- id: comment-109
+  template: "{% comment -%}hello{% endcomment %}"
+  error_path: 0
+- id: comment-110
+  template: "{%- comment -%}hello{%- endcomment -%}"
+  error_path: 0
+- id: comment-111
+  template: "{%  comment   %}hello{% endcomment %}"
+  error_path: 0
+- id: comment-120
+  template: "{% comment %}{% if %}{% endcomment %}"
+  error_path: 0
+- id: comment-121
+  template: "{% comment %}this is {{{ not }}} valid{{ liquid{% endcomment %}"
+  error_path: 0
+- id: comment-themecheck-invalid-liquid-body
+  template: "{% comment %}this is {% if liquid{% endcomment %}"
+  error_path: 1
+- id: comment-122
+  template: '{% comment %}<div class="test">{% endcomment %}'
+  error_path: 0
+- id: comment-123
+  template: "{% comment %}{% for x in y %}{% endcomment %}"
+  error_path: 0
+- id: comment-130
+  template: "{% comment %}{% comment %}inner{% endcomment %}{% endcomment %}"
+  error_path: 0
+- id: comment-131
+  template: "{% comment %}{% comment %}{% comment %}deep{% endcomment %}{% endcomment
+    %}{% endcomment %}"
+  error_path: 0
+- id: comment-140
+  template: "{% comment %}{% raw %}hello{% endraw %}{% endcomment %}"
+  error_path: 0
+- id: comment-141
+  template: "{% comment %}{% raw %}{% endcomment %}{% endraw %}{% endcomment %}"
+  error_path: 0
+- id: comment-themecheck-whitespace-control-raw-body
+  template: "{%- comment -%}{%- raw -%}{%- endcomment -%}{%- endraw -%}{%- endcomment
+    -%}"
+  error_path: 0
+- id: comment-150
+  template: "{% comment %}a{% endcomment %}{% comment %}b{% endcomment %}"
+  error_path: 0
+- id: comment-151
+  template: hello{% comment %}world{% endcomment %}goodbye
+  error_path: 0
+- id: comment-160
+  template: "{{ shop.name }}"
+  error_path: 0
+- id: comment-161
+  template: "{% endcomment %}"
+  error_path: 0
+- id: comment-themecheck-nested-followed-by-independent
+  template: "{% comment %}{% comment %}inner{% endcomment %}{% comment %}second{% endcomment %}"
+  error_path: 1
+- id: comment-themecheck-raw-followed-by-independent
+  template: "{% comment %}{% raw %}inner{% endcomment %}{% raw %}second{% endraw %}"
+  error_path: 2

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/content_for.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/content_for.yml
@@ -1,0 +1,117 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: content_for-100
+  template: "{% content_for 'blocks' %}"
+  error_path:
+- id: content_for-101
+  template: "{% content_for 'block', type: 'text', id: 'my-id' %}"
+  error_path:
+- id: content_for-102
+  template: "{% content_for 'blocks', closest.product: product %}"
+  error_path:
+- id: content_for-103
+  template: "{% content_for 'block', type: 'slide', id: 'slide-1', closest.product:
+    product %}"
+  error_path:
+- id: content_for-104
+  template: "{% content_for 'block', type: 'text', id: 'my-id', color: 'red' %}"
+  error_path:
+- id: content_for-200
+  template: "{% content_for blocks %}"
+  error_path: 1
+- id: content_for-201
+  template: "{% content_for ??? %}"
+  error_path: 1
+- id: content_for-202
+  template: "{% content_for 'block', closest.: 'text' %}"
+  error_path: 1
+- id: content_for-203
+  template: '{% content_for ''blocks'', type "text" %}'
+  error_path: 1
+- id: content_for-204
+  template: "{% content_for 'blocks', closest.product: | %}"
+  error_path: 1
+- id: content_for-205
+  template: "{% content_for 'blocks' trailing garbage %}"
+  error_path: 1
+- id: content_for-206
+  template: "{% content_for 'block', type: foo=>bar %}"
+  error_path: 1
+- id: content_for-300
+  template: "{% content_for %}"
+  error_path: 1
+- id: content_for-301
+  template: "{% content_for 'invalid' %}"
+  error_path: 1
+- id: content_for-302
+  template: "{% content_for 'block', type: 'text', id: 'x', color: 'red', color: 'blue'
+    %}"
+  error_path: 1
+- id: content_for-303
+  template: "{% content_for 'block', type: 'text', id: 'x', schema: 'y' %}"
+  error_path: 1
+- id: content_for-304
+  template: "{% content_for 'block', type: myvar, id: 'x' %}"
+  error_path: 1
+- id: content_for-305
+  template: "{% content_for 'block', type: '', id: 'x' %}"
+  error_path: 1
+- id: content_for-306
+  template: "{% content_for 'block', id: '', type: 'x' %}"
+  error_path: 1
+- id: content_for-307
+  template: "{% content_for 'blocks', closest.product: 'invalid' %}"
+  error_path: 1
+- id: content_for-308
+  template: "{% content_for 'blocks', extra: 'val' %}"
+  error_path: 1
+- id: content_for-309
+  template: "{% content_for 'blocks', closest.product: p, closest.article: a %}"
+  error_path: 1
+- id: content_for-310
+  template: "{% content_for 'blocks', closest.settings: true %}"
+  error_path: 1
+- id: content_for-311
+  template: "{% content_for 'block', type: 'text' %}"
+  error_path: 1
+- id: content_for-312
+  template: "{% content_for 'block', id: 'x' %}"
+  error_path: 1
+- id: content_for-313
+  template: "{% content_for 'block', type: 'text', id: 'x', block: 'y' %}"
+  error_path: 1
+- id: content_for-314
+  template: "{% content_for 'block', type: 'text', id: 'x', closest.product: p, color:
+    'red' %}"
+  error_path: 1
+- id: content_for-themecheck-block-quoted-closest
+  template: "{% content_for 'block', type: 'text', id: 'x', closest.product: 'invalid'
+    %}"
+  error_path: 1
+- id: content_for-themecheck-block-closest-product
+  template: "{% content_for 'block', type: 'text', id: 'x', closest.product: product
+    %}"
+  error_path: 0
+- id: content_for-themecheck-block-closest-metaobject-custom-type
+  template: "{% content_for 'block', type: 'text', id: 'x', closest.metaobject.custom-type:
+    custom_type %}"
+  error_path: 0
+- id: content_for-themecheck-block-multiple-closest
+  template: "{% content_for 'block', type: 'text', id: 'x', closest.product: product,
+    closest.article: article %}"
+  error_path: 1
+- id: content_for-themecheck-block-closest-settings
+  template: "{% content_for 'block', type: 'text', id: 'x', closest.settings: settings
+    %}"
+  error_path: 1
+- id: content_for-themecheck-block-closest-product-property
+  template: "{% content_for 'block', type: 'text', id: 'x', closest.product.s: product
+    %}"
+  error_path: 1
+- id: content_for-themecheck-block-closest-metaobject-without-type
+  template: "{% content_for 'block', type: 'text', id: 'x', closest.metaobject:
+    metaobject %}"
+  error_path: 1
+- id: content_for-llm-900
+  template: "{% content_for block %}"
+  error_path: CONTENT_FOR-PARSE-CON-string

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/continue.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/continue.yml
@@ -1,0 +1,66 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: continue-100
+  template: "{% for i in (1..5) %}{% continue %}{% endfor %}"
+  error_path: 0
+- id: continue-101
+  template: "{% for i in (1..5) %}{%- continue %}{% endfor %}"
+  error_path: 0
+- id: continue-102
+  template: "{% for i in (1..5) %}{% continue -%}{% endfor %}"
+  error_path: 0
+- id: continue-103
+  template: "{% for i in (1..5) %}{%- continue -%}{% endfor %}"
+  error_path: 0
+- id: continue-104
+  template: "{% for i in (1..5) %}{%  continue   %}{% endfor %}"
+  error_path: 0
+- id: continue-200
+  template: "{% for i in (1..5) %}{% continue x %}{% endfor %}"
+  error_path: 0
+- id: continue-201
+  template: "{% for i in (1..5) %}{% continue 123 %}{% endfor %}"
+  error_path: 0
+- id: continue-202
+  template: "{% for i in (1..5) %}{% continue 'hello' %}{% endfor %}"
+  error_path: 0
+- id: continue-203
+  template: "{% for i in (1..5) %}{% continue i | plus: 1 %}{% endfor %}"
+  error_path: 0
+- id: continue-204
+  template: "{% for i in (1..5) %}{% continue == %}{% endfor %}"
+  error_path: 0
+- id: continue-205
+  template: "{% for i in (1..5) %}{% continue x y z %}{% endfor %}"
+  error_path: 0
+- id: continue-206
+  template: "{% for i in (1..5) %}{% continue @ # $ %}{% endfor %}"
+  error_path: 0
+- id: continue-207
+  template: "{% for i in (1..5) %}{% continue | %}{% endfor %}"
+  error_path: 0
+- id: continue-208
+  template: "{% for i in (1..5) %}{% continue . %}{% endfor %}"
+  error_path: 0
+- id: continue-209
+  template: "{% for i in (1..5) %}{% continue [0] %}{% endfor %}"
+  error_path: 0
+- id: continue-300
+  template: "{% continue %}"
+  error_path: 0
+- id: continue-301
+  template: "{% continue garbage %}"
+  error_path: 0
+- id: continue-302
+  template: "{% for i in (1..5) %}{% continue %}{% continue %}{% endfor %}"
+  error_path: 0
+- id: continue-303
+  template: "{% for i in (1..3) %}{% for j in (1..3) %}{% continue %}{% endfor %}{%
+    endfor %}"
+  error_path: 0
+- id: continue-304
+  template: "{{ shop.name }}"
+  error_path: 0
+- id: continue-themecheck-liquid-statement
+  template: "{% liquid\n  for i in (1..5)\n    continue\n  endfor\n%}"
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/cycle.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/cycle.yml
@@ -1,0 +1,551 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: cycle-mut-pregate-000
+  template: "{% cycle  %}"
+  error_path: pre_gate
+- id: cycle-mut-first_value-pipe-000
+  template: "{% cycle | %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-comma-001
+  template: "{% cycle , %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-colon-002
+  template: "{% cycle : %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-close_square-003
+  template: "{% cycle ] %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-close_round-004
+  template: "{% cycle ) %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-question-005
+  template: "{% cycle ? %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-dash-006
+  template: "{% cycle - %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-dot-007
+  template: "{% cycle . %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-dotdot-008
+  template: "{% cycle .. %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-comparison-009
+  template: "{% cycle == %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-comparison-010
+  template: "{% cycle != %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-comparison-011
+  template: "{% cycle < %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-comparison-012
+  template: "{% cycle > %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-comparison-013
+  template: "{% cycle <= %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-comparison-014
+  template: "{% cycle >= %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-comparison-015
+  template: "{% cycle contains %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-eos-016
+  template: "{% cycle  %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-bare_bracket
+  template: "{% cycle [0] %}"
+  error_path: first_value/bad_start
+- id: cycle-mut-first_value-lookup-trailing_dot
+  template: "{% cycle x. %}"
+  error_path: first_value/lookup
+- id: cycle-mut-first_value-lookup-dot_number
+  template: "{% cycle x.123 %}"
+  error_path: first_value/lookup
+- id: cycle-mut-first_value-lookup-dot_string
+  template: '{% cycle x."y" %}'
+  error_path: first_value/lookup
+- id: cycle-mut-first_value-lookup-unclosed_bracket
+  template: "{% cycle x[0 %}"
+  error_path: first_value/lookup
+- id: cycle-mut-first_value-lookup-bracket_wrong_content
+  template: "{% cycle x[,] %}"
+  error_path: first_value/lookup
+- id: cycle-mut-first_value-lookup-unclosed_range
+  template: "{% cycle (1..5 %}"
+  error_path: first_value/lookup
+- id: cycle-mut-first_value-lookup-range_bad_separator
+  template: "{% cycle (1, 5) %}"
+  error_path: first_value/lookup
+- id: cycle-mut-first_value-lookup-range_missing_end
+  template: "{% cycle (1..) %}"
+  error_path: first_value/lookup
+- id: cycle-mut-first_value-lexerr-at
+  template: "{% cycle @ %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-hash
+  template: "{% cycle # %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-dollar
+  template: "{% cycle $ %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-caret
+  template: "{% cycle ^ %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-ampersand
+  template: "{% cycle & %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-asterisk
+  template: "{% cycle * %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-tilde
+  template: "{% cycle ~ %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-backtick
+  template: "{% cycle ` %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-backslash
+  template: "{% cycle \\ %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-semicolon
+  template: "{% cycle ; %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-unclosed_double_quote
+  template: '{% cycle "hello %}'
+  error_path: first_value/lexer
+- id: cycle-mut-first_value-lexerr-unclosed_single_quote
+  template: "{% cycle 'hello %}"
+  error_path: first_value/lexer
+- id: cycle-mut-first_cycle_value-pipe-000
+  template: "{% cycle x : | %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-comma-001
+  template: "{% cycle x : , %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-colon-002
+  template: "{% cycle x : : %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-close_square-003
+  template: "{% cycle x : ] %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-close_round-004
+  template: "{% cycle x : ) %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-question-005
+  template: "{% cycle x : ? %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-dash-006
+  template: "{% cycle x : - %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-dot-007
+  template: "{% cycle x : . %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-dotdot-008
+  template: "{% cycle x : .. %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-comparison-009
+  template: "{% cycle x : == %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-comparison-010
+  template: "{% cycle x : != %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-comparison-011
+  template: "{% cycle x : < %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-comparison-012
+  template: "{% cycle x : > %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-comparison-013
+  template: "{% cycle x : <= %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-comparison-014
+  template: "{% cycle x : >= %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-comparison-015
+  template: "{% cycle x : contains %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-eos-016
+  template: "{% cycle x : %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-bare_bracket
+  template: "{% cycle x : [0] %}"
+  error_path: first_cycle_value/bad_start
+- id: cycle-mut-first_cycle_value-lookup-trailing_dot
+  template: "{% cycle x : x. %}"
+  error_path: first_cycle_value/lookup
+- id: cycle-mut-first_cycle_value-lookup-dot_number
+  template: "{% cycle x : x.123 %}"
+  error_path: first_cycle_value/lookup
+- id: cycle-mut-first_cycle_value-lookup-dot_string
+  template: '{% cycle x : x."y" %}'
+  error_path: first_cycle_value/lookup
+- id: cycle-mut-first_cycle_value-lookup-unclosed_bracket
+  template: "{% cycle x : x[0 %}"
+  error_path: first_cycle_value/lookup
+- id: cycle-mut-first_cycle_value-lookup-bracket_wrong_content
+  template: "{% cycle x : x[,] %}"
+  error_path: first_cycle_value/lookup
+- id: cycle-mut-first_cycle_value-lookup-unclosed_range
+  template: "{% cycle x : (1..5 %}"
+  error_path: first_cycle_value/lookup
+- id: cycle-mut-first_cycle_value-lookup-range_bad_separator
+  template: "{% cycle x : (1, 5) %}"
+  error_path: first_cycle_value/lookup
+- id: cycle-mut-first_cycle_value-lookup-range_missing_end
+  template: "{% cycle x : (1..) %}"
+  error_path: first_cycle_value/lookup
+- id: cycle-mut-first_cycle_value-lexerr-at
+  template: "{% cycle x : @ %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-hash
+  template: "{% cycle x : # %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-dollar
+  template: "{% cycle x : $ %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-caret
+  template: "{% cycle x : ^ %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-ampersand
+  template: "{% cycle x : & %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-asterisk
+  template: "{% cycle x : * %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-tilde
+  template: "{% cycle x : ~ %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-backtick
+  template: "{% cycle x : ` %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-backslash
+  template: "{% cycle x : \\ %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-semicolon
+  template: "{% cycle x : ; %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-unclosed_double_quote
+  template: '{% cycle x : "hello %}'
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-first_cycle_value-lexerr-unclosed_single_quote
+  template: "{% cycle x : 'hello %}"
+  error_path: first_cycle_value/lexer
+- id: cycle-mut-cycle_value-pipe-000
+  template: "{% cycle x : x , , | %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comma-001
+  template: "{% cycle x : x , , , %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-colon-002
+  template: "{% cycle x : x , , : %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-close_square-003
+  template: "{% cycle x : x , , ] %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-close_round-004
+  template: "{% cycle x : x , , ) %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-question-005
+  template: "{% cycle x : x , , ? %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-dash-006
+  template: "{% cycle x : x , , - %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-dot-007
+  template: "{% cycle x : x , , . %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-dotdot-008
+  template: "{% cycle x : x , , .. %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-009
+  template: "{% cycle x : x , , == %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-010
+  template: "{% cycle x : x , , != %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-011
+  template: "{% cycle x : x , , < %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-012
+  template: "{% cycle x : x , , > %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-013
+  template: "{% cycle x : x , , <= %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-014
+  template: "{% cycle x : x , , >= %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-015
+  template: "{% cycle x : x , , contains %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-eos-016
+  template: "{% cycle x : x , , %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-bare_bracket
+  template: "{% cycle x : x , , [0] %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-lookup-trailing_dot
+  template: "{% cycle x : x , , x. %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-dot_number
+  template: "{% cycle x : x , , x.123 %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-dot_string
+  template: '{% cycle x : x , , x."y" %}'
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-unclosed_bracket
+  template: "{% cycle x : x , , x[0 %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-bracket_wrong_content
+  template: "{% cycle x : x , , x[,] %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-unclosed_range
+  template: "{% cycle x : x , , (1..5 %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-range_bad_separator
+  template: "{% cycle x : x , , (1, 5) %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-range_missing_end
+  template: "{% cycle x : x , , (1..) %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lexerr-at
+  template: "{% cycle x : x , , @ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-hash
+  template: "{% cycle x : x , , # %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-dollar
+  template: "{% cycle x : x , , $ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-caret
+  template: "{% cycle x : x , , ^ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-ampersand
+  template: "{% cycle x : x , , & %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-asterisk
+  template: "{% cycle x : x , , * %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-tilde
+  template: "{% cycle x : x , , ~ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-backtick
+  template: "{% cycle x : x , , ` %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-backslash
+  template: "{% cycle x : x , , \\ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-semicolon
+  template: "{% cycle x : x , , ; %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-unclosed_double_quote
+  template: '{% cycle x : x , , "hello %}'
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-unclosed_single_quote
+  template: "{% cycle x : x , , 'hello %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-pipe-000-2
+  template: "{% cycle x , , | %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comma-001-2
+  template: "{% cycle x , , , %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-colon-002-2
+  template: "{% cycle x , , : %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-close_square-003-2
+  template: "{% cycle x , , ] %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-close_round-004-2
+  template: "{% cycle x , , ) %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-question-005-2
+  template: "{% cycle x , , ? %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-dash-006-2
+  template: "{% cycle x , , - %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-dot-007-2
+  template: "{% cycle x , , . %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-dotdot-008-2
+  template: "{% cycle x , , .. %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-009-2
+  template: "{% cycle x , , == %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-010-2
+  template: "{% cycle x , , != %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-011-2
+  template: "{% cycle x , , < %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-012-2
+  template: "{% cycle x , , > %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-013-2
+  template: "{% cycle x , , <= %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-014-2
+  template: "{% cycle x , , >= %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-comparison-015-2
+  template: "{% cycle x , , contains %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-eos-016-2
+  template: "{% cycle x , , %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-bare_bracket-2
+  template: "{% cycle x , , [0] %}"
+  error_path: cycle_value/bad_start
+- id: cycle-mut-cycle_value-lookup-trailing_dot-2
+  template: "{% cycle x , , x. %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-dot_number-2
+  template: "{% cycle x , , x.123 %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-dot_string-2
+  template: '{% cycle x , , x."y" %}'
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-unclosed_bracket-2
+  template: "{% cycle x , , x[0 %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-bracket_wrong_content-2
+  template: "{% cycle x , , x[,] %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-unclosed_range-2
+  template: "{% cycle x , , (1..5 %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-range_bad_separator-2
+  template: "{% cycle x , , (1, 5) %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lookup-range_missing_end-2
+  template: "{% cycle x , , (1..) %}"
+  error_path: cycle_value/lookup
+- id: cycle-mut-cycle_value-lexerr-at-2
+  template: "{% cycle x , , @ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-hash-2
+  template: "{% cycle x , , # %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-dollar-2
+  template: "{% cycle x , , $ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-caret-2
+  template: "{% cycle x , , ^ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-ampersand-2
+  template: "{% cycle x , , & %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-asterisk-2
+  template: "{% cycle x , , * %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-tilde-2
+  template: "{% cycle x , , ~ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-backtick-2
+  template: "{% cycle x , , ` %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-backslash-2
+  template: "{% cycle x , , \\ %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-semicolon-2
+  template: "{% cycle x , , ; %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-unclosed_double_quote-2
+  template: '{% cycle x , , "hello %}'
+  error_path: cycle_value/lexer
+- id: cycle-mut-cycle_value-lexerr-unclosed_single_quote-2
+  template: "{% cycle x , , 'hello %}"
+  error_path: cycle_value/lexer
+- id: cycle-mut-end-trail-id
+  template: "{% cycle x extra %}"
+  error_path: end
+- id: cycle-mut-end-trail-number
+  template: "{% cycle x 42 %}"
+  error_path: end
+- id: cycle-mut-end-trail-string
+  template: "{% cycle x 'hi' %}"
+  error_path: end
+- id: cycle-mut-end-trail-pipe
+  template: "{% cycle x | %}"
+  error_path: end
+- id: cycle-mut-end-trail-colon
+  template: "{% cycle x : %}"
+  error_path: end
+- id: cycle-mut-end-trail-comma
+  template: "{% cycle x , %}"
+  error_path: end
+- id: cycle-mut-end-trail-open_square
+  template: "{% cycle x [ %}"
+  error_path: end
+- id: cycle-mut-end-trail-close_square
+  template: "{% cycle x ] %}"
+  error_path: end
+- id: cycle-mut-end-trail-open_round
+  template: "{% cycle x ( %}"
+  error_path: end
+- id: cycle-mut-end-trail-close_round
+  template: "{% cycle x ) %}"
+  error_path: end
+- id: cycle-mut-end-trail-question
+  template: "{% cycle x ? %}"
+  error_path: end
+- id: cycle-mut-end-trail-dot
+  template: "{% cycle x . %}"
+  error_path: end
+- id: cycle-mut-end-trail-comparison
+  template: "{% cycle x == %}"
+  error_path: end
+- id: cycle-mut-end-trail-dash
+  template: "{% cycle x - %}"
+  error_path: end
+- id: cycle-mut-valid-000
+  template: "{% cycle x %}"
+  error_path: valid
+- id: cycle-mut-valid-001
+  template: "{% cycle 42 %}"
+  error_path: valid
+- id: cycle-mut-valid-002
+  template: "{% cycle 3.14 %}"
+  error_path: valid
+- id: cycle-mut-valid-003
+  template: "{% cycle -5 %}"
+  error_path: valid
+- id: cycle-mut-valid-004
+  template: "{% cycle 'hello' %}"
+  error_path: valid
+- id: cycle-mut-valid-005
+  template: "{% cycle true %}"
+  error_path: valid
+- id: cycle-mut-valid-006
+  template: "{% cycle false %}"
+  error_path: valid
+- id: cycle-mut-valid-007
+  template: "{% cycle nil %}"
+  error_path: valid
+- id: cycle-mut-valid-008
+  template: "{% cycle blank %}"
+  error_path: valid
+- id: cycle-mut-valid-009
+  template: "{% cycle empty %}"
+  error_path: valid
+- id: cycle-mut-valid-010
+  template: "{% cycle product.title %}"
+  error_path: valid
+- id: cycle-mut-valid-011
+  template: "{% cycle products[0] %}"
+  error_path: valid
+- id: cycle-mut-valid-012
+  template: "{% cycle a.b.c %}"
+  error_path: valid
+- id: cycle-mut-valid-013
+  template: "{% cycle a[0].b %}"
+  error_path: valid
+- id: cycle-mut-valid-014
+  template: "{% cycle (1..5) %}"
+  error_path: valid
+- id: cycle-themecheck-trailing-comma-lookup
+  template: "{% cycle product.handle, %}"
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/decrement.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/decrement.yml
@@ -1,0 +1,89 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: decrement-mut-variable_name-eos
+  template: "{% decrement  %}"
+  error_path: variable_name
+- id: decrement-mut-variable_name-number
+  template: "{% decrement 42 %}"
+  error_path: variable_name
+- id: decrement-themecheck-bare-bracket
+  template: "{% decrement [0] %}"
+  error_path: variable_name
+- id: decrement-mut-variable_name-lexerr-at
+  template: "{% decrement @ %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-hash
+  template: "{% decrement # %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-dollar
+  template: "{% decrement $ %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-caret
+  template: "{% decrement ^ %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-ampersand
+  template: "{% decrement & %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-asterisk
+  template: "{% decrement * %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-tilde
+  template: "{% decrement ~ %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-backtick
+  template: "{% decrement ` %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-backslash
+  template: "{% decrement \\ %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-semicolon
+  template: "{% decrement ; %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% decrement "hello %}'
+  error_path: variable_name/lexer
+- id: decrement-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% decrement 'hello %}"
+  error_path: variable_name/lexer
+- id: decrement-mut-end-trail-id
+  template: "{% decrement x extra %}"
+  error_path: end
+- id: decrement-mut-end-trail-number
+  template: "{% decrement x 42 %}"
+  error_path: end
+- id: decrement-mut-end-trail-string
+  template: "{% decrement x 'hi' %}"
+  error_path: end
+- id: decrement-mut-end-trail-pipe
+  template: "{% decrement x | %}"
+  error_path: end
+- id: decrement-mut-end-trail-colon
+  template: "{% decrement x : %}"
+  error_path: end
+- id: decrement-mut-end-trail-comma
+  template: "{% decrement x , %}"
+  error_path: end
+- id: decrement-mut-end-trail-open_square
+  template: "{% decrement x [ %}"
+  error_path: end
+- id: decrement-mut-end-trail-close_square
+  template: "{% decrement x ] %}"
+  error_path: end
+- id: decrement-mut-end-trail-open_round
+  template: "{% decrement x ( %}"
+  error_path: end
+- id: decrement-mut-end-trail-close_round
+  template: "{% decrement x ) %}"
+  error_path: end
+- id: decrement-mut-end-trail-question
+  template: "{% decrement x ? %}"
+  error_path: end
+- id: decrement-mut-end-trail-dot
+  template: "{% decrement x . %}"
+  error_path: end
+- id: decrement-mut-end-trail-comparison
+  template: "{% decrement x == %}"
+  error_path: end
+- id: decrement-mut-end-trail-dash
+  template: "{% decrement x - %}"
+  error_path: end

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/doc.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/doc.yml
@@ -1,0 +1,153 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: doc-001
+  template: "{% doc foo %}{% enddoc %}"
+  error_path: 1
+- id: doc-002
+  template: "{% doc foo bar %}{% enddoc %}"
+  error_path: 1
+- id: doc-003
+  template: "{% doc 123 %}{% enddoc %}"
+  error_path: 1
+- id: doc-004
+  template: "{% doc 'hello' %}{% enddoc %}"
+  error_path: 1
+- id: doc-005
+  template: "{% doc == %}{% enddoc %}"
+  error_path: 1
+- id: doc-006
+  template: "{% doc | %}{% enddoc %}"
+  error_path: 1
+- id: doc-007
+  template: "{% doc @#$ %}{% enddoc %}"
+  error_path: 1
+- id: doc-008
+  template: "{%- doc foo -%}{%- enddoc -%}"
+  error_path: 1
+- id: doc-009
+  template: "{% doc foo %}{% enddoc %}"
+  error_path: 1
+- id: doc-010
+  template: "{% doc foo %}some content"
+  error_path: 1
+- id: doc-020
+  template: "{% doc %}{% doc %}{% enddoc %}{% enddoc %}"
+  error_path: 2
+- id: doc-021
+  template: "{% doc %}hello{% doc %}world{% enddoc %}{% enddoc %}"
+  error_path: 2
+- id: doc-022
+  template: "{% doc %}{% doc %}{% enddoc %}"
+  error_path: 2
+- id: doc-023
+  template: "{% doc %}{% doc %}content"
+  error_path: 2
+- id: doc-024
+  template: "{% doc %}{% doc %}{% doc %}{% enddoc %}"
+  error_path: 2
+- id: doc-025
+  template: "{% doc %}{% doc foo %}{% enddoc %}"
+  error_path: 2
+- id: doc-040
+  template: "{% doc %}"
+  error_path: 3
+- id: doc-041
+  template: "{% doc %}some content here"
+  error_path: 3
+- id: doc-042
+  template: "{% doc %}{% if true %}hello{% endif %}"
+  error_path: 3
+- id: doc-043
+  template: "{%- doc -%}content"
+  error_path: 3
+- id: doc-044
+  template: |-
+    hello
+
+    {% doc %}content
+  error_path: 3
+- id: doc-045
+  template: "{% doc %}a{% enddoc %}{% doc %}b"
+  error_path: 3
+- id: doc-100
+  template: "{% doc %}{% enddoc %}"
+  error_path: 0
+- id: doc-101
+  template: "{% doc %}This is documentation{% enddoc %}"
+  error_path: 0
+- id: doc-102
+  template: |-
+    {% doc %}
+    line1
+    line2
+    {% enddoc %}
+  error_path: 0
+- id: doc-103
+  template: "{% doc %}{% if true %}hello{% endif %}{% enddoc %}"
+  error_path: 0
+- id: doc-104
+  template: '{% doc %}<div class="test">content</div>{% enddoc %}'
+  error_path: 0
+- id: doc-105
+  template: "{% doc %}{{ variable }} and {{{ triple }}}{% enddoc %}"
+  error_path: 0
+- id: doc-106
+  template: "{%- doc %}content{% enddoc %}"
+  error_path: 0
+- id: doc-107
+  template: "{% doc -%}content{% enddoc %}"
+  error_path: 0
+- id: doc-108
+  template: "{%- doc -%}content{%- enddoc -%}"
+  error_path: 0
+- id: doc-109
+  template: "{%  doc   %}content{%  enddoc   %}"
+  error_path: 0
+- id: doc-110
+  template: hello{% doc %}world{% enddoc %}goodbye
+  error_path: 0
+- id: doc-111
+  template: "{% doc %}a{% enddoc %}{% doc %}b{% enddoc %}"
+  error_path: 0
+- id: doc-112
+  template: |-
+    line1
+    {% doc %}
+    content
+    {% enddoc %}
+    line5
+  error_path: 0
+- id: doc-113
+  template: "{{ shop.name }}"
+  error_path: 0
+- id: doc-114
+  template: "{% enddoc %}"
+  error_path: 0
+- id: doc-115
+  template: "{% doc %}content{% enddoc foo %}"
+  error_path: 0
+- id: doc-themecheck-marked-closer-then-unclosed
+  template: "{% doc %}content{% enddoc foo %}{% doc %}"
+  error_path: 3
+- id: doc-themecheck-marked-closer-then-balanced
+  template: "{% doc %}content{% enddoc foo %}{% doc %}later{% enddoc %}"
+  error_path: 0
+- id: doc-themecheck-whitespace-control-marked-closer
+  template: "{% doc %}content{%- enddoc foo -%}"
+  error_path: 0
+- id: doc-116
+  template: "{% doc %}   {% enddoc %}"
+  error_path: 0
+- id: doc-117
+  template: |-
+    {% doc %}
+
+
+    {% enddoc %}
+  error_path: 0
+- id: doc-themecheck-similar-prefix
+  template: "{% doc %}{% docx %}{% enddoc %}"
+  error_path: 0
+- id: doc-themecheck-nested-whitespace-control
+  template: "{% doc %}{%- doc -%}{% enddoc %}"
+  error_path: 2

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/echo.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/echo.yml
@@ -1,0 +1,614 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: echo-mut-value-pipe-000
+  template: "{% echo | %}"
+  error_path: value/bad_start
+- id: echo-mut-value-comma-001
+  template: "{% echo , %}"
+  error_path: value/bad_start
+- id: echo-mut-value-colon-002
+  template: "{% echo : %}"
+  error_path: value/bad_start
+- id: echo-mut-value-close_square-003
+  template: "{% echo ] %}"
+  error_path: value/bad_start
+- id: echo-mut-value-close_round-004
+  template: "{% echo ) %}"
+  error_path: value/bad_start
+- id: echo-mut-value-question-005
+  template: "{% echo ? %}"
+  error_path: value/bad_start
+- id: echo-mut-value-dash-006
+  template: "{% echo - %}"
+  error_path: value/bad_start
+- id: echo-mut-value-dot-007
+  template: "{% echo . %}"
+  error_path: value/bad_start
+- id: echo-mut-value-dotdot-008
+  template: "{% echo .. %}"
+  error_path: value/bad_start
+- id: echo-mut-value-comparison-009
+  template: "{% echo == %}"
+  error_path: value/bad_start
+- id: echo-mut-value-comparison-010
+  template: "{% echo != %}"
+  error_path: value/bad_start
+- id: echo-mut-value-comparison-011
+  template: "{% echo < %}"
+  error_path: value/bad_start
+- id: echo-mut-value-comparison-012
+  template: "{% echo > %}"
+  error_path: value/bad_start
+- id: echo-mut-value-comparison-013
+  template: "{% echo <= %}"
+  error_path: value/bad_start
+- id: echo-mut-value-comparison-014
+  template: "{% echo >= %}"
+  error_path: value/bad_start
+- id: echo-mut-value-comparison-015
+  template: "{% echo contains %}"
+  error_path: value/bad_start
+- id: echo-mut-value-eos-016
+  template: "{% echo  %}"
+  error_path: value/bad_start
+- id: echo-mut-value-bare_bracket
+  template: "{% echo [0] %}"
+  error_path: value/bad_start
+- id: echo-mut-value-lookup-trailing_dot
+  template: "{% echo x. %}"
+  error_path: value/lookup
+- id: echo-mut-value-lookup-dot_number
+  template: "{% echo x.123 %}"
+  error_path: value/lookup
+- id: echo-mut-value-lookup-dot_string
+  template: '{% echo x."y" %}'
+  error_path: value/lookup
+- id: echo-mut-value-lookup-unclosed_bracket
+  template: "{% echo x[0 %}"
+  error_path: value/lookup
+- id: echo-mut-value-lookup-bracket_wrong_content
+  template: "{% echo x[,] %}"
+  error_path: value/lookup
+- id: echo-mut-value-lookup-unclosed_range
+  template: "{% echo (1..5 %}"
+  error_path: value/lookup
+- id: echo-mut-value-lookup-range_bad_separator
+  template: "{% echo (1, 5) %}"
+  error_path: value/lookup
+- id: echo-mut-value-lookup-range_missing_end
+  template: "{% echo (1..) %}"
+  error_path: value/lookup
+- id: echo-mut-value-lexerr-at
+  template: "{% echo @ %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-hash
+  template: "{% echo # %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-dollar
+  template: "{% echo $ %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-caret
+  template: "{% echo ^ %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-ampersand
+  template: "{% echo & %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-asterisk
+  template: "{% echo * %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-tilde
+  template: "{% echo ~ %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-backtick
+  template: "{% echo ` %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-backslash
+  template: "{% echo \\ %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-semicolon
+  template: "{% echo ; %}"
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-unclosed_double_quote
+  template: '{% echo "hello %}'
+  error_path: value/lexer
+- id: echo-mut-value-lexerr-unclosed_single_quote
+  template: "{% echo 'hello %}"
+  error_path: value/lexer
+- id: echo-mut-filter_name-eos
+  template: "{% echo x | %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-number
+  template: "{% echo x | 42 %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-at
+  template: "{% echo x | @ %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-hash
+  template: "{% echo x | # %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-dollar
+  template: "{% echo x | $ %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-caret
+  template: "{% echo x | ^ %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-ampersand
+  template: "{% echo x | & %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-asterisk
+  template: "{% echo x | * %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-tilde
+  template: "{% echo x | ~ %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-backtick
+  template: "{% echo x | ` %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-backslash
+  template: "{% echo x | \\ %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-semicolon
+  template: "{% echo x | ; %}"
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-unclosed_double_quote
+  template: '{% echo x | "hello %}'
+  error_path: filter_name
+- id: echo-mut-filter_name-lexerr-unclosed_single_quote
+  template: "{% echo x | 'hello %}"
+  error_path: filter_name
+- id: echo-mut-filter_first_arg-pipe-000
+  template: "{% echo x | x : | %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-comma-001
+  template: "{% echo x | x : , %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-colon-002
+  template: "{% echo x | x : : %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-close_square-003
+  template: "{% echo x | x : ] %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-close_round-004
+  template: "{% echo x | x : ) %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-question-005
+  template: "{% echo x | x : ? %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-dash-006
+  template: "{% echo x | x : - %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-dot-007
+  template: "{% echo x | x : . %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-dotdot-008
+  template: "{% echo x | x : .. %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-comparison-009
+  template: "{% echo x | x : == %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-comparison-010
+  template: "{% echo x | x : != %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-comparison-011
+  template: "{% echo x | x : < %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-comparison-012
+  template: "{% echo x | x : > %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-comparison-013
+  template: "{% echo x | x : <= %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-comparison-014
+  template: "{% echo x | x : >= %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-comparison-015
+  template: "{% echo x | x : contains %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-eos-016
+  template: "{% echo x | x : %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-bare_bracket
+  template: "{% echo x | x : [0] %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-mut-filter_first_arg-lookup-trailing_dot
+  template: "{% echo x | x : x. %}"
+  error_path: filter_first_arg/lookup
+- id: echo-mut-filter_first_arg-lookup-dot_number
+  template: "{% echo x | x : x.123 %}"
+  error_path: filter_first_arg/lookup
+- id: echo-mut-filter_first_arg-lookup-dot_string
+  template: '{% echo x | x : x."y" %}'
+  error_path: filter_first_arg/lookup
+- id: echo-mut-filter_first_arg-lookup-unclosed_bracket
+  template: "{% echo x | x : x[0 %}"
+  error_path: filter_first_arg/lookup
+- id: echo-mut-filter_first_arg-lookup-bracket_wrong_content
+  template: "{% echo x | x : x[,] %}"
+  error_path: filter_first_arg/lookup
+- id: echo-mut-filter_first_arg-lookup-unclosed_range
+  template: "{% echo x | x : (1..5 %}"
+  error_path: filter_first_arg/lookup
+- id: echo-mut-filter_first_arg-lookup-range_bad_separator
+  template: "{% echo x | x : (1, 5) %}"
+  error_path: filter_first_arg/lookup
+- id: echo-mut-filter_first_arg-lookup-range_missing_end
+  template: "{% echo x | x : (1..) %}"
+  error_path: filter_first_arg/lookup
+- id: echo-mut-filter_first_arg-lexerr-at
+  template: "{% echo x | x : @ %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-hash
+  template: "{% echo x | x : # %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-dollar
+  template: "{% echo x | x : $ %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-caret
+  template: "{% echo x | x : ^ %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-ampersand
+  template: "{% echo x | x : & %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-asterisk
+  template: "{% echo x | x : * %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-tilde
+  template: "{% echo x | x : ~ %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-backtick
+  template: "{% echo x | x : ` %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-backslash
+  template: "{% echo x | x : \\ %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-semicolon
+  template: "{% echo x | x : ; %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-unclosed_double_quote
+  template: '{% echo x | x : "hello %}'
+  error_path: filter_first_arg/lexer
+- id: echo-mut-filter_first_arg-lexerr-unclosed_single_quote
+  template: "{% echo x | x : 'hello %}"
+  error_path: filter_first_arg/lexer
+- id: echo-mut-kwarg_colon-eos
+  template: "{% echo x | x : x , , x %}"
+  error_path: kwarg_colon
+- id: echo-mut-kwarg_colon-number
+  template: "{% echo x | x : x , , x 42 %}"
+  error_path: kwarg_colon
+- id: echo-mut-kwarg_value-pipe-000
+  template: "{% echo x | x : x , , x : | %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-comma-001
+  template: "{% echo x | x : x , , x : , %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-colon-002
+  template: "{% echo x | x : x , , x : : %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-close_square-003
+  template: "{% echo x | x : x , , x : ] %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-close_round-004
+  template: "{% echo x | x : x , , x : ) %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-question-005
+  template: "{% echo x | x : x , , x : ? %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-dash-006
+  template: "{% echo x | x : x , , x : - %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-dot-007
+  template: "{% echo x | x : x , , x : . %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-dotdot-008
+  template: "{% echo x | x : x , , x : .. %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-comparison-009
+  template: "{% echo x | x : x , , x : == %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-comparison-010
+  template: "{% echo x | x : x , , x : != %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-comparison-011
+  template: "{% echo x | x : x , , x : < %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-comparison-012
+  template: "{% echo x | x : x , , x : > %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-comparison-013
+  template: "{% echo x | x : x , , x : <= %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-comparison-014
+  template: "{% echo x | x : x , , x : >= %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-comparison-015
+  template: "{% echo x | x : x , , x : contains %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-eos-016
+  template: "{% echo x | x : x , , x : %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-bare_bracket
+  template: "{% echo x | x : x , , x : [0] %}"
+  error_path: kwarg_value/bad_start
+- id: echo-mut-kwarg_value-lookup-trailing_dot
+  template: "{% echo x | x : x , , x : x. %}"
+  error_path: kwarg_value/lookup
+- id: echo-mut-kwarg_value-lookup-dot_number
+  template: "{% echo x | x : x , , x : x.123 %}"
+  error_path: kwarg_value/lookup
+- id: echo-mut-kwarg_value-lookup-dot_string
+  template: '{% echo x | x : x , , x : x."y" %}'
+  error_path: kwarg_value/lookup
+- id: echo-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% echo x | x : x , , x : x[0 %}"
+  error_path: kwarg_value/lookup
+- id: echo-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% echo x | x : x , , x : x[,] %}"
+  error_path: kwarg_value/lookup
+- id: echo-mut-kwarg_value-lookup-unclosed_range
+  template: "{% echo x | x : x , , x : (1..5 %}"
+  error_path: kwarg_value/lookup
+- id: echo-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% echo x | x : x , , x : (1, 5) %}"
+  error_path: kwarg_value/lookup
+- id: echo-mut-kwarg_value-lookup-range_missing_end
+  template: "{% echo x | x : x , , x : (1..) %}"
+  error_path: kwarg_value/lookup
+- id: echo-mut-kwarg_value-lexerr-at
+  template: "{% echo x | x : x , , x : @ %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-hash
+  template: "{% echo x | x : x , , x : # %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-dollar
+  template: "{% echo x | x : x , , x : $ %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-caret
+  template: "{% echo x | x : x , , x : ^ %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-ampersand
+  template: "{% echo x | x : x , , x : & %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-asterisk
+  template: "{% echo x | x : x , , x : * %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-tilde
+  template: "{% echo x | x : x , , x : ~ %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-backtick
+  template: "{% echo x | x : x , , x : ` %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-backslash
+  template: "{% echo x | x : x , , x : \\ %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-semicolon
+  template: "{% echo x | x : x , , x : ; %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% echo x | x : x , , x : "hello %}'
+  error_path: kwarg_value/lexer
+- id: echo-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% echo x | x : x , , x : 'hello %}"
+  error_path: kwarg_value/lexer
+- id: echo-mut-filter_arg_value-pipe-000
+  template: "{% echo x | x : x , , | %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-comma-001
+  template: "{% echo x | x : x , , , %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-colon-002
+  template: "{% echo x | x : x , , : %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-close_square-003
+  template: "{% echo x | x : x , , ] %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-close_round-004
+  template: "{% echo x | x : x , , ) %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-question-005
+  template: "{% echo x | x : x , , ? %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-dash-006
+  template: "{% echo x | x : x , , - %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-dot-007
+  template: "{% echo x | x : x , , . %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-dotdot-008
+  template: "{% echo x | x : x , , .. %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-comparison-009
+  template: "{% echo x | x : x , , == %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-comparison-010
+  template: "{% echo x | x : x , , != %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-comparison-011
+  template: "{% echo x | x : x , , < %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-comparison-012
+  template: "{% echo x | x : x , , > %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-comparison-013
+  template: "{% echo x | x : x , , <= %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-comparison-014
+  template: "{% echo x | x : x , , >= %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-comparison-015
+  template: "{% echo x | x : x , , contains %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-eos-016
+  template: "{% echo x | x : x , , %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-bare_bracket
+  template: "{% echo x | x : x , , [0] %}"
+  error_path: filter_arg_value/bad_start
+- id: echo-mut-filter_arg_value-lookup-trailing_dot
+  template: "{% echo x | x : x , , x. %}"
+  error_path: filter_arg_value/lookup
+- id: echo-mut-filter_arg_value-lookup-dot_number
+  template: "{% echo x | x : x , , x.123 %}"
+  error_path: filter_arg_value/lookup
+- id: echo-mut-filter_arg_value-lookup-dot_string
+  template: '{% echo x | x : x , , x."y" %}'
+  error_path: filter_arg_value/lookup
+- id: echo-mut-filter_arg_value-lookup-unclosed_bracket
+  template: "{% echo x | x : x , , x[0 %}"
+  error_path: filter_arg_value/lookup
+- id: echo-mut-filter_arg_value-lookup-bracket_wrong_content
+  template: "{% echo x | x : x , , x[,] %}"
+  error_path: filter_arg_value/lookup
+- id: echo-mut-filter_arg_value-lookup-unclosed_range
+  template: "{% echo x | x : x , , (1..5 %}"
+  error_path: filter_arg_value/lookup
+- id: echo-mut-filter_arg_value-lookup-range_bad_separator
+  template: "{% echo x | x : x , , (1, 5) %}"
+  error_path: filter_arg_value/lookup
+- id: echo-mut-filter_arg_value-lookup-range_missing_end
+  template: "{% echo x | x : x , , (1..) %}"
+  error_path: filter_arg_value/lookup
+- id: echo-mut-filter_arg_value-lexerr-at
+  template: "{% echo x | x : x , , @ %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-hash
+  template: "{% echo x | x : x , , # %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-dollar
+  template: "{% echo x | x : x , , $ %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-caret
+  template: "{% echo x | x : x , , ^ %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-ampersand
+  template: "{% echo x | x : x , , & %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-asterisk
+  template: "{% echo x | x : x , , * %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-tilde
+  template: "{% echo x | x : x , , ~ %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-backtick
+  template: "{% echo x | x : x , , ` %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-backslash
+  template: "{% echo x | x : x , , \\ %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-semicolon
+  template: "{% echo x | x : x , , ; %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-unclosed_double_quote
+  template: '{% echo x | x : x , , "hello %}'
+  error_path: filter_arg_value/lexer
+- id: echo-mut-filter_arg_value-lexerr-unclosed_single_quote
+  template: "{% echo x | x : x , , 'hello %}"
+  error_path: filter_arg_value/lexer
+- id: echo-mut-end-trail-id
+  template: "{% echo x extra %}"
+  error_path: end
+- id: echo-mut-end-trail-number
+  template: "{% echo x 42 %}"
+  error_path: end
+- id: echo-mut-end-trail-string
+  template: "{% echo x 'hi' %}"
+  error_path: end
+- id: echo-mut-end-trail-pipe
+  template: "{% echo x | %}"
+  error_path: end
+- id: echo-mut-end-trail-colon
+  template: "{% echo x : %}"
+  error_path: end
+- id: echo-mut-end-trail-comma
+  template: "{% echo x , %}"
+  error_path: end
+- id: echo-mut-end-trail-open_square
+  template: "{% echo x [ %}"
+  error_path: end
+- id: echo-mut-end-trail-close_square
+  template: "{% echo x ] %}"
+  error_path: end
+- id: echo-mut-end-trail-open_round
+  template: "{% echo x ( %}"
+  error_path: end
+- id: echo-mut-end-trail-close_round
+  template: "{% echo x ) %}"
+  error_path: end
+- id: echo-mut-end-trail-question
+  template: "{% echo x ? %}"
+  error_path: end
+- id: echo-mut-end-trail-dot
+  template: "{% echo x . %}"
+  error_path: end
+- id: echo-mut-end-trail-comparison
+  template: "{% echo x == %}"
+  error_path: end
+- id: echo-mut-end-trail-dash
+  template: "{% echo x - %}"
+  error_path: end
+- id: echo-mut-valid-000
+  template: "{% echo x %}"
+  error_path: valid
+- id: echo-mut-valid-001
+  template: "{% echo 42 %}"
+  error_path: valid
+- id: echo-mut-valid-002
+  template: "{% echo 3.14 %}"
+  error_path: valid
+- id: echo-mut-valid-003
+  template: "{% echo -5 %}"
+  error_path: valid
+- id: echo-mut-valid-004
+  template: "{% echo 'hello' %}"
+  error_path: valid
+- id: echo-mut-valid-005
+  template: "{% echo true %}"
+  error_path: valid
+- id: echo-mut-valid-006
+  template: "{% echo false %}"
+  error_path: valid
+- id: echo-mut-valid-007
+  template: "{% echo nil %}"
+  error_path: valid
+- id: echo-mut-valid-008
+  template: "{% echo blank %}"
+  error_path: valid
+- id: echo-mut-valid-009
+  template: "{% echo empty %}"
+  error_path: valid
+- id: echo-mut-valid-010
+  template: "{% echo product.title %}"
+  error_path: valid
+- id: echo-mut-valid-011
+  template: "{% echo products[0] %}"
+  error_path: valid
+- id: echo-mut-valid-012
+  template: "{% echo a.b.c %}"
+  error_path: valid
+- id: echo-mut-valid-013
+  template: "{% echo a[0].b %}"
+  error_path: valid
+- id: echo-mut-valid-014
+  template: "{% echo (1..5) %}"
+  error_path: valid
+- id: echo-themecheck-empty-first-filter-arg
+  template: "{% echo product.title | append: %}"
+  error_path: valid
+- id: echo-themecheck-filter-separator-trailing-comma-before-pipe
+  template: "{% echo n | filter: 1, 2, 3, | filter2: k1: 1, k2: 2 %}"
+  error_path: valid
+- id: echo-themecheck-filter-separator-mixed-positional-keyword
+  template: "{% echo n | filter: 'a', 'b', key1: 1, key2: 2, 'c' %}"
+  error_path: valid
+- id: echo-themecheck-filter-separator-leading-comma
+  template: "{% echo n | f1: , %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-themecheck-filter-separator-leading-comma-before-pipe
+  template: "{% echo n | f1: , | f2 %}"
+  error_path: filter_first_arg/bad_start
+- id: echo-themecheck-filter-separator-missing-comma
+  template: "{% echo n | filter: 1 2, 3 %}"
+  error_path: end
+- id: echo-themecheck-filter-separator-adjacent-colon
+  template: "{% echo n | pluralize: 'comment': 'comments' %}"
+  error_path: end

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/elsif.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/elsif.yml
@@ -1,0 +1,598 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: elsif-mut-elsif_condition-pipe-000
+  template: "{% if false %}{% elsif false %}{% elsif | %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-comma-001
+  template: "{% if false %}{% elsif false %}{% elsif , %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-colon-002
+  template: "{% if false %}{% elsif false %}{% elsif : %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-close_square-003
+  template: "{% if false %}{% elsif false %}{% elsif ] %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-close_round-004
+  template: "{% if false %}{% elsif false %}{% elsif ) %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-question-005
+  template: "{% if false %}{% elsif false %}{% elsif ? %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-dash-006
+  template: "{% if false %}{% elsif false %}{% elsif - %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-dot-007
+  template: "{% if false %}{% elsif false %}{% elsif . %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-dotdot-008
+  template: "{% if false %}{% elsif false %}{% elsif .. %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-comparison-009
+  template: "{% if false %}{% elsif false %}{% elsif == %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-comparison-010
+  template: "{% if false %}{% elsif false %}{% elsif != %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-comparison-011
+  template: "{% if false %}{% elsif false %}{% elsif < %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-comparison-012
+  template: "{% if false %}{% elsif false %}{% elsif > %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-comparison-013
+  template: "{% if false %}{% elsif false %}{% elsif <= %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-comparison-014
+  template: "{% if false %}{% elsif false %}{% elsif >= %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-comparison-015
+  template: "{% if false %}{% elsif false %}{% elsif contains %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-eos-016
+  template: "{% if false %}{% elsif false %}{% elsif  %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-bare_bracket
+  template: "{% if false %}{% elsif false %}{% elsif [0] %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: elsif-mut-elsif_condition-lookup-trailing_dot
+  template: "{% if false %}{% elsif false %}{% elsif x. %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: elsif-mut-elsif_condition-lookup-dot_number
+  template: "{% if false %}{% elsif false %}{% elsif x.123 %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: elsif-mut-elsif_condition-lookup-dot_string
+  template: '{% if false %}{% elsif false %}{% elsif x."y" %}{% endif %}'
+  error_path: elsif_condition/lookup
+- id: elsif-mut-elsif_condition-lookup-unclosed_bracket
+  template: "{% if false %}{% elsif false %}{% elsif x[0 %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: elsif-mut-elsif_condition-lookup-bracket_wrong_content
+  template: "{% if false %}{% elsif false %}{% elsif x[,] %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: elsif-mut-elsif_condition-lookup-unclosed_range
+  template: "{% if false %}{% elsif false %}{% elsif (1..5 %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: elsif-mut-elsif_condition-lookup-range_bad_separator
+  template: "{% if false %}{% elsif false %}{% elsif (1, 5) %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: elsif-mut-elsif_condition-lookup-range_missing_end
+  template: "{% if false %}{% elsif false %}{% elsif (1..) %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: elsif-mut-elsif_condition-lexerr-at
+  template: "{% if false %}{% elsif false %}{% elsif @ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-hash
+  template: "{% if false %}{% elsif false %}{% elsif # %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-dollar
+  template: "{% if false %}{% elsif false %}{% elsif $ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-caret
+  template: "{% if false %}{% elsif false %}{% elsif ^ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-ampersand
+  template: "{% if false %}{% elsif false %}{% elsif & %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-asterisk
+  template: "{% if false %}{% elsif false %}{% elsif * %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-tilde
+  template: "{% if false %}{% elsif false %}{% elsif ~ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-backtick
+  template: "{% if false %}{% elsif false %}{% elsif ` %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-backslash
+  template: "{% if false %}{% elsif false %}{% elsif \\ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-semicolon
+  template: "{% if false %}{% elsif false %}{% elsif ; %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif false %}{% elsif "hello %}{% endif %}'
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_condition-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif false %}{% elsif 'hello %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: elsif-mut-elsif_comparison_rhs-pipe-000
+  template: "{% if false %}{% elsif false %}{% elsif x == | %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-comma-001
+  template: "{% if false %}{% elsif false %}{% elsif x == , %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-colon-002
+  template: "{% if false %}{% elsif false %}{% elsif x == : %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-close_square-003
+  template: "{% if false %}{% elsif false %}{% elsif x == ] %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-close_round-004
+  template: "{% if false %}{% elsif false %}{% elsif x == ) %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-question-005
+  template: "{% if false %}{% elsif false %}{% elsif x == ? %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-dash-006
+  template: "{% if false %}{% elsif false %}{% elsif x == - %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-dot-007
+  template: "{% if false %}{% elsif false %}{% elsif x == . %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-dotdot-008
+  template: "{% if false %}{% elsif false %}{% elsif x == .. %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-comparison-009
+  template: "{% if false %}{% elsif false %}{% elsif x == == %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-comparison-010
+  template: "{% if false %}{% elsif false %}{% elsif x == != %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-comparison-011
+  template: "{% if false %}{% elsif false %}{% elsif x == < %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-comparison-012
+  template: "{% if false %}{% elsif false %}{% elsif x == > %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-comparison-013
+  template: "{% if false %}{% elsif false %}{% elsif x == <= %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-comparison-014
+  template: "{% if false %}{% elsif false %}{% elsif x == >= %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-comparison-015
+  template: "{% if false %}{% elsif false %}{% elsif x == contains %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-eos-016
+  template: "{% if false %}{% elsif false %}{% elsif x == %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-bare_bracket
+  template: "{% if false %}{% elsif false %}{% elsif x == [0] %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: elsif-mut-elsif_comparison_rhs-lookup-trailing_dot
+  template: "{% if false %}{% elsif false %}{% elsif x == x. %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: elsif-mut-elsif_comparison_rhs-lookup-dot_number
+  template: "{% if false %}{% elsif false %}{% elsif x == x.123 %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: elsif-mut-elsif_comparison_rhs-lookup-dot_string
+  template: '{% if false %}{% elsif false %}{% elsif x == x."y" %}{% endif %}'
+  error_path: elsif_comparison_rhs/lookup
+- id: elsif-mut-elsif_comparison_rhs-lookup-unclosed_bracket
+  template: "{% if false %}{% elsif false %}{% elsif x == x[0 %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: elsif-mut-elsif_comparison_rhs-lookup-bracket_wrong_content
+  template: "{% if false %}{% elsif false %}{% elsif x == x[,] %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: elsif-mut-elsif_comparison_rhs-lookup-unclosed_range
+  template: "{% if false %}{% elsif false %}{% elsif x == (1..5 %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: elsif-mut-elsif_comparison_rhs-lookup-range_bad_separator
+  template: "{% if false %}{% elsif false %}{% elsif x == (1, 5) %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: elsif-mut-elsif_comparison_rhs-lookup-range_missing_end
+  template: "{% if false %}{% elsif false %}{% elsif x == (1..) %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: elsif-mut-elsif_comparison_rhs-lexerr-at
+  template: "{% if false %}{% elsif false %}{% elsif x == @ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-hash
+  template: "{% if false %}{% elsif false %}{% elsif x == # %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-dollar
+  template: "{% if false %}{% elsif false %}{% elsif x == $ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-caret
+  template: "{% if false %}{% elsif false %}{% elsif x == ^ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-ampersand
+  template: "{% if false %}{% elsif false %}{% elsif x == & %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-asterisk
+  template: "{% if false %}{% elsif false %}{% elsif x == * %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-tilde
+  template: "{% if false %}{% elsif false %}{% elsif x == ~ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-backtick
+  template: "{% if false %}{% elsif false %}{% elsif x == ` %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-backslash
+  template: "{% if false %}{% elsif false %}{% elsif x == \\ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-semicolon
+  template: "{% if false %}{% elsif false %}{% elsif x == ; %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif false %}{% elsif x == "hello %}{% endif %}'
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif false %}{% elsif x == 'hello %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_op-eos
+  template: "{% if false %}{% elsif false %}{% elsif x and %}{% endif %}"
+  error_path: elsif_boolean_op
+- id: elsif-mut-elsif_boolean_op-number
+  template: "{% if false %}{% elsif false %}{% elsif x and 42 %}{% endif %}"
+  error_path: elsif_boolean_op
+- id: elsif-mut-elsif_boolean_op-lexerr-at
+  template: "{% if false %}{% elsif false %}{% elsif x and @ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-hash
+  template: "{% if false %}{% elsif false %}{% elsif x and # %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-dollar
+  template: "{% if false %}{% elsif false %}{% elsif x and $ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-caret
+  template: "{% if false %}{% elsif false %}{% elsif x and ^ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-ampersand
+  template: "{% if false %}{% elsif false %}{% elsif x and & %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-asterisk
+  template: "{% if false %}{% elsif false %}{% elsif x and * %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-tilde
+  template: "{% if false %}{% elsif false %}{% elsif x and ~ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-backtick
+  template: "{% if false %}{% elsif false %}{% elsif x and ` %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-backslash
+  template: "{% if false %}{% elsif false %}{% elsif x and \\ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-semicolon
+  template: "{% if false %}{% elsif false %}{% elsif x and ; %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif false %}{% elsif x and "hello %}{% endif %}'
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_op-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif false %}{% elsif x and 'hello %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: elsif-mut-elsif_boolean_expr-pipe-000
+  template: "{% if false %}{% elsif false %}{% elsif x and x | %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-comma-001
+  template: "{% if false %}{% elsif false %}{% elsif x and x , %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-colon-002
+  template: "{% if false %}{% elsif false %}{% elsif x and x : %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-close_square-003
+  template: "{% if false %}{% elsif false %}{% elsif x and x ] %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-close_round-004
+  template: "{% if false %}{% elsif false %}{% elsif x and x ) %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-question-005
+  template: "{% if false %}{% elsif false %}{% elsif x and x ? %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-dash-006
+  template: "{% if false %}{% elsif false %}{% elsif x and x - %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-dot-007
+  template: "{% if false %}{% elsif false %}{% elsif x and x . %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-dotdot-008
+  template: "{% if false %}{% elsif false %}{% elsif x and x .. %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-comparison-009
+  template: "{% if false %}{% elsif false %}{% elsif x and x == %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-comparison-010
+  template: "{% if false %}{% elsif false %}{% elsif x and x != %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-comparison-011
+  template: "{% if false %}{% elsif false %}{% elsif x and x < %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-comparison-012
+  template: "{% if false %}{% elsif false %}{% elsif x and x > %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-comparison-013
+  template: "{% if false %}{% elsif false %}{% elsif x and x <= %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-comparison-014
+  template: "{% if false %}{% elsif false %}{% elsif x and x >= %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-comparison-015
+  template: "{% if false %}{% elsif false %}{% elsif x and x contains %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-eos-016
+  template: "{% if false %}{% elsif false %}{% elsif x and x %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-bare_bracket
+  template: "{% if false %}{% elsif false %}{% elsif x and x [0] %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: elsif-mut-elsif_boolean_expr-lookup-trailing_dot
+  template: "{% if false %}{% elsif false %}{% elsif x and x x. %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: elsif-mut-elsif_boolean_expr-lookup-dot_number
+  template: "{% if false %}{% elsif false %}{% elsif x and x x.123 %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: elsif-mut-elsif_boolean_expr-lookup-dot_string
+  template: '{% if false %}{% elsif false %}{% elsif x and x x."y" %}{% endif %}'
+  error_path: elsif_boolean_expr/lookup
+- id: elsif-mut-elsif_boolean_expr-lookup-unclosed_bracket
+  template: "{% if false %}{% elsif false %}{% elsif x and x x[0 %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: elsif-mut-elsif_boolean_expr-lookup-bracket_wrong_content
+  template: "{% if false %}{% elsif false %}{% elsif x and x x[,] %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: elsif-mut-elsif_boolean_expr-lookup-unclosed_range
+  template: "{% if false %}{% elsif false %}{% elsif x and x (1..5 %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: elsif-mut-elsif_boolean_expr-lookup-range_bad_separator
+  template: "{% if false %}{% elsif false %}{% elsif x and x (1, 5) %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: elsif-mut-elsif_boolean_expr-lookup-range_missing_end
+  template: "{% if false %}{% elsif false %}{% elsif x and x (1..) %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: elsif-mut-elsif_boolean_expr-lexerr-at
+  template: "{% if false %}{% elsif false %}{% elsif x and x @ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-hash
+  template: "{% if false %}{% elsif false %}{% elsif x and x # %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-dollar
+  template: "{% if false %}{% elsif false %}{% elsif x and x $ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-caret
+  template: "{% if false %}{% elsif false %}{% elsif x and x ^ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-ampersand
+  template: "{% if false %}{% elsif false %}{% elsif x and x & %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-asterisk
+  template: "{% if false %}{% elsif false %}{% elsif x and x * %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-tilde
+  template: "{% if false %}{% elsif false %}{% elsif x and x ~ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-backtick
+  template: "{% if false %}{% elsif false %}{% elsif x and x ` %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-backslash
+  template: "{% if false %}{% elsif false %}{% elsif x and x \\ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-semicolon
+  template: "{% if false %}{% elsif false %}{% elsif x and x ; %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif false %}{% elsif x and x "hello %}{% endif %}'
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_expr-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif false %}{% elsif x and x 'hello %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-pipe-000
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == | %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-comma-001
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == , %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-colon-002
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == : %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-close_square-003
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == ] %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-close_round-004
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == ) %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-question-005
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == ? %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-dash-006
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == - %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-dot-007
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == . %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-dotdot-008
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == .. %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-009
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == == %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-010
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == != %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-011
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == < %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-012
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == > %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-013
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == <= %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-014
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == >= %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-015
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == contains %}{% endif
+    %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-eos-016
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-bare_bracket
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == [0] %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-trailing_dot
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == x. %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-dot_number
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == x.123 %}{% endif
+    %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-dot_string
+  template: '{% if false %}{% elsif false %}{% elsif x and x x == x."y" %}{% endif
+    %}'
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-unclosed_bracket
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == x[0 %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-bracket_wrong_content
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == x[,] %}{% endif
+    %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-unclosed_range
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == (1..5 %}{% endif
+    %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-range_bad_separator
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == (1, 5) %}{% endif
+    %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-range_missing_end
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == (1..) %}{% endif
+    %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-at
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == @ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-hash
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == # %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-dollar
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == $ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-caret
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == ^ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-ampersand
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == & %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-asterisk
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == * %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-tilde
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == ~ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-backtick
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == ` %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-backslash
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == \\ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-semicolon
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == ; %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif false %}{% elsif x and x x == "hello %}{% endif
+    %}'
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif false %}{% elsif x and x x == 'hello %}{% endif
+    %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: elsif-mut-elsif_end-trail-id
+  template: "{% if false %}{% elsif false %}{% elsif x extra %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-number
+  template: "{% if false %}{% elsif false %}{% elsif x 42 %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-string
+  template: "{% if false %}{% elsif false %}{% elsif x 'hi' %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-pipe
+  template: "{% if false %}{% elsif false %}{% elsif x | %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-colon
+  template: "{% if false %}{% elsif false %}{% elsif x : %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-comma
+  template: "{% if false %}{% elsif false %}{% elsif x , %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-open_square
+  template: "{% if false %}{% elsif false %}{% elsif x [ %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-close_square
+  template: "{% if false %}{% elsif false %}{% elsif x ] %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-open_round
+  template: "{% if false %}{% elsif false %}{% elsif x ( %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-close_round
+  template: "{% if false %}{% elsif false %}{% elsif x ) %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-question
+  template: "{% if false %}{% elsif false %}{% elsif x ? %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-dot
+  template: "{% if false %}{% elsif false %}{% elsif x . %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-comparison
+  template: "{% if false %}{% elsif false %}{% elsif x == %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-elsif_end-trail-dash
+  template: "{% if false %}{% elsif false %}{% elsif x - %}{% endif %}"
+  error_path: elsif_end
+- id: elsif-mut-valid-000
+  template: "{% if false %}{% elsif false %}{% elsif x %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-001
+  template: "{% if false %}{% elsif false %}{% elsif 42 %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-002
+  template: "{% if false %}{% elsif false %}{% elsif 3.14 %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-003
+  template: "{% if false %}{% elsif false %}{% elsif -5 %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-004
+  template: "{% if false %}{% elsif false %}{% elsif 'hello' %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-005
+  template: "{% if false %}{% elsif false %}{% elsif true %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-006
+  template: "{% if false %}{% elsif false %}{% elsif false %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-007
+  template: "{% if false %}{% elsif false %}{% elsif nil %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-008
+  template: "{% if false %}{% elsif false %}{% elsif blank %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-009
+  template: "{% if false %}{% elsif false %}{% elsif empty %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-010
+  template: "{% if false %}{% elsif false %}{% elsif product.title %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-011
+  template: "{% if false %}{% elsif false %}{% elsif products[0] %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-012
+  template: "{% if false %}{% elsif false %}{% elsif a.b.c %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-013
+  template: "{% if false %}{% elsif false %}{% elsif a[0].b %}{% endif %}"
+  error_path: valid
+- id: elsif-mut-valid-014
+  template: "{% if false %}{% elsif false %}{% elsif (1..5) %}{% endif %}"
+  error_path: valid
+- id: elsif-themecheck-misplaced-branch
+  template: "{% elsif product.available %}"

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/for.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/for.yml
@@ -1,0 +1,386 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: for-mut-variable_name-eos
+  template: "{% for  %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-number
+  template: "{% for 42 %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-at
+  template: "{% for @ %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-hash
+  template: "{% for # %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-dollar
+  template: "{% for $ %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-caret
+  template: "{% for ^ %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-ampersand
+  template: "{% for & %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-asterisk
+  template: "{% for * %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-tilde
+  template: "{% for ~ %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-backtick
+  template: "{% for ` %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-backslash
+  template: "{% for \\ %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-semicolon
+  template: "{% for ; %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% for "hello %}{% endfor %}'
+  error_path: variable_name
+- id: for-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% for 'hello %}{% endfor %}"
+  error_path: variable_name
+- id: for-mut-in_keyword-eos
+  template: "{% for x %}{% endfor %}"
+  error_path: in_keyword
+- id: for-mut-in_keyword-id
+  template: "{% for x of %}{% endfor %}"
+  error_path: in_keyword
+- id: for-mut-collection-pipe-000
+  template: "{% for x in | %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-comma-001
+  template: "{% for x in , %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-colon-002
+  template: "{% for x in : %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-close_square-003
+  template: "{% for x in ] %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-close_round-004
+  template: "{% for x in ) %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-question-005
+  template: "{% for x in ? %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-dash-006
+  template: "{% for x in - %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-dot-007
+  template: "{% for x in . %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-dotdot-008
+  template: "{% for x in .. %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-comparison-009
+  template: "{% for x in == %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-comparison-010
+  template: "{% for x in != %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-comparison-011
+  template: "{% for x in < %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-comparison-012
+  template: "{% for x in > %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-comparison-013
+  template: "{% for x in <= %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-comparison-014
+  template: "{% for x in >= %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-comparison-015
+  template: "{% for x in contains %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-eos-016
+  template: "{% for x in %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-bare_bracket
+  template: "{% for x in [0] %}{% endfor %}"
+  error_path: collection/bad_start
+- id: for-mut-collection-lookup-trailing_dot
+  template: "{% for x in x. %}{% endfor %}"
+  error_path: collection/lookup
+- id: for-mut-collection-lookup-dot_number
+  template: "{% for x in x.123 %}{% endfor %}"
+  error_path: collection/lookup
+- id: for-mut-collection-lookup-dot_string
+  template: '{% for x in x."y" %}{% endfor %}'
+  error_path: collection/lookup
+- id: for-mut-collection-lookup-unclosed_bracket
+  template: "{% for x in x[0 %}{% endfor %}"
+  error_path: collection/lookup
+- id: for-mut-collection-lookup-bracket_wrong_content
+  template: "{% for x in x[,] %}{% endfor %}"
+  error_path: collection/lookup
+- id: for-mut-collection-lookup-unclosed_range
+  template: "{% for x in (1..5 %}{% endfor %}"
+  error_path: collection/lookup
+- id: for-mut-collection-lookup-range_bad_separator
+  template: "{% for x in (1, 5) %}{% endfor %}"
+  error_path: collection/lookup
+- id: for-mut-collection-lookup-range_missing_end
+  template: "{% for x in (1..) %}{% endfor %}"
+  error_path: collection/lookup
+- id: for-mut-collection-lexerr-at
+  template: "{% for x in @ %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-hash
+  template: "{% for x in # %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-dollar
+  template: "{% for x in $ %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-caret
+  template: "{% for x in ^ %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-ampersand
+  template: "{% for x in & %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-asterisk
+  template: "{% for x in * %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-tilde
+  template: "{% for x in ~ %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-backtick
+  template: "{% for x in ` %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-backslash
+  template: "{% for x in \\ %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-semicolon
+  template: "{% for x in ; %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-unclosed_double_quote
+  template: '{% for x in "hello %}{% endfor %}'
+  error_path: collection/lexer
+- id: for-mut-collection-lexerr-unclosed_single_quote
+  template: "{% for x in 'hello %}{% endfor %}"
+  error_path: collection/lexer
+- id: for-mut-invalid_attribute-invalid
+  template: "{% for x in x step , %}{% endfor %}"
+  error_path: invalid_attribute
+- id: for-mut-attr_colon-eos
+  template: "{% for x in x step , %}{% endfor %}"
+  error_path: attr_colon
+- id: for-mut-attr_colon-number
+  template: "{% for x in x step , 42 %}{% endfor %}"
+  error_path: attr_colon
+- id: for-mut-attr_value-pipe-000
+  template: "{% for x in x step , : | %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-comma-001
+  template: "{% for x in x step , : , %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-colon-002
+  template: "{% for x in x step , : : %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-close_square-003
+  template: "{% for x in x step , : ] %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-close_round-004
+  template: "{% for x in x step , : ) %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-question-005
+  template: "{% for x in x step , : ? %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-dash-006
+  template: "{% for x in x step , : - %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-dot-007
+  template: "{% for x in x step , : . %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-dotdot-008
+  template: "{% for x in x step , : .. %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-comparison-009
+  template: "{% for x in x step , : == %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-comparison-010
+  template: "{% for x in x step , : != %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-comparison-011
+  template: "{% for x in x step , : < %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-comparison-012
+  template: "{% for x in x step , : > %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-comparison-013
+  template: "{% for x in x step , : <= %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-comparison-014
+  template: "{% for x in x step , : >= %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-comparison-015
+  template: "{% for x in x step , : contains %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-eos-016
+  template: "{% for x in x step , : %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-bare_bracket
+  template: "{% for x in x step , : [0] %}{% endfor %}"
+  error_path: attr_value/bad_start
+- id: for-mut-attr_value-lookup-trailing_dot
+  template: "{% for x in x step , : x. %}{% endfor %}"
+  error_path: attr_value/lookup
+- id: for-mut-attr_value-lookup-dot_number
+  template: "{% for x in x step , : x.123 %}{% endfor %}"
+  error_path: attr_value/lookup
+- id: for-mut-attr_value-lookup-dot_string
+  template: '{% for x in x step , : x."y" %}{% endfor %}'
+  error_path: attr_value/lookup
+- id: for-mut-attr_value-lookup-unclosed_bracket
+  template: "{% for x in x step , : x[0 %}{% endfor %}"
+  error_path: attr_value/lookup
+- id: for-mut-attr_value-lookup-bracket_wrong_content
+  template: "{% for x in x step , : x[,] %}{% endfor %}"
+  error_path: attr_value/lookup
+- id: for-mut-attr_value-lookup-unclosed_range
+  template: "{% for x in x step , : (1..5 %}{% endfor %}"
+  error_path: attr_value/lookup
+- id: for-mut-attr_value-lookup-range_bad_separator
+  template: "{% for x in x step , : (1, 5) %}{% endfor %}"
+  error_path: attr_value/lookup
+- id: for-mut-attr_value-lookup-range_missing_end
+  template: "{% for x in x step , : (1..) %}{% endfor %}"
+  error_path: attr_value/lookup
+- id: for-mut-attr_value-lexerr-at
+  template: "{% for x in x step , : @ %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-hash
+  template: "{% for x in x step , : # %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-dollar
+  template: "{% for x in x step , : $ %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-caret
+  template: "{% for x in x step , : ^ %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-ampersand
+  template: "{% for x in x step , : & %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-asterisk
+  template: "{% for x in x step , : * %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-tilde
+  template: "{% for x in x step , : ~ %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-backtick
+  template: "{% for x in x step , : ` %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-backslash
+  template: "{% for x in x step , : \\ %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-semicolon
+  template: "{% for x in x step , : ; %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-unclosed_double_quote
+  template: '{% for x in x step , : "hello %}{% endfor %}'
+  error_path: attr_value/lexer
+- id: for-mut-attr_value-lexerr-unclosed_single_quote
+  template: "{% for x in x step , : 'hello %}{% endfor %}"
+  error_path: attr_value/lexer
+- id: for-mut-end-trail-id
+  template: "{% for x in x extra %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-number
+  template: "{% for x in x 42 %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-string
+  template: "{% for x in x 'hi' %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-pipe
+  template: "{% for x in x | %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-colon
+  template: "{% for x in x : %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-comma
+  template: "{% for x in x , %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-open_square
+  template: "{% for x in x [ %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-close_square
+  template: "{% for x in x ] %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-open_round
+  template: "{% for x in x ( %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-close_round
+  template: "{% for x in x ) %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-question
+  template: "{% for x in x ? %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-dot
+  template: "{% for x in x . %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-comparison
+  template: "{% for x in x == %}{% endfor %}"
+  error_path: end
+- id: for-mut-end-trail-dash
+  template: "{% for x in x - %}{% endfor %}"
+  error_path: end
+- id: for-mut-valid-000
+  template: "{% for x in x %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-001
+  template: "{% for x in 42 %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-002
+  template: "{% for x in 3.14 %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-003
+  template: "{% for x in -5 %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-004
+  template: "{% for x in 'hello' %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-005
+  template: "{% for x in true %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-006
+  template: "{% for x in false %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-007
+  template: "{% for x in nil %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-008
+  template: "{% for x in blank %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-009
+  template: "{% for x in empty %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-010
+  template: "{% for x in product.title %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-011
+  template: "{% for x in products[0] %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-012
+  template: "{% for x in a.b.c %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-013
+  template: "{% for x in a[0].b %}{% endfor %}"
+  error_path: valid
+- id: for-mut-valid-014
+  template: "{% for x in (1..5) %}{% endfor %}"
+  error_path: valid
+- id: for-branch-when-in-for
+  template: "{% for x in xs %}{% when x %}{% endfor %}"
+  error_path: unknown_tag
+- id: for-branch-else-valid
+  template: "{% for x in xs %}{% else %}{% endfor %}"
+  error_path: valid
+- id: for-parity-elsif-in-for
+  template: "{% for i in (1..3) %}{% elsif %}{% endfor %}"
+  error_path: unknown_tag
+- id: for-themecheck-skipped-prefix
+  template: "{% for !x in xs %}{% endfor %}"
+  error_path: variable_name

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/form.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/form.yml
@@ -1,0 +1,490 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: form-mut-type_expr-pipe-000
+  template: "{% form | %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-comma-001
+  template: "{% form , %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-colon-002
+  template: "{% form : %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-close_square-003
+  template: "{% form ] %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-close_round-004
+  template: "{% form ) %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-question-005
+  template: "{% form ? %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-dash-006
+  template: "{% form - %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-dot-007
+  template: "{% form . %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-dotdot-008
+  template: "{% form .. %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-comparison-009
+  template: "{% form == %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-comparison-010
+  template: "{% form != %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-comparison-011
+  template: "{% form < %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-comparison-012
+  template: "{% form > %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-comparison-013
+  template: "{% form <= %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-comparison-014
+  template: "{% form >= %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-comparison-015
+  template: "{% form contains %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-eos-016
+  template: "{% form  %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-bare_bracket
+  template: "{% form [0] %}{% endform %}"
+  error_path: type_expr/bad_start
+- id: form-mut-type_expr-lookup-trailing_dot
+  template: "{% form x. %}{% endform %}"
+  error_path: type_expr/lookup
+- id: form-mut-type_expr-lookup-dot_number
+  template: "{% form x.123 %}{% endform %}"
+  error_path: type_expr/lookup
+- id: form-mut-type_expr-lookup-dot_string
+  template: '{% form x."y" %}{% endform %}'
+  error_path: type_expr/lookup
+- id: form-mut-type_expr-lookup-unclosed_bracket
+  template: "{% form x[0 %}{% endform %}"
+  error_path: type_expr/lookup
+- id: form-mut-type_expr-lookup-bracket_wrong_content
+  template: "{% form x[,] %}{% endform %}"
+  error_path: type_expr/lookup
+- id: form-mut-type_expr-lookup-unclosed_range
+  template: "{% form (1..5 %}{% endform %}"
+  error_path: type_expr/lookup
+- id: form-mut-type_expr-lookup-range_bad_separator
+  template: "{% form (1, 5) %}{% endform %}"
+  error_path: type_expr/lookup
+- id: form-mut-type_expr-lookup-range_missing_end
+  template: "{% form (1..) %}{% endform %}"
+  error_path: type_expr/lookup
+- id: form-mut-type_expr-lexerr-at
+  template: "{% form @ %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-hash
+  template: "{% form # %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-dollar
+  template: "{% form $ %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-caret
+  template: "{% form ^ %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-ampersand
+  template: "{% form & %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-asterisk
+  template: "{% form * %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-tilde
+  template: "{% form ~ %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-backtick
+  template: "{% form ` %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-backslash
+  template: "{% form \\ %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-semicolon
+  template: "{% form ; %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-unclosed_double_quote
+  template: '{% form "hello %}{% endform %}'
+  error_path: type_expr/lexer
+- id: form-mut-type_expr-lexerr-unclosed_single_quote
+  template: "{% form 'hello %}{% endform %}"
+  error_path: type_expr/lexer
+- id: form-mut-variable_name-pipe-000
+  template: "{% form x , | %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-comma-001
+  template: "{% form x , , %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-colon-002
+  template: "{% form x , : %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-close_square-003
+  template: "{% form x , ] %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-close_round-004
+  template: "{% form x , ) %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-question-005
+  template: "{% form x , ? %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-dash-006
+  template: "{% form x , - %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-dot-007
+  template: "{% form x , . %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-dotdot-008
+  template: "{% form x , .. %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-comparison-009
+  template: "{% form x , == %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-comparison-010
+  template: "{% form x , != %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-comparison-011
+  template: "{% form x , < %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-comparison-012
+  template: "{% form x , > %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-comparison-013
+  template: "{% form x , <= %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-comparison-014
+  template: "{% form x , >= %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-comparison-015
+  template: "{% form x , contains %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-eos-016
+  template: "{% form x , %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-bare_bracket
+  template: "{% form x , [0] %}{% endform %}"
+  error_path: variable_name/bad_start
+- id: form-mut-variable_name-lookup-trailing_dot
+  template: "{% form x , x. %}{% endform %}"
+  error_path: variable_name/lookup
+- id: form-mut-variable_name-lookup-dot_number
+  template: "{% form x , x.123 %}{% endform %}"
+  error_path: variable_name/lookup
+- id: form-mut-variable_name-lookup-dot_string
+  template: '{% form x , x."y" %}{% endform %}'
+  error_path: variable_name/lookup
+- id: form-mut-variable_name-lookup-unclosed_bracket
+  template: "{% form x , x[0 %}{% endform %}"
+  error_path: variable_name/lookup
+- id: form-mut-variable_name-lookup-bracket_wrong_content
+  template: "{% form x , x[,] %}{% endform %}"
+  error_path: variable_name/lookup
+- id: form-mut-variable_name-lookup-unclosed_range
+  template: "{% form x , (1..5 %}{% endform %}"
+  error_path: variable_name/lookup
+- id: form-mut-variable_name-lookup-range_bad_separator
+  template: "{% form x , (1, 5) %}{% endform %}"
+  error_path: variable_name/lookup
+- id: form-mut-variable_name-lookup-range_missing_end
+  template: "{% form x , (1..) %}{% endform %}"
+  error_path: variable_name/lookup
+- id: form-mut-variable_name-lexerr-at
+  template: "{% form x , @ %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-hash
+  template: "{% form x , # %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-dollar
+  template: "{% form x , $ %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-caret
+  template: "{% form x , ^ %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-ampersand
+  template: "{% form x , & %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-asterisk
+  template: "{% form x , * %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-tilde
+  template: "{% form x , ~ %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-backtick
+  template: "{% form x , ` %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-backslash
+  template: "{% form x , \\ %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-semicolon
+  template: "{% form x , ; %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% form x , "hello %}{% endform %}'
+  error_path: variable_name/lexer
+- id: form-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% form x , 'hello %}{% endform %}"
+  error_path: variable_name/lexer
+- id: form-mut-kwarg_name-eos
+  template: "{% form x step , %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-number
+  template: "{% form x step , 42 %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-at
+  template: "{% form x step , @ %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-hash
+  template: "{% form x step , # %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-dollar
+  template: "{% form x step , $ %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-caret
+  template: "{% form x step , ^ %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-ampersand
+  template: "{% form x step , & %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-asterisk
+  template: "{% form x step , * %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-tilde
+  template: "{% form x step , ~ %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-backtick
+  template: "{% form x step , ` %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-backslash
+  template: "{% form x step , \\ %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-semicolon
+  template: "{% form x step , ; %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-unclosed_double_quote
+  template: '{% form x step , "hello %}{% endform %}'
+  error_path: kwarg_name
+- id: form-mut-kwarg_name-lexerr-unclosed_single_quote
+  template: "{% form x step , 'hello %}{% endform %}"
+  error_path: kwarg_name
+- id: form-mut-kwarg_colon-eos
+  template: "{% form x step , x %}{% endform %}"
+  error_path: kwarg_colon
+- id: form-mut-kwarg_colon-number
+  template: "{% form x step , x 42 %}{% endform %}"
+  error_path: kwarg_colon
+- id: form-mut-kwarg_value-pipe-000
+  template: "{% form x step , x : | %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-comma-001
+  template: "{% form x step , x : , %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-colon-002
+  template: "{% form x step , x : : %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-close_square-003
+  template: "{% form x step , x : ] %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-close_round-004
+  template: "{% form x step , x : ) %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-question-005
+  template: "{% form x step , x : ? %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-dash-006
+  template: "{% form x step , x : - %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-dot-007
+  template: "{% form x step , x : . %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-dotdot-008
+  template: "{% form x step , x : .. %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-comparison-009
+  template: "{% form x step , x : == %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-comparison-010
+  template: "{% form x step , x : != %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-comparison-011
+  template: "{% form x step , x : < %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-comparison-012
+  template: "{% form x step , x : > %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-comparison-013
+  template: "{% form x step , x : <= %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-comparison-014
+  template: "{% form x step , x : >= %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-comparison-015
+  template: "{% form x step , x : contains %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-eos-016
+  template: "{% form x step , x : %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-bare_bracket
+  template: "{% form x step , x : [0] %}{% endform %}"
+  error_path: kwarg_value/bad_start
+- id: form-mut-kwarg_value-lookup-trailing_dot
+  template: "{% form x step , x : x. %}{% endform %}"
+  error_path: kwarg_value/lookup
+- id: form-mut-kwarg_value-lookup-dot_number
+  template: "{% form x step , x : x.123 %}{% endform %}"
+  error_path: kwarg_value/lookup
+- id: form-mut-kwarg_value-lookup-dot_string
+  template: '{% form x step , x : x."y" %}{% endform %}'
+  error_path: kwarg_value/lookup
+- id: form-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% form x step , x : x[0 %}{% endform %}"
+  error_path: kwarg_value/lookup
+- id: form-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% form x step , x : x[,] %}{% endform %}"
+  error_path: kwarg_value/lookup
+- id: form-mut-kwarg_value-lookup-unclosed_range
+  template: "{% form x step , x : (1..5 %}{% endform %}"
+  error_path: kwarg_value/lookup
+- id: form-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% form x step , x : (1, 5) %}{% endform %}"
+  error_path: kwarg_value/lookup
+- id: form-mut-kwarg_value-lookup-range_missing_end
+  template: "{% form x step , x : (1..) %}{% endform %}"
+  error_path: kwarg_value/lookup
+- id: form-mut-kwarg_value-lexerr-at
+  template: "{% form x step , x : @ %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-hash
+  template: "{% form x step , x : # %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-dollar
+  template: "{% form x step , x : $ %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-caret
+  template: "{% form x step , x : ^ %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-ampersand
+  template: "{% form x step , x : & %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-asterisk
+  template: "{% form x step , x : * %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-tilde
+  template: "{% form x step , x : ~ %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-backtick
+  template: "{% form x step , x : ` %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-backslash
+  template: "{% form x step , x : \\ %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-semicolon
+  template: "{% form x step , x : ; %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% form x step , x : "hello %}{% endform %}'
+  error_path: kwarg_value/lexer
+- id: form-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% form x step , x : 'hello %}{% endform %}"
+  error_path: kwarg_value/lexer
+- id: form-mut-attrs_value-pipe
+  template: "{% form x, y: | %}{% endform %}"
+  error_path: attrs_value/bad_start
+  target_branch: FORM-PARSE-EXPR-attrs:value_expr
+- id: form-mut-attrs_value-lookup-trailing_dot
+  template: "{% form x, y: x. %}{% endform %}"
+  error_path: attrs_value/lookup
+  target_branch: FORM-PARSE-EXPR-attrs:value_expr
+- id: form-themecheck-positional-after-named
+  template: "{% form 'contact', id: 'login', customer %}{% endform %}"
+  error_path: kwarg_colon
+- id: form-mut-end-trail-id
+  template: "{% form x extra %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-number
+  template: "{% form x 42 %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-string
+  template: "{% form x 'hi' %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-pipe
+  template: "{% form x | %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-colon
+  template: "{% form x : %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-comma
+  template: "{% form x , %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-open_square
+  template: "{% form x [ %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-close_square
+  template: "{% form x ] %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-open_round
+  template: "{% form x ( %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-close_round
+  template: "{% form x ) %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-question
+  template: "{% form x ? %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-dot
+  template: "{% form x . %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-comparison
+  template: "{% form x == %}{% endform %}"
+  error_path: end
+- id: form-mut-end-trail-dash
+  template: "{% form x - %}{% endform %}"
+  error_path: end
+- id: form-mut-valid-000
+  template: "{% form x %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-001
+  template: "{% form 42 %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-002
+  template: "{% form 3.14 %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-003
+  template: "{% form -5 %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-004
+  template: "{% form 'hello' %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-005
+  template: "{% form true %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-006
+  template: "{% form false %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-007
+  template: "{% form nil %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-008
+  template: "{% form blank %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-009
+  template: "{% form empty %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-010
+  template: "{% form product.title %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-011
+  template: "{% form products[0] %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-012
+  template: "{% form a.b.c %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-013
+  template: "{% form a[0].b %}{% endform %}"
+  error_path: valid
+- id: form-mut-valid-014
+  template: "{% form (1..5) %}{% endform %}"
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/if.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/if.yml
@@ -1,0 +1,1181 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: if-mut-condition-pipe-000
+  template: "{% if | %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-comma-001
+  template: "{% if , %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-colon-002
+  template: "{% if : %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-close_square-003
+  template: "{% if ] %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-close_round-004
+  template: "{% if ) %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-question-005
+  template: "{% if ? %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-dash-006
+  template: "{% if - %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-dot-007
+  template: "{% if . %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-dotdot-008
+  template: "{% if .. %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-comparison-009
+  template: "{% if == %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-comparison-010
+  template: "{% if != %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-comparison-011
+  template: "{% if < %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-comparison-012
+  template: "{% if > %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-comparison-013
+  template: "{% if <= %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-comparison-014
+  template: "{% if >= %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-comparison-015
+  template: "{% if contains %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-eos-016
+  template: "{% if  %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-bare_bracket
+  template: "{% if [0] %}{% endif %}"
+  error_path: condition/bad_start
+- id: if-mut-condition-lookup-trailing_dot
+  template: "{% if x. %}{% endif %}"
+  error_path: condition/lookup
+- id: if-mut-condition-lookup-dot_number
+  template: "{% if x.123 %}{% endif %}"
+  error_path: condition/lookup
+- id: if-mut-condition-lookup-dot_string
+  template: '{% if x."y" %}{% endif %}'
+  error_path: condition/lookup
+- id: if-mut-condition-lookup-unclosed_bracket
+  template: "{% if x[0 %}{% endif %}"
+  error_path: condition/lookup
+- id: if-mut-condition-lookup-bracket_wrong_content
+  template: "{% if x[,] %}{% endif %}"
+  error_path: condition/lookup
+- id: if-mut-condition-lookup-unclosed_range
+  template: "{% if (1..5 %}{% endif %}"
+  error_path: condition/lookup
+- id: if-mut-condition-lookup-range_bad_separator
+  template: "{% if (1, 5) %}{% endif %}"
+  error_path: condition/lookup
+- id: if-mut-condition-lookup-range_missing_end
+  template: "{% if (1..) %}{% endif %}"
+  error_path: condition/lookup
+- id: if-mut-condition-lexerr-at
+  template: "{% if @ %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-hash
+  template: "{% if # %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-dollar
+  template: "{% if $ %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-caret
+  template: "{% if ^ %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-ampersand
+  template: "{% if & %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-asterisk
+  template: "{% if * %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-tilde
+  template: "{% if ~ %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-backtick
+  template: "{% if ` %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-backslash
+  template: "{% if \\ %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-semicolon
+  template: "{% if ; %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-unclosed_double_quote
+  template: '{% if "hello %}{% endif %}'
+  error_path: condition/lexer
+- id: if-mut-condition-lexerr-unclosed_single_quote
+  template: "{% if 'hello %}{% endif %}"
+  error_path: condition/lexer
+- id: if-mut-comparison_rhs-pipe-000
+  template: "{% if x == | %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-comma-001
+  template: "{% if x == , %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-colon-002
+  template: "{% if x == : %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-close_square-003
+  template: "{% if x == ] %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-close_round-004
+  template: "{% if x == ) %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-question-005
+  template: "{% if x == ? %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-dash-006
+  template: "{% if x == - %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-dot-007
+  template: "{% if x == . %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-dotdot-008
+  template: "{% if x == .. %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-comparison-009
+  template: "{% if x == == %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-comparison-010
+  template: "{% if x == != %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-comparison-011
+  template: "{% if x == < %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-comparison-012
+  template: "{% if x == > %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-comparison-013
+  template: "{% if x == <= %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-comparison-014
+  template: "{% if x == >= %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-comparison-015
+  template: "{% if x == contains %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-eos-016
+  template: "{% if x == %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-bare_bracket
+  template: "{% if x == [0] %}{% endif %}"
+  error_path: comparison_rhs/bad_start
+- id: if-mut-comparison_rhs-lookup-trailing_dot
+  template: "{% if x == x. %}{% endif %}"
+  error_path: comparison_rhs/lookup
+- id: if-mut-comparison_rhs-lookup-dot_number
+  template: "{% if x == x.123 %}{% endif %}"
+  error_path: comparison_rhs/lookup
+- id: if-mut-comparison_rhs-lookup-dot_string
+  template: '{% if x == x."y" %}{% endif %}'
+  error_path: comparison_rhs/lookup
+- id: if-mut-comparison_rhs-lookup-unclosed_bracket
+  template: "{% if x == x[0 %}{% endif %}"
+  error_path: comparison_rhs/lookup
+- id: if-mut-comparison_rhs-lookup-bracket_wrong_content
+  template: "{% if x == x[,] %}{% endif %}"
+  error_path: comparison_rhs/lookup
+- id: if-mut-comparison_rhs-lookup-unclosed_range
+  template: "{% if x == (1..5 %}{% endif %}"
+  error_path: comparison_rhs/lookup
+- id: if-mut-comparison_rhs-lookup-range_bad_separator
+  template: "{% if x == (1, 5) %}{% endif %}"
+  error_path: comparison_rhs/lookup
+- id: if-mut-comparison_rhs-lookup-range_missing_end
+  template: "{% if x == (1..) %}{% endif %}"
+  error_path: comparison_rhs/lookup
+- id: if-mut-comparison_rhs-lexerr-at
+  template: "{% if x == @ %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-hash
+  template: "{% if x == # %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-dollar
+  template: "{% if x == $ %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-caret
+  template: "{% if x == ^ %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-ampersand
+  template: "{% if x == & %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-asterisk
+  template: "{% if x == * %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-tilde
+  template: "{% if x == ~ %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-backtick
+  template: "{% if x == ` %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-backslash
+  template: "{% if x == \\ %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-semicolon
+  template: "{% if x == ; %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% if x == "hello %}{% endif %}'
+  error_path: comparison_rhs/lexer
+- id: if-mut-comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% if x == 'hello %}{% endif %}"
+  error_path: comparison_rhs/lexer
+- id: if-mut-boolean_op-eos
+  template: "{% if x and %}{% endif %}"
+  error_path: boolean_op
+- id: if-mut-boolean_op-number
+  template: "{% if x and 42 %}{% endif %}"
+  error_path: boolean_op
+- id: if-mut-boolean_op-lexerr-at
+  template: "{% if x and @ %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-hash
+  template: "{% if x and # %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-dollar
+  template: "{% if x and $ %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-caret
+  template: "{% if x and ^ %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-ampersand
+  template: "{% if x and & %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-asterisk
+  template: "{% if x and * %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-tilde
+  template: "{% if x and ~ %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-backtick
+  template: "{% if x and ` %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-backslash
+  template: "{% if x and \\ %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-semicolon
+  template: "{% if x and ; %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-unclosed_double_quote
+  template: '{% if x and "hello %}{% endif %}'
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_op-lexerr-unclosed_single_quote
+  template: "{% if x and 'hello %}{% endif %}"
+  error_path: boolean_op/lexer
+- id: if-mut-boolean_expr-pipe-000
+  template: "{% if x and x | %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-comma-001
+  template: "{% if x and x , %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-colon-002
+  template: "{% if x and x : %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-close_square-003
+  template: "{% if x and x ] %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-close_round-004
+  template: "{% if x and x ) %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-question-005
+  template: "{% if x and x ? %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-dash-006
+  template: "{% if x and x - %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-dot-007
+  template: "{% if x and x . %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-dotdot-008
+  template: "{% if x and x .. %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-comparison-009
+  template: "{% if x and x == %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-comparison-010
+  template: "{% if x and x != %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-comparison-011
+  template: "{% if x and x < %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-comparison-012
+  template: "{% if x and x > %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-comparison-013
+  template: "{% if x and x <= %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-comparison-014
+  template: "{% if x and x >= %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-comparison-015
+  template: "{% if x and x contains %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-eos-016
+  template: "{% if x and x %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-bare_bracket
+  template: "{% if x and x [0] %}{% endif %}"
+  error_path: boolean_expr/bad_start
+- id: if-mut-boolean_expr-lookup-trailing_dot
+  template: "{% if x and x x. %}{% endif %}"
+  error_path: boolean_expr/lookup
+- id: if-mut-boolean_expr-lookup-dot_number
+  template: "{% if x and x x.123 %}{% endif %}"
+  error_path: boolean_expr/lookup
+- id: if-mut-boolean_expr-lookup-dot_string
+  template: '{% if x and x x."y" %}{% endif %}'
+  error_path: boolean_expr/lookup
+- id: if-mut-boolean_expr-lookup-unclosed_bracket
+  template: "{% if x and x x[0 %}{% endif %}"
+  error_path: boolean_expr/lookup
+- id: if-mut-boolean_expr-lookup-bracket_wrong_content
+  template: "{% if x and x x[,] %}{% endif %}"
+  error_path: boolean_expr/lookup
+- id: if-mut-boolean_expr-lookup-unclosed_range
+  template: "{% if x and x (1..5 %}{% endif %}"
+  error_path: boolean_expr/lookup
+- id: if-mut-boolean_expr-lookup-range_bad_separator
+  template: "{% if x and x (1, 5) %}{% endif %}"
+  error_path: boolean_expr/lookup
+- id: if-mut-boolean_expr-lookup-range_missing_end
+  template: "{% if x and x (1..) %}{% endif %}"
+  error_path: boolean_expr/lookup
+- id: if-mut-boolean_expr-lexerr-at
+  template: "{% if x and x @ %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-hash
+  template: "{% if x and x # %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-dollar
+  template: "{% if x and x $ %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-caret
+  template: "{% if x and x ^ %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-ampersand
+  template: "{% if x and x & %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-asterisk
+  template: "{% if x and x * %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-tilde
+  template: "{% if x and x ~ %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-backtick
+  template: "{% if x and x ` %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-backslash
+  template: "{% if x and x \\ %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-semicolon
+  template: "{% if x and x ; %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-unclosed_double_quote
+  template: '{% if x and x "hello %}{% endif %}'
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_expr-lexerr-unclosed_single_quote
+  template: "{% if x and x 'hello %}{% endif %}"
+  error_path: boolean_expr/lexer
+- id: if-mut-boolean_comparison_rhs-pipe-000
+  template: "{% if x and x x == | %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-comma-001
+  template: "{% if x and x x == , %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-colon-002
+  template: "{% if x and x x == : %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-close_square-003
+  template: "{% if x and x x == ] %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-close_round-004
+  template: "{% if x and x x == ) %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-question-005
+  template: "{% if x and x x == ? %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-dash-006
+  template: "{% if x and x x == - %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-dot-007
+  template: "{% if x and x x == . %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-dotdot-008
+  template: "{% if x and x x == .. %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-comparison-009
+  template: "{% if x and x x == == %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-comparison-010
+  template: "{% if x and x x == != %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-comparison-011
+  template: "{% if x and x x == < %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-comparison-012
+  template: "{% if x and x x == > %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-comparison-013
+  template: "{% if x and x x == <= %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-comparison-014
+  template: "{% if x and x x == >= %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-comparison-015
+  template: "{% if x and x x == contains %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-eos-016
+  template: "{% if x and x x == %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-bare_bracket
+  template: "{% if x and x x == [0] %}{% endif %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: if-mut-boolean_comparison_rhs-lookup-trailing_dot
+  template: "{% if x and x x == x. %}{% endif %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: if-mut-boolean_comparison_rhs-lookup-dot_number
+  template: "{% if x and x x == x.123 %}{% endif %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: if-mut-boolean_comparison_rhs-lookup-dot_string
+  template: '{% if x and x x == x."y" %}{% endif %}'
+  error_path: boolean_comparison_rhs/lookup
+- id: if-mut-boolean_comparison_rhs-lookup-unclosed_bracket
+  template: "{% if x and x x == x[0 %}{% endif %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: if-mut-boolean_comparison_rhs-lookup-bracket_wrong_content
+  template: "{% if x and x x == x[,] %}{% endif %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: if-mut-boolean_comparison_rhs-lookup-unclosed_range
+  template: "{% if x and x x == (1..5 %}{% endif %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: if-mut-boolean_comparison_rhs-lookup-range_bad_separator
+  template: "{% if x and x x == (1, 5) %}{% endif %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: if-mut-boolean_comparison_rhs-lookup-range_missing_end
+  template: "{% if x and x x == (1..) %}{% endif %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: if-mut-boolean_comparison_rhs-lexerr-at
+  template: "{% if x and x x == @ %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-hash
+  template: "{% if x and x x == # %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-dollar
+  template: "{% if x and x x == $ %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-caret
+  template: "{% if x and x x == ^ %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-ampersand
+  template: "{% if x and x x == & %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-asterisk
+  template: "{% if x and x x == * %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-tilde
+  template: "{% if x and x x == ~ %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-backtick
+  template: "{% if x and x x == ` %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-backslash
+  template: "{% if x and x x == \\ %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-semicolon
+  template: "{% if x and x x == ; %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% if x and x x == "hello %}{% endif %}'
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-boolean_comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% if x and x x == 'hello %}{% endif %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: if-mut-end-trail-id
+  template: "{% if x extra %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-number
+  template: "{% if x 42 %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-string
+  template: "{% if x 'hi' %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-pipe
+  template: "{% if x | %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-colon
+  template: "{% if x : %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-comma
+  template: "{% if x , %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-open_square
+  template: "{% if x [ %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-close_square
+  template: "{% if x ] %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-open_round
+  template: "{% if x ( %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-close_round
+  template: "{% if x ) %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-question
+  template: "{% if x ? %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-dot
+  template: "{% if x . %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-comparison
+  template: "{% if x == %}{% endif %}"
+  error_path: end
+- id: if-mut-end-trail-dash
+  template: "{% if x - %}{% endif %}"
+  error_path: end
+- id: if-mut-valid-000
+  template: "{% if x %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-001
+  template: "{% if 42 %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-002
+  template: "{% if 3.14 %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-003
+  template: "{% if -5 %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-004
+  template: "{% if 'hello' %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-005
+  template: "{% if true %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-006
+  template: "{% if false %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-007
+  template: "{% if nil %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-008
+  template: "{% if blank %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-009
+  template: "{% if empty %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-010
+  template: "{% if product.title %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-011
+  template: "{% if products[0] %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-012
+  template: "{% if a.b.c %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-013
+  template: "{% if a[0].b %}{% endif %}"
+  error_path: valid
+- id: if-mut-valid-014
+  template: "{% if (1..5) %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-elsif_condition-pipe-000
+  template: "{% if false %}{% elsif | %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-comma-001
+  template: "{% if false %}{% elsif , %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-colon-002
+  template: "{% if false %}{% elsif : %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-close_square-003
+  template: "{% if false %}{% elsif ] %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-close_round-004
+  template: "{% if false %}{% elsif ) %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-question-005
+  template: "{% if false %}{% elsif ? %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-dash-006
+  template: "{% if false %}{% elsif - %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-dot-007
+  template: "{% if false %}{% elsif . %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-dotdot-008
+  template: "{% if false %}{% elsif .. %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-comparison-009
+  template: "{% if false %}{% elsif == %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-comparison-010
+  template: "{% if false %}{% elsif != %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-comparison-011
+  template: "{% if false %}{% elsif < %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-comparison-012
+  template: "{% if false %}{% elsif > %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-comparison-013
+  template: "{% if false %}{% elsif <= %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-comparison-014
+  template: "{% if false %}{% elsif >= %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-comparison-015
+  template: "{% if false %}{% elsif contains %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-eos-016
+  template: "{% if false %}{% elsif  %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-bare_bracket
+  template: "{% if false %}{% elsif [0] %}{% endif %}"
+  error_path: elsif_condition/bad_start
+- id: if_elsif-mut-elsif_condition-lookup-trailing_dot
+  template: "{% if false %}{% elsif x. %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: if_elsif-mut-elsif_condition-lookup-dot_number
+  template: "{% if false %}{% elsif x.123 %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: if_elsif-mut-elsif_condition-lookup-dot_string
+  template: '{% if false %}{% elsif x."y" %}{% endif %}'
+  error_path: elsif_condition/lookup
+- id: if_elsif-mut-elsif_condition-lookup-unclosed_bracket
+  template: "{% if false %}{% elsif x[0 %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: if_elsif-mut-elsif_condition-lookup-bracket_wrong_content
+  template: "{% if false %}{% elsif x[,] %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: if_elsif-mut-elsif_condition-lookup-unclosed_range
+  template: "{% if false %}{% elsif (1..5 %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: if_elsif-mut-elsif_condition-lookup-range_bad_separator
+  template: "{% if false %}{% elsif (1, 5) %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: if_elsif-mut-elsif_condition-lookup-range_missing_end
+  template: "{% if false %}{% elsif (1..) %}{% endif %}"
+  error_path: elsif_condition/lookup
+- id: if_elsif-mut-elsif_condition-lexerr-at
+  template: "{% if false %}{% elsif @ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-hash
+  template: "{% if false %}{% elsif # %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-dollar
+  template: "{% if false %}{% elsif $ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-caret
+  template: "{% if false %}{% elsif ^ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-ampersand
+  template: "{% if false %}{% elsif & %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-asterisk
+  template: "{% if false %}{% elsif * %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-tilde
+  template: "{% if false %}{% elsif ~ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-backtick
+  template: "{% if false %}{% elsif ` %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-backslash
+  template: "{% if false %}{% elsif \\ %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-semicolon
+  template: "{% if false %}{% elsif ; %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif "hello %}{% endif %}'
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_condition-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif 'hello %}{% endif %}"
+  error_path: elsif_condition/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-pipe-000
+  template: "{% if false %}{% elsif x == | %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-comma-001
+  template: "{% if false %}{% elsif x == , %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-colon-002
+  template: "{% if false %}{% elsif x == : %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-close_square-003
+  template: "{% if false %}{% elsif x == ] %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-close_round-004
+  template: "{% if false %}{% elsif x == ) %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-question-005
+  template: "{% if false %}{% elsif x == ? %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-dash-006
+  template: "{% if false %}{% elsif x == - %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-dot-007
+  template: "{% if false %}{% elsif x == . %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-dotdot-008
+  template: "{% if false %}{% elsif x == .. %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-009
+  template: "{% if false %}{% elsif x == == %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-010
+  template: "{% if false %}{% elsif x == != %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-011
+  template: "{% if false %}{% elsif x == < %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-012
+  template: "{% if false %}{% elsif x == > %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-013
+  template: "{% if false %}{% elsif x == <= %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-014
+  template: "{% if false %}{% elsif x == >= %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-015
+  template: "{% if false %}{% elsif x == contains %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-eos-016
+  template: "{% if false %}{% elsif x == %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-bare_bracket
+  template: "{% if false %}{% elsif x == [0] %}{% endif %}"
+  error_path: elsif_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-trailing_dot
+  template: "{% if false %}{% elsif x == x. %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-dot_number
+  template: "{% if false %}{% elsif x == x.123 %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-dot_string
+  template: '{% if false %}{% elsif x == x."y" %}{% endif %}'
+  error_path: elsif_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-unclosed_bracket
+  template: "{% if false %}{% elsif x == x[0 %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-bracket_wrong_content
+  template: "{% if false %}{% elsif x == x[,] %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-unclosed_range
+  template: "{% if false %}{% elsif x == (1..5 %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-range_bad_separator
+  template: "{% if false %}{% elsif x == (1, 5) %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-range_missing_end
+  template: "{% if false %}{% elsif x == (1..) %}{% endif %}"
+  error_path: elsif_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-at
+  template: "{% if false %}{% elsif x == @ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-hash
+  template: "{% if false %}{% elsif x == # %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-dollar
+  template: "{% if false %}{% elsif x == $ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-caret
+  template: "{% if false %}{% elsif x == ^ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-ampersand
+  template: "{% if false %}{% elsif x == & %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-asterisk
+  template: "{% if false %}{% elsif x == * %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-tilde
+  template: "{% if false %}{% elsif x == ~ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-backtick
+  template: "{% if false %}{% elsif x == ` %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-backslash
+  template: "{% if false %}{% elsif x == \\ %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-semicolon
+  template: "{% if false %}{% elsif x == ; %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif x == "hello %}{% endif %}'
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif x == 'hello %}{% endif %}"
+  error_path: elsif_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_op-eos
+  template: "{% if false %}{% elsif x and %}{% endif %}"
+  error_path: elsif_boolean_op
+- id: if_elsif-mut-elsif_boolean_op-number
+  template: "{% if false %}{% elsif x and 42 %}{% endif %}"
+  error_path: elsif_boolean_op
+- id: if_elsif-mut-elsif_boolean_op-lexerr-at
+  template: "{% if false %}{% elsif x and @ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-hash
+  template: "{% if false %}{% elsif x and # %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-dollar
+  template: "{% if false %}{% elsif x and $ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-caret
+  template: "{% if false %}{% elsif x and ^ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-ampersand
+  template: "{% if false %}{% elsif x and & %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-asterisk
+  template: "{% if false %}{% elsif x and * %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-tilde
+  template: "{% if false %}{% elsif x and ~ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-backtick
+  template: "{% if false %}{% elsif x and ` %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-backslash
+  template: "{% if false %}{% elsif x and \\ %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-semicolon
+  template: "{% if false %}{% elsif x and ; %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif x and "hello %}{% endif %}'
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_op-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif x and 'hello %}{% endif %}"
+  error_path: elsif_boolean_op/lexer
+- id: if_elsif-mut-elsif_boolean_expr-pipe-000
+  template: "{% if false %}{% elsif x and x | %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-comma-001
+  template: "{% if false %}{% elsif x and x , %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-colon-002
+  template: "{% if false %}{% elsif x and x : %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-close_square-003
+  template: "{% if false %}{% elsif x and x ] %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-close_round-004
+  template: "{% if false %}{% elsif x and x ) %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-question-005
+  template: "{% if false %}{% elsif x and x ? %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-dash-006
+  template: "{% if false %}{% elsif x and x - %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-dot-007
+  template: "{% if false %}{% elsif x and x . %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-dotdot-008
+  template: "{% if false %}{% elsif x and x .. %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-comparison-009
+  template: "{% if false %}{% elsif x and x == %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-comparison-010
+  template: "{% if false %}{% elsif x and x != %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-comparison-011
+  template: "{% if false %}{% elsif x and x < %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-comparison-012
+  template: "{% if false %}{% elsif x and x > %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-comparison-013
+  template: "{% if false %}{% elsif x and x <= %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-comparison-014
+  template: "{% if false %}{% elsif x and x >= %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-comparison-015
+  template: "{% if false %}{% elsif x and x contains %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-eos-016
+  template: "{% if false %}{% elsif x and x %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-bare_bracket
+  template: "{% if false %}{% elsif x and x [0] %}{% endif %}"
+  error_path: elsif_boolean_expr/bad_start
+- id: if_elsif-mut-elsif_boolean_expr-lookup-trailing_dot
+  template: "{% if false %}{% elsif x and x x. %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: if_elsif-mut-elsif_boolean_expr-lookup-dot_number
+  template: "{% if false %}{% elsif x and x x.123 %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: if_elsif-mut-elsif_boolean_expr-lookup-dot_string
+  template: '{% if false %}{% elsif x and x x."y" %}{% endif %}'
+  error_path: elsif_boolean_expr/lookup
+- id: if_elsif-mut-elsif_boolean_expr-lookup-unclosed_bracket
+  template: "{% if false %}{% elsif x and x x[0 %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: if_elsif-mut-elsif_boolean_expr-lookup-bracket_wrong_content
+  template: "{% if false %}{% elsif x and x x[,] %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: if_elsif-mut-elsif_boolean_expr-lookup-unclosed_range
+  template: "{% if false %}{% elsif x and x (1..5 %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: if_elsif-mut-elsif_boolean_expr-lookup-range_bad_separator
+  template: "{% if false %}{% elsif x and x (1, 5) %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: if_elsif-mut-elsif_boolean_expr-lookup-range_missing_end
+  template: "{% if false %}{% elsif x and x (1..) %}{% endif %}"
+  error_path: elsif_boolean_expr/lookup
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-at
+  template: "{% if false %}{% elsif x and x @ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-hash
+  template: "{% if false %}{% elsif x and x # %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-dollar
+  template: "{% if false %}{% elsif x and x $ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-caret
+  template: "{% if false %}{% elsif x and x ^ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-ampersand
+  template: "{% if false %}{% elsif x and x & %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-asterisk
+  template: "{% if false %}{% elsif x and x * %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-tilde
+  template: "{% if false %}{% elsif x and x ~ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-backtick
+  template: "{% if false %}{% elsif x and x ` %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-backslash
+  template: "{% if false %}{% elsif x and x \\ %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-semicolon
+  template: "{% if false %}{% elsif x and x ; %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif x and x "hello %}{% endif %}'
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif x and x 'hello %}{% endif %}"
+  error_path: elsif_boolean_expr/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-pipe-000
+  template: "{% if false %}{% elsif x and x x == | %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comma-001
+  template: "{% if false %}{% elsif x and x x == , %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-colon-002
+  template: "{% if false %}{% elsif x and x x == : %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-close_square-003
+  template: "{% if false %}{% elsif x and x x == ] %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-close_round-004
+  template: "{% if false %}{% elsif x and x x == ) %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-question-005
+  template: "{% if false %}{% elsif x and x x == ? %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-dash-006
+  template: "{% if false %}{% elsif x and x x == - %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-dot-007
+  template: "{% if false %}{% elsif x and x x == . %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-dotdot-008
+  template: "{% if false %}{% elsif x and x x == .. %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-009
+  template: "{% if false %}{% elsif x and x x == == %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-010
+  template: "{% if false %}{% elsif x and x x == != %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-011
+  template: "{% if false %}{% elsif x and x x == < %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-012
+  template: "{% if false %}{% elsif x and x x == > %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-013
+  template: "{% if false %}{% elsif x and x x == <= %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-014
+  template: "{% if false %}{% elsif x and x x == >= %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-015
+  template: "{% if false %}{% elsif x and x x == contains %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-eos-016
+  template: "{% if false %}{% elsif x and x x == %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-bare_bracket
+  template: "{% if false %}{% elsif x and x x == [0] %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/bad_start
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-trailing_dot
+  template: "{% if false %}{% elsif x and x x == x. %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-dot_number
+  template: "{% if false %}{% elsif x and x x == x.123 %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-dot_string
+  template: '{% if false %}{% elsif x and x x == x."y" %}{% endif %}'
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-unclosed_bracket
+  template: "{% if false %}{% elsif x and x x == x[0 %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-bracket_wrong_content
+  template: "{% if false %}{% elsif x and x x == x[,] %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-unclosed_range
+  template: "{% if false %}{% elsif x and x x == (1..5 %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-range_bad_separator
+  template: "{% if false %}{% elsif x and x x == (1, 5) %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-range_missing_end
+  template: "{% if false %}{% elsif x and x x == (1..) %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lookup
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-at
+  template: "{% if false %}{% elsif x and x x == @ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-hash
+  template: "{% if false %}{% elsif x and x x == # %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-dollar
+  template: "{% if false %}{% elsif x and x x == $ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-caret
+  template: "{% if false %}{% elsif x and x x == ^ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-ampersand
+  template: "{% if false %}{% elsif x and x x == & %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-asterisk
+  template: "{% if false %}{% elsif x and x x == * %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-tilde
+  template: "{% if false %}{% elsif x and x x == ~ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-backtick
+  template: "{% if false %}{% elsif x and x x == ` %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-backslash
+  template: "{% if false %}{% elsif x and x x == \\ %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-semicolon
+  template: "{% if false %}{% elsif x and x x == ; %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% if false %}{% elsif x and x x == "hello %}{% endif %}'
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% if false %}{% elsif x and x x == 'hello %}{% endif %}"
+  error_path: elsif_boolean_comparison_rhs/lexer
+- id: if_elsif-mut-elsif_end-trail-id
+  template: "{% if false %}{% elsif x extra %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-number
+  template: "{% if false %}{% elsif x 42 %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-string
+  template: "{% if false %}{% elsif x 'hi' %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-pipe
+  template: "{% if false %}{% elsif x | %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-colon
+  template: "{% if false %}{% elsif x : %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-comma
+  template: "{% if false %}{% elsif x , %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-open_square
+  template: "{% if false %}{% elsif x [ %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-close_square
+  template: "{% if false %}{% elsif x ] %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-open_round
+  template: "{% if false %}{% elsif x ( %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-close_round
+  template: "{% if false %}{% elsif x ) %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-question
+  template: "{% if false %}{% elsif x ? %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-dot
+  template: "{% if false %}{% elsif x . %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-comparison
+  template: "{% if false %}{% elsif x == %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-elsif_end-trail-dash
+  template: "{% if false %}{% elsif x - %}{% endif %}"
+  error_path: elsif_end
+- id: if_elsif-mut-valid-000
+  template: "{% if false %}{% elsif x %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-001
+  template: "{% if false %}{% elsif 42 %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-002
+  template: "{% if false %}{% elsif 3.14 %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-003
+  template: "{% if false %}{% elsif -5 %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-004
+  template: "{% if false %}{% elsif 'hello' %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-005
+  template: "{% if false %}{% elsif true %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-006
+  template: "{% if false %}{% elsif false %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-007
+  template: "{% if false %}{% elsif nil %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-008
+  template: "{% if false %}{% elsif blank %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-009
+  template: "{% if false %}{% elsif empty %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-010
+  template: "{% if false %}{% elsif product.title %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-011
+  template: "{% if false %}{% elsif products[0] %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-012
+  template: "{% if false %}{% elsif a.b.c %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-013
+  template: "{% if false %}{% elsif a[0].b %}{% endif %}"
+  error_path: valid
+- id: if_elsif-mut-valid-014
+  template: "{% if false %}{% elsif (1..5) %}{% endif %}"
+  error_path: valid
+- id: if-branch-when-in-if
+  template: "{% if true %}{% when x %}{% endif %}"
+  error_path: unknown_tag
+- id: if-branch-else-valid
+  template: "{% if true %}{% else %}{% endif %}"
+  error_path: valid
+- id: if-themecheck-skipped-prefix
+  template: "{% if !product.available %}{% endif %}"
+  error_path: condition

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/ifchanged.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/ifchanged.yml
@@ -1,0 +1,63 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: ifchanged-100
+  template: "{% ifchanged %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-101
+  template: "{%- ifchanged %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-102
+  template: "{% ifchanged -%}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-103
+  template: "{%- ifchanged -%}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-104
+  template: "{%  ifchanged   %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-200
+  template: "{% ifchanged x %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-201
+  template: "{% ifchanged 123 %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-202
+  template: "{% ifchanged 'hello' %}world{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-203
+  template: "{% ifchanged i | plus: 1 %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-204
+  template: "{% ifchanged == %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-205
+  template: "{% ifchanged x y z %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-206
+  template: "{% ifchanged @ # $ %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-207
+  template: "{% ifchanged | %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-208
+  template: "{% ifchanged . %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-209
+  template: "{% ifchanged [0] %}hello{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-300
+  template: "{% ifchanged %}{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-301
+  template: "{% ifchanged garbage %}{% endifchanged %}"
+  error_path: 0
+- id: ifchanged-302
+  template: "{% for i in (1..5) %}{% ifchanged %}{{ i }}{% endifchanged %}{% endfor
+    %}"
+  error_path: 0
+- id: ifchanged-303
+  template: "{{ shop.name }}"
+  error_path: 0
+- id: ifchanged-themecheck-nested-block
+  template: "{% ifchanged %}{% ifchanged %}inner{% endifchanged %}{% endifchanged %}"
+  error_path: 0

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/include.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/include.yml
@@ -1,0 +1,527 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: include-mut-template_expr-pipe-000
+  template: "{% include | %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-comma-001
+  template: "{% include , %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-colon-002
+  template: "{% include : %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-close_square-003
+  template: "{% include ] %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-close_round-004
+  template: "{% include ) %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-question-005
+  template: "{% include ? %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-dash-006
+  template: "{% include - %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-dot-007
+  template: "{% include . %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-dotdot-008
+  template: "{% include .. %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-comparison-009
+  template: "{% include == %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-comparison-010
+  template: "{% include != %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-comparison-011
+  template: "{% include < %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-comparison-012
+  template: "{% include > %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-comparison-013
+  template: "{% include <= %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-comparison-014
+  template: "{% include >= %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-comparison-015
+  template: "{% include contains %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-eos-016
+  template: "{% include  %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-bare_bracket
+  template: "{% include [0] %}"
+  error_path: template_expr/bad_start
+- id: include-mut-template_expr-lookup-trailing_dot
+  template: "{% include x. %}"
+  error_path: template_expr/lookup
+- id: include-mut-template_expr-lookup-dot_number
+  template: "{% include x.123 %}"
+  error_path: template_expr/lookup
+- id: include-mut-template_expr-lookup-dot_string
+  template: '{% include x."y" %}'
+  error_path: template_expr/lookup
+- id: include-mut-template_expr-lookup-unclosed_bracket
+  template: "{% include x[0 %}"
+  error_path: template_expr/lookup
+- id: include-mut-template_expr-lookup-bracket_wrong_content
+  template: "{% include x[,] %}"
+  error_path: template_expr/lookup
+- id: include-mut-template_expr-lookup-unclosed_range
+  template: "{% include (1..5 %}"
+  error_path: template_expr/lookup
+- id: include-mut-template_expr-lookup-range_bad_separator
+  template: "{% include (1, 5) %}"
+  error_path: template_expr/lookup
+- id: include-mut-template_expr-lookup-range_missing_end
+  template: "{% include (1..) %}"
+  error_path: template_expr/lookup
+- id: include-mut-template_expr-lexerr-at
+  template: "{% include @ %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-hash
+  template: "{% include # %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-dollar
+  template: "{% include $ %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-caret
+  template: "{% include ^ %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-ampersand
+  template: "{% include & %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-asterisk
+  template: "{% include * %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-tilde
+  template: "{% include ~ %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-backtick
+  template: "{% include ` %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-backslash
+  template: "{% include \\ %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-semicolon
+  template: "{% include ; %}"
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-unclosed_double_quote
+  template: '{% include "hello %}'
+  error_path: template_expr/lexer
+- id: include-mut-template_expr-lexerr-unclosed_single_quote
+  template: "{% include 'hello %}"
+  error_path: template_expr/lexer
+- id: include-mut-binding_keyword-id
+  template: "{% include x with %}"
+  error_path: binding_keyword
+- id: include-mut-binding_value-pipe-000
+  template: "{% include x for | %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-comma-001
+  template: "{% include x for , %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-colon-002
+  template: "{% include x for : %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-close_square-003
+  template: "{% include x for ] %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-close_round-004
+  template: "{% include x for ) %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-question-005
+  template: "{% include x for ? %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-dash-006
+  template: "{% include x for - %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-dot-007
+  template: "{% include x for . %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-dotdot-008
+  template: "{% include x for .. %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-comparison-009
+  template: "{% include x for == %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-comparison-010
+  template: "{% include x for != %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-comparison-011
+  template: "{% include x for < %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-comparison-012
+  template: "{% include x for > %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-comparison-013
+  template: "{% include x for <= %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-comparison-014
+  template: "{% include x for >= %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-comparison-015
+  template: "{% include x for contains %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-eos-016
+  template: "{% include x for %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-bare_bracket
+  template: "{% include x for [0] %}"
+  error_path: binding_value/bad_start
+- id: include-mut-binding_value-lookup-trailing_dot
+  template: "{% include x for x. %}"
+  error_path: binding_value/lookup
+- id: include-mut-binding_value-lookup-dot_number
+  template: "{% include x for x.123 %}"
+  error_path: binding_value/lookup
+- id: include-mut-binding_value-lookup-dot_string
+  template: '{% include x for x."y" %}'
+  error_path: binding_value/lookup
+- id: include-mut-binding_value-lookup-unclosed_bracket
+  template: "{% include x for x[0 %}"
+  error_path: binding_value/lookup
+- id: include-mut-binding_value-lookup-bracket_wrong_content
+  template: "{% include x for x[,] %}"
+  error_path: binding_value/lookup
+- id: include-mut-binding_value-lookup-unclosed_range
+  template: "{% include x for (1..5 %}"
+  error_path: binding_value/lookup
+- id: include-mut-binding_value-lookup-range_bad_separator
+  template: "{% include x for (1, 5) %}"
+  error_path: binding_value/lookup
+- id: include-mut-binding_value-lookup-range_missing_end
+  template: "{% include x for (1..) %}"
+  error_path: binding_value/lookup
+- id: include-mut-binding_value-lexerr-at
+  template: "{% include x for @ %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-hash
+  template: "{% include x for # %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-dollar
+  template: "{% include x for $ %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-caret
+  template: "{% include x for ^ %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-ampersand
+  template: "{% include x for & %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-asterisk
+  template: "{% include x for * %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-tilde
+  template: "{% include x for ~ %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-backtick
+  template: "{% include x for ` %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-backslash
+  template: "{% include x for \\ %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-semicolon
+  template: "{% include x for ; %}"
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-unclosed_double_quote
+  template: '{% include x for "hello %}'
+  error_path: binding_value/lexer
+- id: include-mut-binding_value-lexerr-unclosed_single_quote
+  template: "{% include x for 'hello %}"
+  error_path: binding_value/lexer
+- id: include-mut-alias_name-eos
+  template: "{% include x as %}"
+  error_path: alias_name
+- id: include-mut-alias_name-number
+  template: "{% include x as 42 %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-at
+  template: "{% include x as @ %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-hash
+  template: "{% include x as # %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-dollar
+  template: "{% include x as $ %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-caret
+  template: "{% include x as ^ %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-ampersand
+  template: "{% include x as & %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-asterisk
+  template: "{% include x as * %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-tilde
+  template: "{% include x as ~ %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-backtick
+  template: "{% include x as ` %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-backslash
+  template: "{% include x as \\ %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-semicolon
+  template: "{% include x as ; %}"
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-unclosed_double_quote
+  template: '{% include x as "hello %}'
+  error_path: alias_name
+- id: include-mut-alias_name-lexerr-unclosed_single_quote
+  template: "{% include x as 'hello %}"
+  error_path: alias_name
+- id: include-mut-kwarg_name-eos
+  template: "{% include x step , %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-number
+  template: "{% include x step , 42 %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-at
+  template: "{% include x step , @ %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-hash
+  template: "{% include x step , # %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-dollar
+  template: "{% include x step , $ %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-caret
+  template: "{% include x step , ^ %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-ampersand
+  template: "{% include x step , & %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-asterisk
+  template: "{% include x step , * %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-tilde
+  template: "{% include x step , ~ %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-backtick
+  template: "{% include x step , ` %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-backslash
+  template: "{% include x step , \\ %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-semicolon
+  template: "{% include x step , ; %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-unclosed_double_quote
+  template: '{% include x step , "hello %}'
+  error_path: kwarg_name
+- id: include-mut-kwarg_name-lexerr-unclosed_single_quote
+  template: "{% include x step , 'hello %}"
+  error_path: kwarg_name
+- id: include-mut-kwarg_colon-eos
+  template: "{% include x step , x %}"
+  error_path: kwarg_colon
+- id: include-mut-kwarg_colon-number
+  template: "{% include x step , x 42 %}"
+  error_path: kwarg_colon
+- id: include-mut-kwarg_value-pipe-000
+  template: "{% include x step , x : | %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-comma-001
+  template: "{% include x step , x : , %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-colon-002
+  template: "{% include x step , x : : %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-close_square-003
+  template: "{% include x step , x : ] %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-close_round-004
+  template: "{% include x step , x : ) %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-question-005
+  template: "{% include x step , x : ? %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-dash-006
+  template: "{% include x step , x : - %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-dot-007
+  template: "{% include x step , x : . %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-dotdot-008
+  template: "{% include x step , x : .. %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-comparison-009
+  template: "{% include x step , x : == %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-comparison-010
+  template: "{% include x step , x : != %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-comparison-011
+  template: "{% include x step , x : < %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-comparison-012
+  template: "{% include x step , x : > %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-comparison-013
+  template: "{% include x step , x : <= %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-comparison-014
+  template: "{% include x step , x : >= %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-comparison-015
+  template: "{% include x step , x : contains %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-eos-016
+  template: "{% include x step , x : %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-bare_bracket
+  template: "{% include x step , x : [0] %}"
+  error_path: kwarg_value/bad_start
+- id: include-mut-kwarg_value-lookup-trailing_dot
+  template: "{% include x step , x : x. %}"
+  error_path: kwarg_value/lookup
+- id: include-mut-kwarg_value-lookup-dot_number
+  template: "{% include x step , x : x.123 %}"
+  error_path: kwarg_value/lookup
+- id: include-mut-kwarg_value-lookup-dot_string
+  template: '{% include x step , x : x."y" %}'
+  error_path: kwarg_value/lookup
+- id: include-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% include x step , x : x[0 %}"
+  error_path: kwarg_value/lookup
+- id: include-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% include x step , x : x[,] %}"
+  error_path: kwarg_value/lookup
+- id: include-mut-kwarg_value-lookup-unclosed_range
+  template: "{% include x step , x : (1..5 %}"
+  error_path: kwarg_value/lookup
+- id: include-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% include x step , x : (1, 5) %}"
+  error_path: kwarg_value/lookup
+- id: include-mut-kwarg_value-lookup-range_missing_end
+  template: "{% include x step , x : (1..) %}"
+  error_path: kwarg_value/lookup
+- id: include-mut-kwarg_value-lexerr-at
+  template: "{% include x step , x : @ %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-hash
+  template: "{% include x step , x : # %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-dollar
+  template: "{% include x step , x : $ %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-caret
+  template: "{% include x step , x : ^ %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-ampersand
+  template: "{% include x step , x : & %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-asterisk
+  template: "{% include x step , x : * %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-tilde
+  template: "{% include x step , x : ~ %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-backtick
+  template: "{% include x step , x : ` %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-backslash
+  template: "{% include x step , x : \\ %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-semicolon
+  template: "{% include x step , x : ; %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% include x step , x : "hello %}'
+  error_path: kwarg_value/lexer
+- id: include-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% include x step , x : 'hello %}"
+  error_path: kwarg_value/lexer
+- id: include-mut-end-trail-id
+  template: "{% include x extra %}"
+  error_path: end
+- id: include-mut-end-trail-number
+  template: "{% include x 42 %}"
+  error_path: end
+- id: include-mut-end-trail-string
+  template: "{% include x 'hi' %}"
+  error_path: end
+- id: include-mut-end-trail-pipe
+  template: "{% include x | %}"
+  error_path: end
+- id: include-mut-end-trail-colon
+  template: "{% include x : %}"
+  error_path: end
+- id: include-mut-end-trail-comma
+  template: "{% include x , %}"
+  error_path: end
+- id: include-mut-end-trail-open_square
+  template: "{% include x [ %}"
+  error_path: end
+- id: include-mut-end-trail-close_square
+  template: "{% include x ] %}"
+  error_path: end
+- id: include-mut-end-trail-open_round
+  template: "{% include x ( %}"
+  error_path: end
+- id: include-mut-end-trail-close_round
+  template: "{% include x ) %}"
+  error_path: end
+- id: include-mut-end-trail-question
+  template: "{% include x ? %}"
+  error_path: end
+- id: include-mut-end-trail-dot
+  template: "{% include x . %}"
+  error_path: end
+- id: include-mut-end-trail-comparison
+  template: "{% include x == %}"
+  error_path: end
+- id: include-mut-end-trail-dash
+  template: "{% include x - %}"
+  error_path: end
+- id: include-mut-valid-000
+  template: "{% include x %}"
+  error_path: valid
+- id: include-mut-valid-001
+  template: "{% include 42 %}"
+  error_path: valid
+- id: include-mut-valid-002
+  template: "{% include 3.14 %}"
+  error_path: valid
+- id: include-mut-valid-003
+  template: "{% include -5 %}"
+  error_path: valid
+- id: include-mut-valid-004
+  template: "{% include 'hello' %}"
+  error_path: valid
+- id: include-mut-valid-005
+  template: "{% include true %}"
+  error_path: valid
+- id: include-mut-valid-006
+  template: "{% include false %}"
+  error_path: valid
+- id: include-mut-valid-007
+  template: "{% include nil %}"
+  error_path: valid
+- id: include-mut-valid-008
+  template: "{% include blank %}"
+  error_path: valid
+- id: include-mut-valid-009
+  template: "{% include empty %}"
+  error_path: valid
+- id: include-mut-valid-010
+  template: "{% include product.title %}"
+  error_path: valid
+- id: include-mut-valid-011
+  template: "{% include products[0] %}"
+  error_path: valid
+- id: include-mut-valid-012
+  template: "{% include a.b.c %}"
+  error_path: valid
+- id: include-mut-valid-013
+  template: "{% include a[0].b %}"
+  error_path: valid
+- id: include-mut-valid-014
+  template: "{% include (1..5) %}"
+  error_path: valid
+- id: include-themecheck-range-snippet-with-binding
+  template: "{% include (1..5) for products as item %}"
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/increment.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/increment.yml
@@ -1,0 +1,89 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: increment-mut-variable_name-eos
+  template: "{% increment  %}"
+  error_path: variable_name
+- id: increment-mut-variable_name-number
+  template: "{% increment 42 %}"
+  error_path: variable_name
+- id: increment-themecheck-bare-bracket
+  template: "{% increment [0] %}"
+  error_path: variable_name
+- id: increment-mut-variable_name-lexerr-at
+  template: "{% increment @ %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-hash
+  template: "{% increment # %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-dollar
+  template: "{% increment $ %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-caret
+  template: "{% increment ^ %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-ampersand
+  template: "{% increment & %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-asterisk
+  template: "{% increment * %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-tilde
+  template: "{% increment ~ %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-backtick
+  template: "{% increment ` %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-backslash
+  template: "{% increment \\ %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-semicolon
+  template: "{% increment ; %}"
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% increment "hello %}'
+  error_path: variable_name/lexer
+- id: increment-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% increment 'hello %}"
+  error_path: variable_name/lexer
+- id: increment-mut-end-trail-id
+  template: "{% increment x extra %}"
+  error_path: end
+- id: increment-mut-end-trail-number
+  template: "{% increment x 42 %}"
+  error_path: end
+- id: increment-mut-end-trail-string
+  template: "{% increment x 'hi' %}"
+  error_path: end
+- id: increment-mut-end-trail-pipe
+  template: "{% increment x | %}"
+  error_path: end
+- id: increment-mut-end-trail-colon
+  template: "{% increment x : %}"
+  error_path: end
+- id: increment-mut-end-trail-comma
+  template: "{% increment x , %}"
+  error_path: end
+- id: increment-mut-end-trail-open_square
+  template: "{% increment x [ %}"
+  error_path: end
+- id: increment-mut-end-trail-close_square
+  template: "{% increment x ] %}"
+  error_path: end
+- id: increment-mut-end-trail-open_round
+  template: "{% increment x ( %}"
+  error_path: end
+- id: increment-mut-end-trail-close_round
+  template: "{% increment x ) %}"
+  error_path: end
+- id: increment-mut-end-trail-question
+  template: "{% increment x ? %}"
+  error_path: end
+- id: increment-mut-end-trail-dot
+  template: "{% increment x . %}"
+  error_path: end
+- id: increment-mut-end-trail-comparison
+  template: "{% increment x == %}"
+  error_path: end
+- id: increment-mut-end-trail-dash
+  template: "{% increment x - %}"
+  error_path: end

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/inline_comment.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/inline_comment.yml
@@ -1,0 +1,177 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: inline_comment-001
+  template: |-
+    {% #
+    foo %}
+  error_path: 0
+- id: inline_comment-002
+  template: |-
+    {% #
+      foo %}
+  error_path: 0
+- id: inline_comment-003
+  template: |-
+    {% # ok
+    foo %}
+  error_path: 1
+- id: inline_comment-014
+  template: |-
+    {% #ok
+    foo %}
+  error_path: 1
+- id: inline_comment-004
+  template: |-
+    {% # ok
+    # ok
+    foo %}
+  error_path: 1
+- id: inline_comment-005
+  template: |-
+    {% # ok
+
+    foo %}
+  error_path: 1
+- id: inline_comment-006
+  template: "{% #\n\tfoo %}"
+  error_path: 0
+- id: inline_comment-007
+  template: "{% # ok\n \t foo %}"
+  error_path: 1
+- id: inline_comment-008
+  template: |-
+    {% #
+    foo
+    bar %}
+  error_path: 1
+- id: inline_comment-009
+  template: |-
+    {% #
+    123 %}
+  error_path: 0
+- id: inline_comment-010
+  template: |-
+    {% #
+    @ %}
+  error_path: 0
+- id: inline_comment-011
+  template: |-
+    {%- #
+    foo %}
+  error_path: 0
+- id: inline_comment-012
+  template: |-
+    {% #
+    foo -%}
+  error_path: 0
+- id: inline_comment-013
+  template: |-
+    {%- #
+    foo -%}
+  error_path: 0
+- id: inline_comment-100
+  template: "{% # this is a comment %}"
+  error_path: 0
+- id: inline_comment-101
+  template: "{% # %}"
+  error_path: 0
+- id: inline_comment-102
+  template: "{% #%}"
+  error_path: 0
+- id: inline_comment-103
+  template: |-
+    {% # line 1
+    # line 2 %}
+  error_path: 0
+- id: inline_comment-104
+  template: |-
+    {% # line 1
+      # line 2 %}
+  error_path: 0
+- id: inline_comment-105
+  template: |-
+    {% # a
+    # b
+    # c %}
+  error_path: 0
+- id: inline_comment-106
+  template: |-
+    {% # a
+
+    # b %}
+  error_path: 0
+- id: inline_comment-107
+  template: "{% # a\n   \n# b %}"
+  error_path: 0
+- id: inline_comment-108
+  template: "{% # a\n\t\t\n# b %}"
+  error_path: 0
+- id: inline_comment-109
+  template: "{%- # comment %}"
+  error_path: 0
+- id: inline_comment-110
+  template: "{% # comment -%}"
+  error_path: 0
+- id: inline_comment-111
+  template: "{%- # comment -%}"
+  error_path: 0
+- id: inline_comment-112
+  template: "{%  # comment %}"
+  error_path: 0
+- id: inline_comment-113
+  template: "{% # @$%^&* %}"
+  error_path: 0
+- id: inline_comment-114
+  template: "{% # {% if true %} %}"
+  error_path: 0
+- id: inline_comment-115
+  template: |-
+    {% # line
+    #   indented %}
+  error_path: 0
+- id: inline_comment-116
+  template: |-
+    {% # a
+
+
+
+    # b %}
+  error_path: 0
+- id: inline_comment-117
+  template: |-
+    {% # a
+    # %}
+  error_path: 0
+- id: inline_comment-118
+  template: |-
+    {% #
+
+
+     %}
+  error_path: 0
+- id: inline_comment-200
+  template: "{{ shop.name }}"
+  error_path: 0
+- id: inline_comment-201
+  template: "{% comment %}hello{% endcomment %}"
+  error_path: 0
+- id: inline_comment-202
+  template: |-
+    {% # a %}
+    {% # b %}
+  error_path: 0
+- id: inline_comment-203
+  template: |-
+    {% # ok %}
+    {% #
+    foo %}
+  error_path: 0
+- id: inline_comment-204
+  template: "{{ '#' }}"
+  error_path: 0
+- id: inline_comment-205
+  template: "{% assign x = '#' %}"
+  error_path: 0
+- id: inline_comment-themecheck-no-space-prefixed-continuation
+  template: "{% #hello\n#world %}"
+  error_path: 0

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/javascript.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/javascript.yml
@@ -1,0 +1,102 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: javascript-001
+  template: "{% javascript foo %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-002
+  template: "{% javascript foo bar %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-003
+  template: "{% javascript 123 %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-004
+  template: "{% javascript 'hello' %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-005
+  template: "{% javascript == %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-006
+  template: "{% javascript | %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-007
+  template: "{% javascript @#$ %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-008
+  template: "{% javascript . %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-009
+  template: "{% javascript : %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-010
+  template: "{% javascript x = 1 %}{% endjavascript %}"
+  error_path: markup
+- id: javascript-011
+  template: "{%- javascript foo -%}{%- endjavascript -%}"
+  error_path: markup
+- id: javascript-012
+  template: "{% javascript foo %}content"
+  error_path: markup
+- id: javascript-020
+  template: "{% javascript %}"
+  error_path: unclosed
+- id: javascript-021
+  template: "{% javascript %}some content"
+  error_path: unclosed
+- id: javascript-022
+  template: "{% javascript %}{% if true %}{% endif %}"
+  error_path: unclosed
+- id: javascript-023
+  template: "{%- javascript -%}content"
+  error_path: unclosed
+- id: javascript-024
+  template: "{% javascript %}a{% endjavascript %}{% javascript %}b"
+  error_path: unclosed
+- id: javascript-025
+  template: |-
+    hello
+
+    {% javascript %}content
+  error_path: unclosed
+- id: javascript-026
+  template: "{% javascript %}{% javascript %}content"
+  error_path: unclosed
+- id: javascript-100
+  template: "{% javascript %}content{% endjavascript %}"
+  error_path: valid
+- id: javascript-101
+  template: "{% javascript %}{% endjavascript %}"
+  error_path: valid
+- id: javascript-102
+  template: "{% javascript %}{{ x }} {% if true %}{% endif %}{% endjavascript %}"
+  error_path: valid
+- id: javascript-103
+  template: "{%- javascript -%}c{%- endjavascript -%}"
+  error_path: valid
+- id: javascript-104
+  template: "{%  javascript   %}c{%  endjavascript   %}"
+  error_path: valid
+- id: javascript-105
+  template: "{% javascript %}a{% endjavascript %}{% javascript %}b{% endjavascript %}"
+  error_path: valid
+- id: javascript-106
+  template: hello{% javascript %}world{% endjavascript %}bye
+  error_path: valid
+- id: javascript-107
+  template: "{% javascript %}c{% endjavascript foo %}"
+  error_path: valid
+- id: javascript-108
+  template: |-
+    {% javascript %}
+    line1
+    line2
+    {% endjavascript %}
+  error_path: valid
+- id: javascript-109
+  template: "{% javascript %}{% javascript %}inner{% endjavascript %}"
+  error_path: valid
+- id: javascript-themecheck-prefixed-closing
+  template: "{% javascript %}console.log('x');{% endjavascriptx foo %}"
+  error_path: themecheck_prefixed_closing
+- id: javascript-200
+  template: "{% endjavascript %}"
+  error_path: unknown_end_tag

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/layout.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/layout.yml
@@ -1,0 +1,206 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: layout-mut-layout_expr-pipe-000
+  template: "{% layout | %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-comma-001
+  template: "{% layout , %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-colon-002
+  template: "{% layout : %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-close_square-003
+  template: "{% layout ] %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-close_round-004
+  template: "{% layout ) %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-question-005
+  template: "{% layout ? %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-dash-006
+  template: "{% layout - %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-dot-007
+  template: "{% layout . %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-dotdot-008
+  template: "{% layout .. %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-comparison-009
+  template: "{% layout == %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-comparison-010
+  template: "{% layout != %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-comparison-011
+  template: "{% layout < %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-comparison-012
+  template: "{% layout > %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-comparison-013
+  template: "{% layout <= %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-comparison-014
+  template: "{% layout >= %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-comparison-015
+  template: "{% layout contains %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-eos-016
+  template: "{% layout  %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-bare_bracket
+  template: "{% layout [0] %}"
+  error_path: layout_expr/bad_start
+- id: layout-mut-layout_expr-lookup-trailing_dot
+  template: "{% layout x. %}"
+  error_path: layout_expr/lookup
+- id: layout-mut-layout_expr-lookup-dot_number
+  template: "{% layout x.123 %}"
+  error_path: layout_expr/lookup
+- id: layout-mut-layout_expr-lookup-dot_string
+  template: '{% layout x."y" %}'
+  error_path: layout_expr/lookup
+- id: layout-mut-layout_expr-lookup-unclosed_bracket
+  template: "{% layout x[0 %}"
+  error_path: layout_expr/lookup
+- id: layout-mut-layout_expr-lookup-bracket_wrong_content
+  template: "{% layout x[,] %}"
+  error_path: layout_expr/lookup
+- id: layout-mut-layout_expr-lookup-unclosed_range
+  template: "{% layout (1..5 %}"
+  error_path: layout_expr/lookup
+- id: layout-mut-layout_expr-lookup-range_bad_separator
+  template: "{% layout (1, 5) %}"
+  error_path: layout_expr/lookup
+- id: layout-mut-layout_expr-lookup-range_missing_end
+  template: "{% layout (1..) %}"
+  error_path: layout_expr/lookup
+- id: layout-mut-layout_expr-lexerr-at
+  template: "{% layout @ %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-hash
+  template: "{% layout # %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-dollar
+  template: "{% layout $ %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-caret
+  template: "{% layout ^ %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-ampersand
+  template: "{% layout & %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-asterisk
+  template: "{% layout * %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-tilde
+  template: "{% layout ~ %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-backtick
+  template: "{% layout ` %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-backslash
+  template: "{% layout \\ %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-semicolon
+  template: "{% layout ; %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-unclosed_double_quote
+  template: '{% layout "hello %}'
+  error_path: layout_expr/lexer
+- id: layout-mut-layout_expr-lexerr-unclosed_single_quote
+  template: "{% layout 'hello %}"
+  error_path: layout_expr/lexer
+- id: layout-mut-end-trail-id
+  template: "{% layout x extra %}"
+  error_path: end
+- id: layout-mut-end-trail-number
+  template: "{% layout x 42 %}"
+  error_path: end
+- id: layout-mut-end-trail-string
+  template: "{% layout x 'hi' %}"
+  error_path: end
+- id: layout-mut-end-trail-pipe
+  template: "{% layout x | %}"
+  error_path: end
+- id: layout-mut-end-trail-colon
+  template: "{% layout x : %}"
+  error_path: end
+- id: layout-mut-end-trail-comma
+  template: "{% layout x , %}"
+  error_path: end
+- id: layout-mut-end-trail-open_square
+  template: "{% layout x [ %}"
+  error_path: end
+- id: layout-mut-end-trail-close_square
+  template: "{% layout x ] %}"
+  error_path: end
+- id: layout-mut-end-trail-open_round
+  template: "{% layout x ( %}"
+  error_path: end
+- id: layout-mut-end-trail-close_round
+  template: "{% layout x ) %}"
+  error_path: end
+- id: layout-mut-end-trail-question
+  template: "{% layout x ? %}"
+  error_path: end
+- id: layout-mut-end-trail-dot
+  template: "{% layout x . %}"
+  error_path: end
+- id: layout-mut-end-trail-comparison
+  template: "{% layout x == %}"
+  error_path: end
+- id: layout-mut-end-trail-dash
+  template: "{% layout x - %}"
+  error_path: end
+- id: layout-mut-valid-000
+  template: "{% layout x %}"
+  error_path: valid
+- id: layout-mut-valid-001
+  template: "{% layout 42 %}"
+  error_path: valid
+- id: layout-mut-valid-002
+  template: "{% layout 3.14 %}"
+  error_path: valid
+- id: layout-mut-valid-003
+  template: "{% layout -5 %}"
+  error_path: valid
+- id: layout-mut-valid-004
+  template: "{% layout 'hello' %}"
+  error_path: valid
+- id: layout-mut-valid-005
+  template: "{% layout true %}"
+  error_path: valid
+- id: layout-mut-valid-006
+  template: "{% layout false %}"
+  error_path: valid
+- id: layout-mut-valid-007
+  template: "{% layout nil %}"
+  error_path: valid
+- id: layout-mut-valid-008
+  template: "{% layout blank %}"
+  error_path: valid
+- id: layout-mut-valid-009
+  template: "{% layout empty %}"
+  error_path: valid
+- id: layout-mut-valid-010
+  template: "{% layout product.title %}"
+  error_path: valid
+- id: layout-mut-valid-011
+  template: "{% layout products[0] %}"
+  error_path: valid
+- id: layout-mut-valid-012
+  template: "{% layout a.b.c %}"
+  error_path: valid
+- id: layout-mut-valid-013
+  template: "{% layout a[0].b %}"
+  error_path: valid
+- id: layout-mut-valid-014
+  template: "{% layout (1..5) %}"
+  error_path: valid
+- id: layout-themecheck-false-trailing-markup
+  template: "{% layout false extra %}"
+  error_path: end

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/liquid.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/liquid.yml
@@ -1,0 +1,103 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: liquid-100
+  template: "{% liquid %}"
+  error_path:
+- id: liquid-101
+  template: |-
+    {% liquid
+    assign x = 1
+    %}
+  error_path:
+- id: liquid-102
+  template: |-
+    {% liquid
+    assign x = 1
+    echo x
+    %}
+  error_path:
+- id: liquid-103
+  template: |-
+    {% liquid
+    for i in (1..3)
+    echo i
+    endfor
+    %}
+  error_path:
+- id: liquid-themecheck-capture-block
+  template: |-
+    {% liquid
+    capture title
+    echo product.title
+    endcapture
+    %}
+  error_path:
+- id: liquid-104
+  template: |-
+    {%- liquid
+    assign x = 1
+    -%}
+  error_path:
+- id: liquid-105
+  template: |-
+    {% liquid
+
+
+    %}
+  error_path:
+- id: liquid-200
+  template: |-
+    {% liquid
+    hello world
+    %}
+  error_path: 1
+- id: liquid-201
+  template: |-
+    {% liquid
+    foobar baz
+    %}
+  error_path: 1
+- id: liquid-203
+  template: |-
+    {% liquid
+    endfor
+    %}
+  error_path: 1
+- id: liquid-204
+  template: |-
+    {% liquid
+    assign
+    %}
+  error_path: 1
+- id: liquid-205
+  template: |-
+    {% liquid
+    assign x = 1
+    assign
+    %}
+  error_path: 1
+- id: liquid-206
+  template: |-
+    {% liquid
+    echo
+    %}
+  error_path:
+- id: liquid-207
+  template: |-
+    {% liquid
+    for i
+    %}
+  error_path: 1
+- id: liquid-208
+  template: |-
+    {% liquid
+    for i in (1..3)
+    echo i
+    %}
+  error_path: 1
+- id: liquid-branch-else-top-level
+  template: "{% else %}"
+  error_path: unknown_tag
+- id: liquid-branch-when-top-level
+  template: "{% when x %}"
+  error_path: unknown_tag

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/paginate.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/paginate.yml
@@ -1,0 +1,488 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: paginate-mut-collection_expr-pipe-000
+  template: "{% paginate | %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-comma-001
+  template: "{% paginate , %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-colon-002
+  template: "{% paginate : %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-close_square-003
+  template: "{% paginate ] %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-close_round-004
+  template: "{% paginate ) %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-question-005
+  template: "{% paginate ? %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-dash-006
+  template: "{% paginate - %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-dot-007
+  template: "{% paginate . %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-dotdot-008
+  template: "{% paginate .. %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-comparison-009
+  template: "{% paginate == %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-comparison-010
+  template: "{% paginate != %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-comparison-011
+  template: "{% paginate < %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-comparison-012
+  template: "{% paginate > %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-comparison-013
+  template: "{% paginate <= %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-comparison-014
+  template: "{% paginate >= %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-comparison-015
+  template: "{% paginate contains %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-eos-016
+  template: "{% paginate  %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-bare_bracket
+  template: "{% paginate [0] %}{% endpaginate %}"
+  error_path: collection_expr/bad_start
+- id: paginate-mut-collection_expr-lookup-trailing_dot
+  template: "{% paginate x. %}{% endpaginate %}"
+  error_path: collection_expr/lookup
+- id: paginate-mut-collection_expr-lookup-dot_number
+  template: "{% paginate x.123 %}{% endpaginate %}"
+  error_path: collection_expr/lookup
+- id: paginate-mut-collection_expr-lookup-dot_string
+  template: '{% paginate x."y" %}{% endpaginate %}'
+  error_path: collection_expr/lookup
+- id: paginate-mut-collection_expr-lookup-unclosed_bracket
+  template: "{% paginate x[0 %}{% endpaginate %}"
+  error_path: collection_expr/lookup
+- id: paginate-mut-collection_expr-lookup-bracket_wrong_content
+  template: "{% paginate x[,] %}{% endpaginate %}"
+  error_path: collection_expr/lookup
+- id: paginate-mut-collection_expr-lookup-unclosed_range
+  template: "{% paginate (1..5 %}{% endpaginate %}"
+  error_path: collection_expr/lookup
+- id: paginate-mut-collection_expr-lookup-range_bad_separator
+  template: "{% paginate (1, 5) %}{% endpaginate %}"
+  error_path: collection_expr/lookup
+- id: paginate-mut-collection_expr-lookup-range_missing_end
+  template: "{% paginate (1..) %}{% endpaginate %}"
+  error_path: collection_expr/lookup
+- id: paginate-mut-collection_expr-lexerr-at
+  template: "{% paginate @ %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-hash
+  template: "{% paginate # %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-dollar
+  template: "{% paginate $ %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-caret
+  template: "{% paginate ^ %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-ampersand
+  template: "{% paginate & %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-asterisk
+  template: "{% paginate * %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-tilde
+  template: "{% paginate ~ %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-backtick
+  template: "{% paginate ` %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-backslash
+  template: "{% paginate \\ %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-semicolon
+  template: "{% paginate ; %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-unclosed_double_quote
+  template: '{% paginate "hello %}{% endpaginate %}'
+  error_path: collection_expr/lexer
+- id: paginate-mut-collection_expr-lexerr-unclosed_single_quote
+  template: "{% paginate 'hello %}{% endpaginate %}"
+  error_path: collection_expr/lexer
+- id: paginate-mut-by_keyword-eos
+  template: "{% paginate x %}{% endpaginate %}"
+  error_path: by_keyword
+- id: paginate-mut-by_keyword-id
+  template: "{% paginate x of %}{% endpaginate %}"
+  error_path: by_keyword
+- id: paginate-mut-page_size_expr-pipe-000
+  template: "{% paginate x by | %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-comma-001
+  template: "{% paginate x by , %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-colon-002
+  template: "{% paginate x by : %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-close_square-003
+  template: "{% paginate x by ] %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-close_round-004
+  template: "{% paginate x by ) %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-question-005
+  template: "{% paginate x by ? %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-dash-006
+  template: "{% paginate x by - %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-dot-007
+  template: "{% paginate x by . %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-dotdot-008
+  template: "{% paginate x by .. %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-comparison-009
+  template: "{% paginate x by == %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-comparison-010
+  template: "{% paginate x by != %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-comparison-011
+  template: "{% paginate x by < %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-comparison-012
+  template: "{% paginate x by > %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-comparison-013
+  template: "{% paginate x by <= %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-comparison-014
+  template: "{% paginate x by >= %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-comparison-015
+  template: "{% paginate x by contains %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-eos-016
+  template: "{% paginate x by %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-bare_bracket
+  template: "{% paginate x by [0] %}{% endpaginate %}"
+  error_path: page_size_expr/bad_start
+- id: paginate-mut-page_size_expr-lookup-trailing_dot
+  template: "{% paginate x by x. %}{% endpaginate %}"
+  error_path: page_size_expr/lookup
+- id: paginate-mut-page_size_expr-lookup-dot_number
+  template: "{% paginate x by x.123 %}{% endpaginate %}"
+  error_path: page_size_expr/lookup
+- id: paginate-mut-page_size_expr-lookup-dot_string
+  template: '{% paginate x by x."y" %}{% endpaginate %}'
+  error_path: page_size_expr/lookup
+- id: paginate-mut-page_size_expr-lookup-unclosed_bracket
+  template: "{% paginate x by x[0 %}{% endpaginate %}"
+  error_path: page_size_expr/lookup
+- id: paginate-mut-page_size_expr-lookup-bracket_wrong_content
+  template: "{% paginate x by x[,] %}{% endpaginate %}"
+  error_path: page_size_expr/lookup
+- id: paginate-mut-page_size_expr-lookup-unclosed_range
+  template: "{% paginate x by (1..5 %}{% endpaginate %}"
+  error_path: page_size_expr/lookup
+- id: paginate-mut-page_size_expr-lookup-range_bad_separator
+  template: "{% paginate x by (1, 5) %}{% endpaginate %}"
+  error_path: page_size_expr/lookup
+- id: paginate-mut-page_size_expr-lookup-range_missing_end
+  template: "{% paginate x by (1..) %}{% endpaginate %}"
+  error_path: page_size_expr/lookup
+- id: paginate-mut-page_size_expr-lexerr-at
+  template: "{% paginate x by @ %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-hash
+  template: "{% paginate x by # %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-dollar
+  template: "{% paginate x by $ %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-caret
+  template: "{% paginate x by ^ %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-ampersand
+  template: "{% paginate x by & %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-asterisk
+  template: "{% paginate x by * %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-tilde
+  template: "{% paginate x by ~ %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-backtick
+  template: "{% paginate x by ` %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-backslash
+  template: "{% paginate x by \\ %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-semicolon
+  template: "{% paginate x by ; %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-unclosed_double_quote
+  template: '{% paginate x by "hello %}{% endpaginate %}'
+  error_path: page_size_expr/lexer
+- id: paginate-mut-page_size_expr-lexerr-unclosed_single_quote
+  template: "{% paginate x by 'hello %}{% endpaginate %}"
+  error_path: page_size_expr/lexer
+- id: paginate-mut-kwarg_name-eos
+  template: "{% paginate x by x , , %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-number
+  template: "{% paginate x by x , , 42 %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-at
+  template: "{% paginate x by x , , @ %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-hash
+  template: "{% paginate x by x , , # %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-dollar
+  template: "{% paginate x by x , , $ %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-caret
+  template: "{% paginate x by x , , ^ %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-ampersand
+  template: "{% paginate x by x , , & %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-asterisk
+  template: "{% paginate x by x , , * %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-tilde
+  template: "{% paginate x by x , , ~ %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-backtick
+  template: "{% paginate x by x , , ` %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-backslash
+  template: "{% paginate x by x , , \\ %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-semicolon
+  template: "{% paginate x by x , , ; %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-unclosed_double_quote
+  template: '{% paginate x by x , , "hello %}{% endpaginate %}'
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_name-lexerr-unclosed_single_quote
+  template: "{% paginate x by x , , 'hello %}{% endpaginate %}"
+  error_path: kwarg_name
+- id: paginate-mut-kwarg_colon-eos
+  template: "{% paginate x by x , , x %}{% endpaginate %}"
+  error_path: kwarg_colon
+- id: paginate-mut-kwarg_colon-number
+  template: "{% paginate x by x , , x 42 %}{% endpaginate %}"
+  error_path: kwarg_colon
+- id: paginate-mut-kwarg_value-pipe-000
+  template: "{% paginate x by x , , x : | %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-comma-001
+  template: "{% paginate x by x , , x : , %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-colon-002
+  template: "{% paginate x by x , , x : : %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-close_square-003
+  template: "{% paginate x by x , , x : ] %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-close_round-004
+  template: "{% paginate x by x , , x : ) %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-question-005
+  template: "{% paginate x by x , , x : ? %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-dash-006
+  template: "{% paginate x by x , , x : - %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-dot-007
+  template: "{% paginate x by x , , x : . %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-dotdot-008
+  template: "{% paginate x by x , , x : .. %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-comparison-009
+  template: "{% paginate x by x , , x : == %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-comparison-010
+  template: "{% paginate x by x , , x : != %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-comparison-011
+  template: "{% paginate x by x , , x : < %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-comparison-012
+  template: "{% paginate x by x , , x : > %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-comparison-013
+  template: "{% paginate x by x , , x : <= %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-comparison-014
+  template: "{% paginate x by x , , x : >= %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-comparison-015
+  template: "{% paginate x by x , , x : contains %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-eos-016
+  template: "{% paginate x by x , , x : %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-bare_bracket
+  template: "{% paginate x by x , , x : [0] %}{% endpaginate %}"
+  error_path: kwarg_value/bad_start
+- id: paginate-mut-kwarg_value-lookup-trailing_dot
+  template: "{% paginate x by x , , x : x. %}{% endpaginate %}"
+  error_path: kwarg_value/lookup
+- id: paginate-mut-kwarg_value-lookup-dot_number
+  template: "{% paginate x by x , , x : x.123 %}{% endpaginate %}"
+  error_path: kwarg_value/lookup
+- id: paginate-mut-kwarg_value-lookup-dot_string
+  template: '{% paginate x by x , , x : x."y" %}{% endpaginate %}'
+  error_path: kwarg_value/lookup
+- id: paginate-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% paginate x by x , , x : x[0 %}{% endpaginate %}"
+  error_path: kwarg_value/lookup
+- id: paginate-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% paginate x by x , , x : x[,] %}{% endpaginate %}"
+  error_path: kwarg_value/lookup
+- id: paginate-mut-kwarg_value-lookup-unclosed_range
+  template: "{% paginate x by x , , x : (1..5 %}{% endpaginate %}"
+  error_path: kwarg_value/lookup
+- id: paginate-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% paginate x by x , , x : (1, 5) %}{% endpaginate %}"
+  error_path: kwarg_value/lookup
+- id: paginate-mut-kwarg_value-lookup-range_missing_end
+  template: "{% paginate x by x , , x : (1..) %}{% endpaginate %}"
+  error_path: kwarg_value/lookup
+- id: paginate-mut-kwarg_value-lexerr-at
+  template: "{% paginate x by x , , x : @ %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-hash
+  template: "{% paginate x by x , , x : # %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-dollar
+  template: "{% paginate x by x , , x : $ %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-caret
+  template: "{% paginate x by x , , x : ^ %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-ampersand
+  template: "{% paginate x by x , , x : & %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-asterisk
+  template: "{% paginate x by x , , x : * %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-tilde
+  template: "{% paginate x by x , , x : ~ %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-backtick
+  template: "{% paginate x by x , , x : ` %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-backslash
+  template: "{% paginate x by x , , x : \\ %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-semicolon
+  template: "{% paginate x by x , , x : ; %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% paginate x by x , , x : "hello %}{% endpaginate %}'
+  error_path: kwarg_value/lexer
+- id: paginate-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% paginate x by x , , x : 'hello %}{% endpaginate %}"
+  error_path: kwarg_value/lexer
+- id: paginate-mut-end-trail-id
+  template: "{% paginate x by x extra %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-number
+  template: "{% paginate x by x 42 %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-string
+  template: "{% paginate x by x 'hi' %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-pipe
+  template: "{% paginate x by x | %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-colon
+  template: "{% paginate x by x : %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-comma
+  template: "{% paginate x by x , %}{% endpaginate %}"
+  error_path: end
+- id: paginate-themecheck-trailing-comma
+  template: "{% paginate collection.products by 12, %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-open_square
+  template: "{% paginate x by x [ %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-close_square
+  template: "{% paginate x by x ] %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-open_round
+  template: "{% paginate x by x ( %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-close_round
+  template: "{% paginate x by x ) %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-question
+  template: "{% paginate x by x ? %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-dot
+  template: "{% paginate x by x . %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-comparison
+  template: "{% paginate x by x == %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-end-trail-dash
+  template: "{% paginate x by x - %}{% endpaginate %}"
+  error_path: end
+- id: paginate-mut-valid-000
+  template: "{% paginate x by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-001
+  template: "{% paginate 42 by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-002
+  template: "{% paginate 3.14 by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-003
+  template: "{% paginate -5 by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-004
+  template: "{% paginate 'hello' by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-005
+  template: "{% paginate true by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-006
+  template: "{% paginate false by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-007
+  template: "{% paginate nil by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-008
+  template: "{% paginate blank by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-009
+  template: "{% paginate empty by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-010
+  template: "{% paginate product.title by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-011
+  template: "{% paginate products[0] by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-012
+  template: "{% paginate a.b.c by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-013
+  template: "{% paginate a[0].b by x %}{% endpaginate %}"
+  error_path: valid
+- id: paginate-mut-valid-014
+  template: "{% paginate (1..5) by x %}{% endpaginate %}"
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/partial.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/partial.yml
@@ -1,0 +1,23 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: partial-valid-basic
+  template: "{% partial 'product-card' %}{% endpartial %}"
+  error_path: valid
+- id: partial-mut-partial_name-eos
+  template: "{% partial  %}{% endpartial %}"
+  error_path: partial_name
+- id: partial-mut-partial_name-id
+  template: "{% partial x %}{% endpartial %}"
+  error_path: partial_name
+- id: partial-mut-partial_name-invalid
+  template: "{% partial 'bad/name' %}{% endpartial %}"
+  error_path: partial_name_validation
+- id: partial-themecheck-empty-name
+  template: "{% partial '' %}{% endpartial %}"
+  error_path: partial_name_validation
+- id: partial-mut-end-trail-id
+  template: "{% partial 'product-card' extra %}{% endpartial %}"
+  error_path: end
+- id: partial-mut-unclosed
+  template: "{% partial 'product-card' %}"
+  error_path: unclosed

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/raw.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/raw.yml
@@ -1,0 +1,128 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: raw-001
+  template: "{% raw foo %}{% endraw %}"
+  error_path: 1
+- id: raw-002
+  template: "{% raw foo bar %}{% endraw %}"
+  error_path: 1
+- id: raw-003
+  template: "{% raw 123 %}{% endraw %}"
+  error_path: 1
+- id: raw-004
+  template: "{% raw 'hello' %}{% endraw %}"
+  error_path: 1
+- id: raw-005
+  template: "{% raw == %}{% endraw %}"
+  error_path: 1
+- id: raw-006
+  template: "{% raw | %}{% endraw %}"
+  error_path: 1
+- id: raw-007
+  template: "{% raw @#$ %}{% endraw %}"
+  error_path: 1
+- id: raw-008
+  template: "{% raw . %}{% endraw %}"
+  error_path: 1
+- id: raw-009
+  template: "{% raw : %}{% endraw %}"
+  error_path: 1
+- id: raw-010
+  template: "{% raw x = 1 %}{% endraw %}"
+  error_path: 1
+- id: raw-011
+  template: "{%- raw foo -%}{%- endraw -%}"
+  error_path: 1
+- id: raw-012
+  template: "{% raw foo %}content"
+  error_path: 1
+- id: raw-020
+  template: "{% raw %}"
+  error_path: 2
+- id: raw-021
+  template: "{% raw %}some content"
+  error_path: 2
+- id: raw-022
+  template: "{% raw %}{% if true %}{% endif %}"
+  error_path: 2
+- id: raw-023
+  template: "{%- raw -%}content"
+  error_path: 2
+- id: raw-024
+  template: "{% raw %}a{% endraw %}{% raw %}b"
+  error_path: 2
+- id: raw-025
+  template: |-
+    hello
+
+    {% raw %}content
+  error_path: 2
+- id: raw-026
+  template: "{% raw %}{% raw %}content"
+  error_path: 2
+- id: raw-100
+  template: "{% raw %}content{% endraw %}"
+  error_path:
+- id: raw-101
+  template: "{% raw %}{% endraw %}"
+  error_path:
+- id: raw-102
+  template: "{% raw %}{{ x }} {% if true %}{% endif %}{% endraw %}"
+  error_path:
+- id: raw-103
+  template: "{%- raw -%}c{%- endraw -%}"
+  error_path:
+- id: raw-104
+  template: "{%  raw   %}c{%  endraw   %}"
+  error_path:
+- id: raw-105
+  template: "{% raw %}a{% endraw %}{% raw %}b{% endraw %}"
+  error_path:
+- id: raw-106
+  template: "{{ shop.name }}"
+  error_path:
+- id: raw-107
+  template: "{% endraw %}"
+  error_path:
+- id: raw-108
+  template: hello{% raw %}world{% endraw %}bye
+  error_path:
+- id: raw-109
+  template: "{% raw %}c{% endraw foo %}"
+  error_path:
+- id: raw-themecheck-marked-closer-then-unclosed
+  template: "{% raw %}c{% endraw foo %}{% raw %}"
+  error_path: 2
+- id: raw-themecheck-marked-closer-then-balanced
+  template: "{% raw %}c{% endraw foo %}{% raw %}later{% endraw %}"
+  error_path:
+- id: raw-themecheck-whitespace-control-marked-closer
+  template: "{% raw %}c{%- endraw foo -%}"
+  error_path:
+- id: raw-themecheck-prefixed-closing
+  template: "{% raw %}c{% endrawx foo %}"
+  error_path: 2
+- id: raw-themecheck-unclosed-quoted-opening
+  template: "{% raw 'hello %}{% endraw %}"
+  error_path: 1
+- id: raw-110
+  template: |-
+    {% raw %}
+    line1
+    line2
+    {% endraw %}
+  error_path:
+- id: raw-111
+  template: "{% raw %}{% raw %}inner{% endraw %}"
+  error_path:
+- id: raw-themecheck-liquid-line-unclosed
+  template: |-
+    {% liquid
+      raw
+    %}
+  error_path: 2
+- id: liquid-endraw
+  template: |-
+    {% liquid
+      endraw
+    %}

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/render.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/render.yml
@@ -1,0 +1,374 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: render-mut-template_name-eos
+  template: "{% render  %}"
+  error_path: template_name
+- id: render-mut-template_name-id
+  template: "{% render x %}"
+  error_path: template_name
+- id: render-mut-binding_keyword-id
+  template: "{% render 'snippet' with %}"
+  error_path: binding_keyword
+- id: render-mut-binding_value-pipe-000
+  template: "{% render 'snippet' for | %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comma-001
+  template: "{% render 'snippet' for , %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-colon-002
+  template: "{% render 'snippet' for : %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-close_square-003
+  template: "{% render 'snippet' for ] %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-close_round-004
+  template: "{% render 'snippet' for ) %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-question-005
+  template: "{% render 'snippet' for ? %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-dash-006
+  template: "{% render 'snippet' for - %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-dot-007
+  template: "{% render 'snippet' for . %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-dotdot-008
+  template: "{% render 'snippet' for .. %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-009
+  template: "{% render 'snippet' for == %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-010
+  template: "{% render 'snippet' for != %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-011
+  template: "{% render 'snippet' for < %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-012
+  template: "{% render 'snippet' for > %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-013
+  template: "{% render 'snippet' for <= %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-014
+  template: "{% render 'snippet' for >= %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-015
+  template: "{% render 'snippet' for contains %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-eos-016
+  template: "{% render 'snippet' for %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-bare_bracket
+  template: "{% render 'snippet' for [0] %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-lookup-trailing_dot
+  template: "{% render 'snippet' for x. %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-dot_number
+  template: "{% render 'snippet' for x.123 %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-dot_string
+  template: '{% render ''snippet'' for x."y" %}'
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-unclosed_bracket
+  template: "{% render 'snippet' for x[0 %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-bracket_wrong_content
+  template: "{% render 'snippet' for x[,] %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-unclosed_range
+  template: "{% render 'snippet' for (1..5 %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-range_bad_separator
+  template: "{% render 'snippet' for (1, 5) %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-range_missing_end
+  template: "{% render 'snippet' for (1..) %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lexerr-at
+  template: "{% render 'snippet' for @ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-hash
+  template: "{% render 'snippet' for # %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-dollar
+  template: "{% render 'snippet' for $ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-caret
+  template: "{% render 'snippet' for ^ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-ampersand
+  template: "{% render 'snippet' for & %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-asterisk
+  template: "{% render 'snippet' for * %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-tilde
+  template: "{% render 'snippet' for ~ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-backtick
+  template: "{% render 'snippet' for ` %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-backslash
+  template: "{% render 'snippet' for \\ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-semicolon
+  template: "{% render 'snippet' for ; %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' for "hello %}'
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' for 'hello %}"
+  error_path: binding_value/lexer
+- id: render-mut-alias_name-eos
+  template: "{% render 'snippet' as %}"
+  error_path: alias_name
+- id: render-mut-alias_name-number
+  template: "{% render 'snippet' as 42 %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-at
+  template: "{% render 'snippet' as @ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-hash
+  template: "{% render 'snippet' as # %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-dollar
+  template: "{% render 'snippet' as $ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-caret
+  template: "{% render 'snippet' as ^ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-ampersand
+  template: "{% render 'snippet' as & %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-asterisk
+  template: "{% render 'snippet' as * %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-tilde
+  template: "{% render 'snippet' as ~ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-backtick
+  template: "{% render 'snippet' as ` %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-backslash
+  template: "{% render 'snippet' as \\ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-semicolon
+  template: "{% render 'snippet' as ; %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' as "hello %}'
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' as 'hello %}"
+  error_path: alias_name
+- id: render-mut-kwarg_name-eos
+  template: "{% render 'snippet' step , %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-number
+  template: "{% render 'snippet' step , 42 %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-at
+  template: "{% render 'snippet' step , @ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-hash
+  template: "{% render 'snippet' step , # %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-dollar
+  template: "{% render 'snippet' step , $ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-caret
+  template: "{% render 'snippet' step , ^ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-ampersand
+  template: "{% render 'snippet' step , & %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-asterisk
+  template: "{% render 'snippet' step , * %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-tilde
+  template: "{% render 'snippet' step , ~ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-backtick
+  template: "{% render 'snippet' step , ` %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-backslash
+  template: "{% render 'snippet' step , \\ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-semicolon
+  template: "{% render 'snippet' step , ; %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' step , "hello %}'
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' step , 'hello %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_colon-eos
+  template: "{% render 'snippet' step , x %}"
+  error_path: kwarg_colon
+- id: render-mut-kwarg_colon-number
+  template: "{% render 'snippet' step , x 42 %}"
+  error_path: kwarg_colon
+- id: render-mut-kwarg_value-pipe-000
+  template: "{% render 'snippet' step , x : | %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comma-001
+  template: "{% render 'snippet' step , x : , %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-colon-002
+  template: "{% render 'snippet' step , x : : %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-close_square-003
+  template: "{% render 'snippet' step , x : ] %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-close_round-004
+  template: "{% render 'snippet' step , x : ) %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-question-005
+  template: "{% render 'snippet' step , x : ? %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-dash-006
+  template: "{% render 'snippet' step , x : - %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-dot-007
+  template: "{% render 'snippet' step , x : . %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-dotdot-008
+  template: "{% render 'snippet' step , x : .. %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-009
+  template: "{% render 'snippet' step , x : == %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-010
+  template: "{% render 'snippet' step , x : != %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-011
+  template: "{% render 'snippet' step , x : < %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-012
+  template: "{% render 'snippet' step , x : > %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-013
+  template: "{% render 'snippet' step , x : <= %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-014
+  template: "{% render 'snippet' step , x : >= %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-015
+  template: "{% render 'snippet' step , x : contains %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-eos-016
+  template: "{% render 'snippet' step , x : %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-bare_bracket
+  template: "{% render 'snippet' step , x : [0] %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-lookup-trailing_dot
+  template: "{% render 'snippet' step , x : x. %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-dot_number
+  template: "{% render 'snippet' step , x : x.123 %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-dot_string
+  template: '{% render ''snippet'' step , x : x."y" %}'
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% render 'snippet' step , x : x[0 %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% render 'snippet' step , x : x[,] %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-unclosed_range
+  template: "{% render 'snippet' step , x : (1..5 %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% render 'snippet' step , x : (1, 5) %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-range_missing_end
+  template: "{% render 'snippet' step , x : (1..) %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lexerr-at
+  template: "{% render 'snippet' step , x : @ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-hash
+  template: "{% render 'snippet' step , x : # %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-dollar
+  template: "{% render 'snippet' step , x : $ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-caret
+  template: "{% render 'snippet' step , x : ^ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-ampersand
+  template: "{% render 'snippet' step , x : & %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-asterisk
+  template: "{% render 'snippet' step , x : * %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-tilde
+  template: "{% render 'snippet' step , x : ~ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-backtick
+  template: "{% render 'snippet' step , x : ` %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-backslash
+  template: "{% render 'snippet' step , x : \\ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-semicolon
+  template: "{% render 'snippet' step , x : ; %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' step , x : "hello %}'
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' step , x : 'hello %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-end-trail-id
+  template: "{% render 'snippet' extra %}"
+  error_path: end
+- id: render-mut-end-trail-number
+  template: "{% render 'snippet' 42 %}"
+  error_path: end
+- id: render-mut-end-trail-string
+  template: "{% render 'snippet' 'hi' %}"
+  error_path: end
+- id: render-mut-end-trail-pipe
+  template: "{% render 'snippet' | %}"
+  error_path: end
+- id: render-mut-end-trail-colon
+  template: "{% render 'snippet' : %}"
+  error_path: end
+- id: render-mut-end-trail-comma
+  template: "{% render 'snippet' , %}"
+  error_path: end
+- id: render-mut-end-trail-open_square
+  template: "{% render 'snippet' [ %}"
+  error_path: end
+- id: render-mut-end-trail-close_square
+  template: "{% render 'snippet' ] %}"
+  error_path: end
+- id: render-mut-end-trail-open_round
+  template: "{% render 'snippet' ( %}"
+  error_path: end
+- id: render-mut-end-trail-close_round
+  template: "{% render 'snippet' ) %}"
+  error_path: end
+- id: render-mut-end-trail-question
+  template: "{% render 'snippet' ? %}"
+  error_path: end
+- id: render-mut-end-trail-dot
+  template: "{% render 'snippet' . %}"
+  error_path: end
+- id: render-mut-end-trail-comparison
+  template: "{% render 'snippet' == %}"
+  error_path: end
+- id: render-mut-end-trail-dash
+  template: "{% render 'snippet' - %}"
+  error_path: end
+- id: render-themecheck-bare-bracket-snippet
+  template: "{% render [0] %}"
+  error_path: themecheck_bare_bracket_snippet

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/schema.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/schema.yml
@@ -1,0 +1,47 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: schema-mut-end-trail-id
+  template: "{% schema extra %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-number
+  template: "{% schema 42 %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-string
+  template: "{% schema 'hi' %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-pipe
+  template: "{% schema | %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-colon
+  template: "{% schema : %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-comma
+  template: "{% schema , %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-open_square
+  template: "{% schema [ %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-close_square
+  template: "{% schema ] %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-open_round
+  template: "{% schema ( %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-close_round
+  template: "{% schema ) %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-question
+  template: "{% schema ? %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-dot
+  template: "{% schema . %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-comparison
+  template: "{% schema == %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-mut-end-trail-dash
+  template: "{% schema - %}{{ x }} {% if true %}{% endif %}{% endschema %}"
+  error_path: end
+- id: schema-themecheck-valid-json-body
+  template: "{% schema %}{\"name\":\"Section\",\"settings\":[]}{% endschema %}"
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/section.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/section.yml
@@ -1,0 +1,59 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: section-mut-section_name-eos
+  template: "{% section  %}"
+  error_path: section_name
+- id: section-mut-section_name-id
+  template: "{% section x %}"
+  error_path: section_name
+- id: section-mut-end-trail-id
+  template: "{% section 'snippet' extra %}"
+  error_path: end
+- id: section-mut-end-trail-number
+  template: "{% section 'snippet' 42 %}"
+  error_path: end
+- id: section-mut-end-trail-string
+  template: "{% section 'snippet' 'hi' %}"
+  error_path: end
+- id: section-mut-end-trail-pipe
+  template: "{% section 'snippet' | %}"
+  error_path: end
+- id: section-mut-end-trail-colon
+  template: "{% section 'snippet' : %}"
+  error_path: end
+- id: section-mut-end-trail-comma
+  template: "{% section 'snippet' , %}"
+  error_path: end
+- id: section-mut-end-trail-open_square
+  template: "{% section 'snippet' [ %}"
+  error_path: end
+- id: section-mut-end-trail-close_square
+  template: "{% section 'snippet' ] %}"
+  error_path: end
+- id: section-mut-end-trail-open_round
+  template: "{% section 'snippet' ( %}"
+  error_path: end
+- id: section-mut-end-trail-close_round
+  template: "{% section 'snippet' ) %}"
+  error_path: end
+- id: section-mut-end-trail-question
+  template: "{% section 'snippet' ? %}"
+  error_path: end
+- id: section-mut-end-trail-dot
+  template: "{% section 'snippet' . %}"
+  error_path: end
+- id: section-mut-end-trail-comparison
+  template: "{% section 'snippet' == %}"
+  error_path: end
+- id: section-mut-end-trail-dash
+  template: "{% section 'snippet' - %}"
+  error_path: end
+- id: section-themecheck-bare-bracket-arg
+  template: "{% section 'header', foo: [0] %}"
+  error_path: themecheck_bare_bracket_arg
+- id: section-themecheck-block-form-with-body
+  template: "{% section 'wrap' %}body{% endsection %}"
+  error_path: unknown_tag
+- id: section-themecheck-block-form-empty
+  template: "{% section 'foo' %}{% endsection %}"
+  error_path: unknown_tag

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/sections.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/sections.yml
@@ -1,0 +1,53 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: sections-mut-section_group_name-eos
+  template: "{% sections  %}"
+  error_path: section_group_name
+- id: sections-mut-section_group_name-id
+  template: "{% sections x %}"
+  error_path: section_group_name
+- id: sections-mut-end-trail-id
+  template: "{% sections 'snippet' extra %}"
+  error_path: end
+- id: sections-mut-end-trail-number
+  template: "{% sections 'snippet' 42 %}"
+  error_path: end
+- id: sections-mut-end-trail-string
+  template: "{% sections 'snippet' 'hi' %}"
+  error_path: end
+- id: sections-mut-end-trail-pipe
+  template: "{% sections 'snippet' | %}"
+  error_path: end
+- id: sections-mut-end-trail-colon
+  template: "{% sections 'snippet' : %}"
+  error_path: end
+- id: sections-mut-end-trail-comma
+  template: "{% sections 'snippet' , %}"
+  error_path: end
+- id: sections-mut-end-trail-open_square
+  template: "{% sections 'snippet' [ %}"
+  error_path: end
+- id: sections-mut-end-trail-close_square
+  template: "{% sections 'snippet' ] %}"
+  error_path: end
+- id: sections-mut-end-trail-open_round
+  template: "{% sections 'snippet' ( %}"
+  error_path: end
+- id: sections-mut-end-trail-close_round
+  template: "{% sections 'snippet' ) %}"
+  error_path: end
+- id: sections-mut-end-trail-question
+  template: "{% sections 'snippet' ? %}"
+  error_path: end
+- id: sections-mut-end-trail-dot
+  template: "{% sections 'snippet' . %}"
+  error_path: end
+- id: sections-mut-end-trail-comparison
+  template: "{% sections 'snippet' == %}"
+  error_path: end
+- id: sections-mut-end-trail-dash
+  template: "{% sections 'snippet' - %}"
+  error_path: end
+- id: sections-themecheck-valid-double-quoted-group
+  template: '{% sections "footer-group" %}'
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/shopify_render.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/shopify_render.yml
@@ -1,0 +1,778 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: render-mut-template_name-eos
+  template: "{% render  %}"
+  error_path: template_name
+- id: render-mut-template_name-id
+  template: "{% render x %}"
+  error_path: template_name
+- id: render-mut-binding_keyword-id
+  template: "{% render 'snippet' with %}"
+  error_path: binding_keyword
+- id: render-mut-binding_value-pipe-000
+  template: "{% render 'snippet' for | %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comma-001
+  template: "{% render 'snippet' for , %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-colon-002
+  template: "{% render 'snippet' for : %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-close_square-003
+  template: "{% render 'snippet' for ] %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-close_round-004
+  template: "{% render 'snippet' for ) %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-question-005
+  template: "{% render 'snippet' for ? %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-dash-006
+  template: "{% render 'snippet' for - %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-dot-007
+  template: "{% render 'snippet' for . %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-dotdot-008
+  template: "{% render 'snippet' for .. %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-009
+  template: "{% render 'snippet' for == %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-010
+  template: "{% render 'snippet' for != %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-011
+  template: "{% render 'snippet' for < %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-012
+  template: "{% render 'snippet' for > %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-013
+  template: "{% render 'snippet' for <= %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-014
+  template: "{% render 'snippet' for >= %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-015
+  template: "{% render 'snippet' for contains %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-eos-016
+  template: "{% render 'snippet' for %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-bare_bracket
+  template: "{% render 'snippet' for [0] %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-lookup-trailing_dot
+  template: "{% render 'snippet' for x. %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-dot_number
+  template: "{% render 'snippet' for x.123 %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-dot_string
+  template: '{% render ''snippet'' for x."y" %}'
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-unclosed_bracket
+  template: "{% render 'snippet' for x[0 %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-bracket_wrong_content
+  template: "{% render 'snippet' for x[,] %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-unclosed_range
+  template: "{% render 'snippet' for (1..5 %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-range_bad_separator
+  template: "{% render 'snippet' for (1, 5) %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-range_missing_end
+  template: "{% render 'snippet' for (1..) %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lexerr-at
+  template: "{% render 'snippet' for @ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-hash
+  template: "{% render 'snippet' for # %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-dollar
+  template: "{% render 'snippet' for $ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-caret
+  template: "{% render 'snippet' for ^ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-ampersand
+  template: "{% render 'snippet' for & %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-asterisk
+  template: "{% render 'snippet' for * %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-tilde
+  template: "{% render 'snippet' for ~ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-backtick
+  template: "{% render 'snippet' for ` %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-backslash
+  template: "{% render 'snippet' for \\ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-semicolon
+  template: "{% render 'snippet' for ; %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' for "hello %}'
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' for 'hello %}"
+  error_path: binding_value/lexer
+- id: render-mut-alias_name-eos
+  template: "{% render 'snippet' as %}"
+  error_path: alias_name
+- id: render-mut-alias_name-number
+  template: "{% render 'snippet' as 42 %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-at
+  template: "{% render 'snippet' as @ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-hash
+  template: "{% render 'snippet' as # %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-dollar
+  template: "{% render 'snippet' as $ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-caret
+  template: "{% render 'snippet' as ^ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-ampersand
+  template: "{% render 'snippet' as & %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-asterisk
+  template: "{% render 'snippet' as * %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-tilde
+  template: "{% render 'snippet' as ~ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-backtick
+  template: "{% render 'snippet' as ` %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-backslash
+  template: "{% render 'snippet' as \\ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-semicolon
+  template: "{% render 'snippet' as ; %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' as "hello %}'
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' as 'hello %}"
+  error_path: alias_name
+- id: render-mut-kwarg_name-eos
+  template: "{% render 'snippet' step , %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-number
+  template: "{% render 'snippet' step , 42 %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-at
+  template: "{% render 'snippet' step , @ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-hash
+  template: "{% render 'snippet' step , # %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-dollar
+  template: "{% render 'snippet' step , $ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-caret
+  template: "{% render 'snippet' step , ^ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-ampersand
+  template: "{% render 'snippet' step , & %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-asterisk
+  template: "{% render 'snippet' step , * %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-tilde
+  template: "{% render 'snippet' step , ~ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-backtick
+  template: "{% render 'snippet' step , ` %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-backslash
+  template: "{% render 'snippet' step , \\ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-semicolon
+  template: "{% render 'snippet' step , ; %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' step , "hello %}'
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' step , 'hello %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_colon-eos
+  template: "{% render 'snippet' step , x %}"
+  error_path: kwarg_colon
+- id: render-mut-kwarg_colon-number
+  template: "{% render 'snippet' step , x 42 %}"
+  error_path: kwarg_colon
+- id: render-mut-kwarg_value-pipe-000
+  template: "{% render 'snippet' step , x : | %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comma-001
+  template: "{% render 'snippet' step , x : , %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-colon-002
+  template: "{% render 'snippet' step , x : : %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-close_square-003
+  template: "{% render 'snippet' step , x : ] %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-close_round-004
+  template: "{% render 'snippet' step , x : ) %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-question-005
+  template: "{% render 'snippet' step , x : ? %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-dash-006
+  template: "{% render 'snippet' step , x : - %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-dot-007
+  template: "{% render 'snippet' step , x : . %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-dotdot-008
+  template: "{% render 'snippet' step , x : .. %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-009
+  template: "{% render 'snippet' step , x : == %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-010
+  template: "{% render 'snippet' step , x : != %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-011
+  template: "{% render 'snippet' step , x : < %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-012
+  template: "{% render 'snippet' step , x : > %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-013
+  template: "{% render 'snippet' step , x : <= %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-014
+  template: "{% render 'snippet' step , x : >= %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-015
+  template: "{% render 'snippet' step , x : contains %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-eos-016
+  template: "{% render 'snippet' step , x : %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-bare_bracket
+  template: "{% render 'snippet' step , x : [0] %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-lookup-trailing_dot
+  template: "{% render 'snippet' step , x : x. %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-dot_number
+  template: "{% render 'snippet' step , x : x.123 %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-dot_string
+  template: '{% render ''snippet'' step , x : x."y" %}'
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% render 'snippet' step , x : x[0 %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% render 'snippet' step , x : x[,] %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-unclosed_range
+  template: "{% render 'snippet' step , x : (1..5 %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% render 'snippet' step , x : (1, 5) %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-range_missing_end
+  template: "{% render 'snippet' step , x : (1..) %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lexerr-at
+  template: "{% render 'snippet' step , x : @ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-hash
+  template: "{% render 'snippet' step , x : # %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-dollar
+  template: "{% render 'snippet' step , x : $ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-caret
+  template: "{% render 'snippet' step , x : ^ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-ampersand
+  template: "{% render 'snippet' step , x : & %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-asterisk
+  template: "{% render 'snippet' step , x : * %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-tilde
+  template: "{% render 'snippet' step , x : ~ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-backtick
+  template: "{% render 'snippet' step , x : ` %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-backslash
+  template: "{% render 'snippet' step , x : \\ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-semicolon
+  template: "{% render 'snippet' step , x : ; %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' step , x : "hello %}'
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' step , x : 'hello %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-end-trail-id
+  template: "{% render 'snippet' extra %}"
+  error_path: end
+- id: render-mut-end-trail-number
+  template: "{% render 'snippet' 42 %}"
+  error_path: end
+- id: render-mut-end-trail-string
+  template: "{% render 'snippet' 'hi' %}"
+  error_path: end
+- id: render-mut-end-trail-pipe
+  template: "{% render 'snippet' | %}"
+  error_path: end
+- id: render-mut-end-trail-colon
+  template: "{% render 'snippet' : %}"
+  error_path: end
+- id: render-mut-end-trail-comma
+  template: "{% render 'snippet' , %}"
+  error_path: end
+- id: render-mut-end-trail-open_square
+  template: "{% render 'snippet' [ %}"
+  error_path: end
+- id: render-mut-end-trail-close_square
+  template: "{% render 'snippet' ] %}"
+  error_path: end
+- id: render-mut-end-trail-open_round
+  template: "{% render 'snippet' ( %}"
+  error_path: end
+- id: render-mut-end-trail-close_round
+  template: "{% render 'snippet' ) %}"
+  error_path: end
+- id: render-mut-end-trail-question
+  template: "{% render 'snippet' ? %}"
+  error_path: end
+- id: render-mut-end-trail-dot
+  template: "{% render 'snippet' . %}"
+  error_path: end
+- id: render-mut-end-trail-comparison
+  template: "{% render 'snippet' == %}"
+  error_path: end
+- id: render-mut-end-trail-dash
+  template: "{% render 'snippet' - %}"
+  error_path: end
+- id: render-mut-template_name_id-eos
+  template: "{% render  %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-number
+  template: "{% render 42 %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-at
+  template: "{% render @ %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-hash
+  template: "{% render # %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-dollar
+  template: "{% render $ %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-caret
+  template: "{% render ^ %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-ampersand
+  template: "{% render & %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-asterisk
+  template: "{% render * %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-tilde
+  template: "{% render ~ %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-backtick
+  template: "{% render ` %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-backslash
+  template: "{% render \\ %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-semicolon
+  template: "{% render ; %}"
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-unclosed_double_quote
+  template: '{% render "hello %}'
+  error_path: template_name_id
+- id: render-mut-template_name_id-lexerr-unclosed_single_quote
+  template: "{% render 'hello %}"
+  error_path: template_name_id
+- id: render-mut-binding_keyword-id-2
+  template: "{% render x with %}"
+  error_path: binding_keyword
+- id: render-mut-binding_value-pipe-000-2
+  template: "{% render x for | %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comma-001-2
+  template: "{% render x for , %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-colon-002-2
+  template: "{% render x for : %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-close_square-003-2
+  template: "{% render x for ] %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-close_round-004-2
+  template: "{% render x for ) %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-question-005-2
+  template: "{% render x for ? %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-dash-006-2
+  template: "{% render x for - %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-dot-007-2
+  template: "{% render x for . %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-dotdot-008-2
+  template: "{% render x for .. %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-009-2
+  template: "{% render x for == %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-010-2
+  template: "{% render x for != %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-011-2
+  template: "{% render x for < %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-012-2
+  template: "{% render x for > %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-013-2
+  template: "{% render x for <= %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-014-2
+  template: "{% render x for >= %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-comparison-015-2
+  template: "{% render x for contains %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-eos-016-2
+  template: "{% render x for %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-bare_bracket-2
+  template: "{% render x for [0] %}"
+  error_path: binding_value/bad_start
+- id: render-mut-binding_value-lookup-trailing_dot-2
+  template: "{% render x for x. %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-dot_number-2
+  template: "{% render x for x.123 %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-dot_string-2
+  template: '{% render x for x."y" %}'
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-unclosed_bracket-2
+  template: "{% render x for x[0 %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-bracket_wrong_content-2
+  template: "{% render x for x[,] %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-unclosed_range-2
+  template: "{% render x for (1..5 %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-range_bad_separator-2
+  template: "{% render x for (1, 5) %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lookup-range_missing_end-2
+  template: "{% render x for (1..) %}"
+  error_path: binding_value/lookup
+- id: render-mut-binding_value-lexerr-at-2
+  template: "{% render x for @ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-hash-2
+  template: "{% render x for # %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-dollar-2
+  template: "{% render x for $ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-caret-2
+  template: "{% render x for ^ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-ampersand-2
+  template: "{% render x for & %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-asterisk-2
+  template: "{% render x for * %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-tilde-2
+  template: "{% render x for ~ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-backtick-2
+  template: "{% render x for ` %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-backslash-2
+  template: "{% render x for \\ %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-semicolon-2
+  template: "{% render x for ; %}"
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-unclosed_double_quote-2
+  template: '{% render x for "hello %}'
+  error_path: binding_value/lexer
+- id: render-mut-binding_value-lexerr-unclosed_single_quote-2
+  template: "{% render x for 'hello %}"
+  error_path: binding_value/lexer
+- id: render-mut-alias_name-eos-2
+  template: "{% render x as %}"
+  error_path: alias_name
+- id: render-mut-alias_name-number-2
+  template: "{% render x as 42 %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-at-2
+  template: "{% render x as @ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-hash-2
+  template: "{% render x as # %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-dollar-2
+  template: "{% render x as $ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-caret-2
+  template: "{% render x as ^ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-ampersand-2
+  template: "{% render x as & %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-asterisk-2
+  template: "{% render x as * %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-tilde-2
+  template: "{% render x as ~ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-backtick-2
+  template: "{% render x as ` %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-backslash-2
+  template: "{% render x as \\ %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-semicolon-2
+  template: "{% render x as ; %}"
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-unclosed_double_quote-2
+  template: '{% render x as "hello %}'
+  error_path: alias_name
+- id: render-mut-alias_name-lexerr-unclosed_single_quote-2
+  template: "{% render x as 'hello %}"
+  error_path: alias_name
+- id: render-mut-kwarg_name-eos-2
+  template: "{% render x step , %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-number-2
+  template: "{% render x step , 42 %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-at-2
+  template: "{% render x step , @ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-hash-2
+  template: "{% render x step , # %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-dollar-2
+  template: "{% render x step , $ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-caret-2
+  template: "{% render x step , ^ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-ampersand-2
+  template: "{% render x step , & %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-asterisk-2
+  template: "{% render x step , * %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-tilde-2
+  template: "{% render x step , ~ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-backtick-2
+  template: "{% render x step , ` %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-backslash-2
+  template: "{% render x step , \\ %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-semicolon-2
+  template: "{% render x step , ; %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-unclosed_double_quote-2
+  template: '{% render x step , "hello %}'
+  error_path: kwarg_name
+- id: render-mut-kwarg_name-lexerr-unclosed_single_quote-2
+  template: "{% render x step , 'hello %}"
+  error_path: kwarg_name
+- id: render-mut-kwarg_colon-eos-2
+  template: "{% render x step , x %}"
+  error_path: kwarg_colon
+- id: render-mut-kwarg_colon-number-2
+  template: "{% render x step , x 42 %}"
+  error_path: kwarg_colon
+- id: render-mut-kwarg_value-pipe-000-2
+  template: "{% render x step , x : | %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comma-001-2
+  template: "{% render x step , x : , %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-colon-002-2
+  template: "{% render x step , x : : %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-close_square-003-2
+  template: "{% render x step , x : ] %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-close_round-004-2
+  template: "{% render x step , x : ) %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-question-005-2
+  template: "{% render x step , x : ? %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-dash-006-2
+  template: "{% render x step , x : - %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-dot-007-2
+  template: "{% render x step , x : . %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-dotdot-008-2
+  template: "{% render x step , x : .. %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-009-2
+  template: "{% render x step , x : == %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-010-2
+  template: "{% render x step , x : != %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-011-2
+  template: "{% render x step , x : < %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-012-2
+  template: "{% render x step , x : > %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-013-2
+  template: "{% render x step , x : <= %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-014-2
+  template: "{% render x step , x : >= %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-comparison-015-2
+  template: "{% render x step , x : contains %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-eos-016-2
+  template: "{% render x step , x : %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-bare_bracket-2
+  template: "{% render x step , x : [0] %}"
+  error_path: kwarg_value/bad_start
+- id: render-mut-kwarg_value-lookup-trailing_dot-2
+  template: "{% render x step , x : x. %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-dot_number-2
+  template: "{% render x step , x : x.123 %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-dot_string-2
+  template: '{% render x step , x : x."y" %}'
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-unclosed_bracket-2
+  template: "{% render x step , x : x[0 %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-bracket_wrong_content-2
+  template: "{% render x step , x : x[,] %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-unclosed_range-2
+  template: "{% render x step , x : (1..5 %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-range_bad_separator-2
+  template: "{% render x step , x : (1, 5) %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lookup-range_missing_end-2
+  template: "{% render x step , x : (1..) %}"
+  error_path: kwarg_value/lookup
+- id: render-mut-kwarg_value-lexerr-at-2
+  template: "{% render x step , x : @ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-hash-2
+  template: "{% render x step , x : # %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-dollar-2
+  template: "{% render x step , x : $ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-caret-2
+  template: "{% render x step , x : ^ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-ampersand-2
+  template: "{% render x step , x : & %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-asterisk-2
+  template: "{% render x step , x : * %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-tilde-2
+  template: "{% render x step , x : ~ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-backtick-2
+  template: "{% render x step , x : ` %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-backslash-2
+  template: "{% render x step , x : \\ %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-semicolon-2
+  template: "{% render x step , x : ; %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-unclosed_double_quote-2
+  template: '{% render x step , x : "hello %}'
+  error_path: kwarg_value/lexer
+- id: render-mut-kwarg_value-lexerr-unclosed_single_quote-2
+  template: "{% render x step , x : 'hello %}"
+  error_path: kwarg_value/lexer
+- id: render-mut-end-trail-id-2
+  template: "{% render x extra %}"
+  error_path: end
+- id: render-mut-end-trail-number-2
+  template: "{% render x 42 %}"
+  error_path: end
+- id: render-mut-end-trail-string-2
+  template: "{% render x 'hi' %}"
+  error_path: end
+- id: render-mut-end-trail-pipe-2
+  template: "{% render x | %}"
+  error_path: end
+- id: render-mut-end-trail-colon-2
+  template: "{% render x : %}"
+  error_path: end
+- id: render-mut-end-trail-comma-2
+  template: "{% render x , %}"
+  error_path: end
+- id: render-mut-end-trail-open_square-2
+  template: "{% render x [ %}"
+  error_path: end
+- id: render-mut-end-trail-close_square-2
+  template: "{% render x ] %}"
+  error_path: end
+- id: render-mut-end-trail-open_round-2
+  template: "{% render x ( %}"
+  error_path: end
+- id: render-mut-end-trail-close_round-2
+  template: "{% render x ) %}"
+  error_path: end
+- id: render-mut-end-trail-question-2
+  template: "{% render x ? %}"
+  error_path: end
+- id: render-mut-end-trail-dot-2
+  template: "{% render x . %}"
+  error_path: end
+- id: render-mut-end-trail-comparison-2
+  template: "{% render x == %}"
+  error_path: end
+- id: render-mut-end-trail-dash-2
+  template: "{% render x - %}"
+  error_path: end
+- id: shopify_render-themecheck-skipped-quote-prefix
+  template: "{% render \"'snippet' %}"

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/style.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/style.yml
@@ -1,0 +1,50 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: style-themecheck-empty-markup
+  template: "{% style %}{% endstyle %}"
+  error_path: none
+- id: style-themecheck-empty-spaced-markup
+  template: "{% style    %}{% endstyle %}"
+  error_path: none
+- id: style-mut-end-trail-id
+  template: "{% style extra %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-number
+  template: "{% style 42 %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-string
+  template: "{% style 'hi' %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-pipe
+  template: "{% style | %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-colon
+  template: "{% style : %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-comma
+  template: "{% style , %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-open_square
+  template: "{% style [ %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-close_square
+  template: "{% style ] %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-open_round
+  template: "{% style ( %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-close_round
+  template: "{% style ) %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-question
+  template: "{% style ? %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-dot
+  template: "{% style . %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-comparison
+  template: "{% style == %}{% endstyle %}"
+  error_path: end
+- id: style-mut-end-trail-dash
+  template: "{% style - %}{% endstyle %}"
+  error_path: end

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/stylesheet.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/stylesheet.yml
@@ -1,0 +1,56 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: stylesheet-themecheck-valid-scss
+  template: "{% stylesheet scss %}{% endstylesheet %}"
+
+- id: stylesheet-themecheck-valid-quoted-scss
+  template: "{% stylesheet 'scss' %}{% endstylesheet %}"
+
+- id: stylesheet-mut-scss_arg-eos
+  template: "{% stylesheet  %}{% endstylesheet %}"
+  error_path: scss_arg
+- id: stylesheet-mut-scss_arg-id
+  template: "{% stylesheet x %}{% endstylesheet %}"
+  error_path: scss_arg
+- id: stylesheet-mut-end-trail-id
+  template: "{% stylesheet 'snippet' extra %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-number
+  template: "{% stylesheet 'snippet' 42 %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-string
+  template: "{% stylesheet 'snippet' 'hi' %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-pipe
+  template: "{% stylesheet 'snippet' | %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-colon
+  template: "{% stylesheet 'snippet' : %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-comma
+  template: "{% stylesheet 'snippet' , %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-open_square
+  template: "{% stylesheet 'snippet' [ %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-close_square
+  template: "{% stylesheet 'snippet' ] %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-open_round
+  template: "{% stylesheet 'snippet' ( %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-close_round
+  template: "{% stylesheet 'snippet' ) %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-question
+  template: "{% stylesheet 'snippet' ? %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-dot
+  template: "{% stylesheet 'snippet' . %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-comparison
+  template: "{% stylesheet 'snippet' == %}{% endstylesheet %}"
+  error_path: end
+- id: stylesheet-mut-end-trail-dash
+  template: "{% stylesheet 'snippet' - %}{% endstylesheet %}"
+  error_path: end

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/table_row.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/table_row.yml
@@ -1,0 +1,377 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: table_row-mut-variable_name-eos
+  template: "{% tablerow  %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-number
+  template: "{% tablerow 42 %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-at
+  template: "{% tablerow @ %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-hash
+  template: "{% tablerow # %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-dollar
+  template: "{% tablerow $ %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-caret
+  template: "{% tablerow ^ %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-ampersand
+  template: "{% tablerow & %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-asterisk
+  template: "{% tablerow * %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-tilde
+  template: "{% tablerow ~ %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-backtick
+  template: "{% tablerow ` %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-backslash
+  template: "{% tablerow \\ %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-semicolon
+  template: "{% tablerow ; %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% tablerow "hello %}{% endtablerow %}'
+  error_path: variable_name
+- id: table_row-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% tablerow 'hello %}{% endtablerow %}"
+  error_path: variable_name
+- id: table_row-mut-in_keyword-eos
+  template: "{% tablerow x %}{% endtablerow %}"
+  error_path: in_keyword
+- id: table_row-mut-in_keyword-id
+  template: "{% tablerow x of %}{% endtablerow %}"
+  error_path: in_keyword
+- id: table_row-mut-collection-pipe-000
+  template: "{% tablerow x in | %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-comma-001
+  template: "{% tablerow x in , %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-colon-002
+  template: "{% tablerow x in : %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-close_square-003
+  template: "{% tablerow x in ] %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-close_round-004
+  template: "{% tablerow x in ) %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-question-005
+  template: "{% tablerow x in ? %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-dash-006
+  template: "{% tablerow x in - %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-dot-007
+  template: "{% tablerow x in . %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-dotdot-008
+  template: "{% tablerow x in .. %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-comparison-009
+  template: "{% tablerow x in == %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-comparison-010
+  template: "{% tablerow x in != %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-comparison-011
+  template: "{% tablerow x in < %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-comparison-012
+  template: "{% tablerow x in > %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-comparison-013
+  template: "{% tablerow x in <= %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-comparison-014
+  template: "{% tablerow x in >= %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-comparison-015
+  template: "{% tablerow x in contains %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-eos-016
+  template: "{% tablerow x in %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-bare_bracket
+  template: "{% tablerow x in [0] %}{% endtablerow %}"
+  error_path: collection/bad_start
+- id: table_row-mut-collection-lookup-trailing_dot
+  template: "{% tablerow x in x. %}{% endtablerow %}"
+  error_path: collection/lookup
+- id: table_row-mut-collection-lookup-dot_number
+  template: "{% tablerow x in x.123 %}{% endtablerow %}"
+  error_path: collection/lookup
+- id: table_row-mut-collection-lookup-dot_string
+  template: '{% tablerow x in x."y" %}{% endtablerow %}'
+  error_path: collection/lookup
+- id: table_row-mut-collection-lookup-unclosed_bracket
+  template: "{% tablerow x in x[0 %}{% endtablerow %}"
+  error_path: collection/lookup
+- id: table_row-mut-collection-lookup-bracket_wrong_content
+  template: "{% tablerow x in x[,] %}{% endtablerow %}"
+  error_path: collection/lookup
+- id: table_row-mut-collection-lookup-unclosed_range
+  template: "{% tablerow x in (1..5 %}{% endtablerow %}"
+  error_path: collection/lookup
+- id: table_row-mut-collection-lookup-range_bad_separator
+  template: "{% tablerow x in (1, 5) %}{% endtablerow %}"
+  error_path: collection/lookup
+- id: table_row-mut-collection-lookup-range_missing_end
+  template: "{% tablerow x in (1..) %}{% endtablerow %}"
+  error_path: collection/lookup
+- id: table_row-mut-collection-lexerr-at
+  template: "{% tablerow x in @ %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-hash
+  template: "{% tablerow x in # %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-dollar
+  template: "{% tablerow x in $ %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-caret
+  template: "{% tablerow x in ^ %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-ampersand
+  template: "{% tablerow x in & %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-asterisk
+  template: "{% tablerow x in * %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-tilde
+  template: "{% tablerow x in ~ %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-backtick
+  template: "{% tablerow x in ` %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-backslash
+  template: "{% tablerow x in \\ %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-semicolon
+  template: "{% tablerow x in ; %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-unclosed_double_quote
+  template: '{% tablerow x in "hello %}{% endtablerow %}'
+  error_path: collection/lexer
+- id: table_row-mut-collection-lexerr-unclosed_single_quote
+  template: "{% tablerow x in 'hello %}{% endtablerow %}"
+  error_path: collection/lexer
+- id: table_row-mut-invalid_attribute-invalid
+  template: "{% tablerow x in x step , %}{% endtablerow %}"
+  error_path: invalid_attribute
+- id: table_row-mut-attr_colon-eos
+  template: "{% tablerow x in x step , %}{% endtablerow %}"
+  error_path: attr_colon
+- id: table_row-mut-attr_colon-number
+  template: "{% tablerow x in x step , 42 %}{% endtablerow %}"
+  error_path: attr_colon
+- id: table_row-mut-attr_value-pipe-000
+  template: "{% tablerow x in x step , : | %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-comma-001
+  template: "{% tablerow x in x step , : , %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-colon-002
+  template: "{% tablerow x in x step , : : %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-close_square-003
+  template: "{% tablerow x in x step , : ] %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-close_round-004
+  template: "{% tablerow x in x step , : ) %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-question-005
+  template: "{% tablerow x in x step , : ? %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-dash-006
+  template: "{% tablerow x in x step , : - %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-dot-007
+  template: "{% tablerow x in x step , : . %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-dotdot-008
+  template: "{% tablerow x in x step , : .. %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-comparison-009
+  template: "{% tablerow x in x step , : == %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-comparison-010
+  template: "{% tablerow x in x step , : != %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-comparison-011
+  template: "{% tablerow x in x step , : < %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-comparison-012
+  template: "{% tablerow x in x step , : > %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-comparison-013
+  template: "{% tablerow x in x step , : <= %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-comparison-014
+  template: "{% tablerow x in x step , : >= %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-comparison-015
+  template: "{% tablerow x in x step , : contains %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-eos-016
+  template: "{% tablerow x in x step , : %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-bare_bracket
+  template: "{% tablerow x in x step , : [0] %}{% endtablerow %}"
+  error_path: attr_value/bad_start
+- id: table_row-mut-attr_value-lookup-trailing_dot
+  template: "{% tablerow x in x step , : x. %}{% endtablerow %}"
+  error_path: attr_value/lookup
+- id: table_row-mut-attr_value-lookup-dot_number
+  template: "{% tablerow x in x step , : x.123 %}{% endtablerow %}"
+  error_path: attr_value/lookup
+- id: table_row-mut-attr_value-lookup-dot_string
+  template: '{% tablerow x in x step , : x."y" %}{% endtablerow %}'
+  error_path: attr_value/lookup
+- id: table_row-mut-attr_value-lookup-unclosed_bracket
+  template: "{% tablerow x in x step , : x[0 %}{% endtablerow %}"
+  error_path: attr_value/lookup
+- id: table_row-mut-attr_value-lookup-bracket_wrong_content
+  template: "{% tablerow x in x step , : x[,] %}{% endtablerow %}"
+  error_path: attr_value/lookup
+- id: table_row-mut-attr_value-lookup-unclosed_range
+  template: "{% tablerow x in x step , : (1..5 %}{% endtablerow %}"
+  error_path: attr_value/lookup
+- id: table_row-mut-attr_value-lookup-range_bad_separator
+  template: "{% tablerow x in x step , : (1, 5) %}{% endtablerow %}"
+  error_path: attr_value/lookup
+- id: table_row-mut-attr_value-lookup-range_missing_end
+  template: "{% tablerow x in x step , : (1..) %}{% endtablerow %}"
+  error_path: attr_value/lookup
+- id: table_row-mut-attr_value-lexerr-at
+  template: "{% tablerow x in x step , : @ %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-hash
+  template: "{% tablerow x in x step , : # %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-dollar
+  template: "{% tablerow x in x step , : $ %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-caret
+  template: "{% tablerow x in x step , : ^ %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-ampersand
+  template: "{% tablerow x in x step , : & %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-asterisk
+  template: "{% tablerow x in x step , : * %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-tilde
+  template: "{% tablerow x in x step , : ~ %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-backtick
+  template: "{% tablerow x in x step , : ` %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-backslash
+  template: "{% tablerow x in x step , : \\ %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-semicolon
+  template: "{% tablerow x in x step , : ; %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-unclosed_double_quote
+  template: '{% tablerow x in x step , : "hello %}{% endtablerow %}'
+  error_path: attr_value/lexer
+- id: table_row-mut-attr_value-lexerr-unclosed_single_quote
+  template: "{% tablerow x in x step , : 'hello %}{% endtablerow %}"
+  error_path: attr_value/lexer
+- id: table_row-mut-end-trail-id
+  template: "{% tablerow x in x extra %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-number
+  template: "{% tablerow x in x 42 %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-string
+  template: "{% tablerow x in x 'hi' %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-pipe
+  template: "{% tablerow x in x | %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-colon
+  template: "{% tablerow x in x : %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-comma
+  template: "{% tablerow x in x , %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-open_square
+  template: "{% tablerow x in x [ %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-close_square
+  template: "{% tablerow x in x ] %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-open_round
+  template: "{% tablerow x in x ( %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-close_round
+  template: "{% tablerow x in x ) %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-question
+  template: "{% tablerow x in x ? %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-dot
+  template: "{% tablerow x in x . %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-comparison
+  template: "{% tablerow x in x == %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-end-trail-dash
+  template: "{% tablerow x in x - %}{% endtablerow %}"
+  error_path: end
+- id: table_row-mut-valid-000
+  template: "{% tablerow x in x %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-001
+  template: "{% tablerow x in 42 %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-002
+  template: "{% tablerow x in 3.14 %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-003
+  template: "{% tablerow x in -5 %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-004
+  template: "{% tablerow x in 'hello' %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-005
+  template: "{% tablerow x in true %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-006
+  template: "{% tablerow x in false %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-007
+  template: "{% tablerow x in nil %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-008
+  template: "{% tablerow x in blank %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-009
+  template: "{% tablerow x in empty %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-010
+  template: "{% tablerow x in product.title %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-011
+  template: "{% tablerow x in products[0] %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-012
+  template: "{% tablerow x in a.b.c %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-013
+  template: "{% tablerow x in a[0].b %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-mut-valid-014
+  template: "{% tablerow x in (1..5) %}{% endtablerow %}"
+  error_path: valid
+- id: table_row-themecheck-trailing-comma
+  template: "{% tablerow product in collection.products, %}{% endtablerow %}"
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/unless.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/unless.yml
@@ -1,0 +1,602 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: unless-mut-condition-pipe-000
+  template: "{% unless | %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-comma-001
+  template: "{% unless , %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-colon-002
+  template: "{% unless : %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-close_square-003
+  template: "{% unless ] %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-close_round-004
+  template: "{% unless ) %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-question-005
+  template: "{% unless ? %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-dash-006
+  template: "{% unless - %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-dot-007
+  template: "{% unless . %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-dotdot-008
+  template: "{% unless .. %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-comparison-009
+  template: "{% unless == %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-comparison-010
+  template: "{% unless != %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-comparison-011
+  template: "{% unless < %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-comparison-012
+  template: "{% unless > %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-comparison-013
+  template: "{% unless <= %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-comparison-014
+  template: "{% unless >= %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-comparison-015
+  template: "{% unless contains %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-eos-016
+  template: "{% unless  %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-bare_bracket
+  template: "{% unless [0] %}{% endunless %}"
+  error_path: condition/bad_start
+- id: unless-mut-condition-lookup-trailing_dot
+  template: "{% unless x. %}{% endunless %}"
+  error_path: condition/lookup
+- id: unless-mut-condition-lookup-dot_number
+  template: "{% unless x.123 %}{% endunless %}"
+  error_path: condition/lookup
+- id: unless-mut-condition-lookup-dot_string
+  template: '{% unless x."y" %}{% endunless %}'
+  error_path: condition/lookup
+- id: unless-mut-condition-lookup-unclosed_bracket
+  template: "{% unless x[0 %}{% endunless %}"
+  error_path: condition/lookup
+- id: unless-mut-condition-lookup-bracket_wrong_content
+  template: "{% unless x[,] %}{% endunless %}"
+  error_path: condition/lookup
+- id: unless-mut-condition-lookup-unclosed_range
+  template: "{% unless (1..5 %}{% endunless %}"
+  error_path: condition/lookup
+- id: unless-mut-condition-lookup-range_bad_separator
+  template: "{% unless (1, 5) %}{% endunless %}"
+  error_path: condition/lookup
+- id: unless-mut-condition-lookup-range_missing_end
+  template: "{% unless (1..) %}{% endunless %}"
+  error_path: condition/lookup
+- id: unless-mut-condition-lexerr-at
+  template: "{% unless @ %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-hash
+  template: "{% unless # %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-dollar
+  template: "{% unless $ %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-caret
+  template: "{% unless ^ %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-ampersand
+  template: "{% unless & %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-asterisk
+  template: "{% unless * %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-tilde
+  template: "{% unless ~ %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-backtick
+  template: "{% unless ` %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-backslash
+  template: "{% unless \\ %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-semicolon
+  template: "{% unless ; %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-unclosed_double_quote
+  template: '{% unless "hello %}{% endunless %}'
+  error_path: condition/lexer
+- id: unless-mut-condition-lexerr-unclosed_single_quote
+  template: "{% unless 'hello %}{% endunless %}"
+  error_path: condition/lexer
+- id: unless-mut-comparison_rhs-pipe-000
+  template: "{% unless x == | %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-comma-001
+  template: "{% unless x == , %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-colon-002
+  template: "{% unless x == : %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-close_square-003
+  template: "{% unless x == ] %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-close_round-004
+  template: "{% unless x == ) %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-question-005
+  template: "{% unless x == ? %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-dash-006
+  template: "{% unless x == - %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-dot-007
+  template: "{% unless x == . %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-dotdot-008
+  template: "{% unless x == .. %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-comparison-009
+  template: "{% unless x == == %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-comparison-010
+  template: "{% unless x == != %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-comparison-011
+  template: "{% unless x == < %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-comparison-012
+  template: "{% unless x == > %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-comparison-013
+  template: "{% unless x == <= %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-comparison-014
+  template: "{% unless x == >= %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-comparison-015
+  template: "{% unless x == contains %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-eos-016
+  template: "{% unless x == %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-bare_bracket
+  template: "{% unless x == [0] %}{% endunless %}"
+  error_path: comparison_rhs/bad_start
+- id: unless-mut-comparison_rhs-lookup-trailing_dot
+  template: "{% unless x == x. %}{% endunless %}"
+  error_path: comparison_rhs/lookup
+- id: unless-mut-comparison_rhs-lookup-dot_number
+  template: "{% unless x == x.123 %}{% endunless %}"
+  error_path: comparison_rhs/lookup
+- id: unless-mut-comparison_rhs-lookup-dot_string
+  template: '{% unless x == x."y" %}{% endunless %}'
+  error_path: comparison_rhs/lookup
+- id: unless-mut-comparison_rhs-lookup-unclosed_bracket
+  template: "{% unless x == x[0 %}{% endunless %}"
+  error_path: comparison_rhs/lookup
+- id: unless-mut-comparison_rhs-lookup-bracket_wrong_content
+  template: "{% unless x == x[,] %}{% endunless %}"
+  error_path: comparison_rhs/lookup
+- id: unless-mut-comparison_rhs-lookup-unclosed_range
+  template: "{% unless x == (1..5 %}{% endunless %}"
+  error_path: comparison_rhs/lookup
+- id: unless-mut-comparison_rhs-lookup-range_bad_separator
+  template: "{% unless x == (1, 5) %}{% endunless %}"
+  error_path: comparison_rhs/lookup
+- id: unless-mut-comparison_rhs-lookup-range_missing_end
+  template: "{% unless x == (1..) %}{% endunless %}"
+  error_path: comparison_rhs/lookup
+- id: unless-mut-comparison_rhs-lexerr-at
+  template: "{% unless x == @ %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-hash
+  template: "{% unless x == # %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-dollar
+  template: "{% unless x == $ %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-caret
+  template: "{% unless x == ^ %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-ampersand
+  template: "{% unless x == & %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-asterisk
+  template: "{% unless x == * %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-tilde
+  template: "{% unless x == ~ %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-backtick
+  template: "{% unless x == ` %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-backslash
+  template: "{% unless x == \\ %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-semicolon
+  template: "{% unless x == ; %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% unless x == "hello %}{% endunless %}'
+  error_path: comparison_rhs/lexer
+- id: unless-mut-comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% unless x == 'hello %}{% endunless %}"
+  error_path: comparison_rhs/lexer
+- id: unless-mut-boolean_op-eos
+  template: "{% unless x and %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-number
+  template: "{% unless x and 42 %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-at
+  template: "{% unless x and @ %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-hash
+  template: "{% unless x and # %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-dollar
+  template: "{% unless x and $ %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-caret
+  template: "{% unless x and ^ %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-ampersand
+  template: "{% unless x and & %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-asterisk
+  template: "{% unless x and * %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-tilde
+  template: "{% unless x and ~ %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-backtick
+  template: "{% unless x and ` %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-backslash
+  template: "{% unless x and \\ %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-semicolon
+  template: "{% unless x and ; %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-unclosed_double_quote
+  template: '{% unless x and "hello %}{% endunless %}'
+  error_path: boolean_op
+- id: unless-mut-boolean_op-lexerr-unclosed_single_quote
+  template: "{% unless x and 'hello %}{% endunless %}"
+  error_path: boolean_op
+- id: unless-mut-boolean_expr-pipe-000
+  template: "{% unless x and x | %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-comma-001
+  template: "{% unless x and x , %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-colon-002
+  template: "{% unless x and x : %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-close_square-003
+  template: "{% unless x and x ] %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-close_round-004
+  template: "{% unless x and x ) %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-question-005
+  template: "{% unless x and x ? %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-dash-006
+  template: "{% unless x and x - %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-dot-007
+  template: "{% unless x and x . %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-dotdot-008
+  template: "{% unless x and x .. %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-comparison-009
+  template: "{% unless x and x == %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-comparison-010
+  template: "{% unless x and x != %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-comparison-011
+  template: "{% unless x and x < %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-comparison-012
+  template: "{% unless x and x > %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-comparison-013
+  template: "{% unless x and x <= %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-comparison-014
+  template: "{% unless x and x >= %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-comparison-015
+  template: "{% unless x and x contains %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-eos-016
+  template: "{% unless x and x %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-bare_bracket
+  template: "{% unless x and x [0] %}{% endunless %}"
+  error_path: boolean_expr/bad_start
+- id: unless-mut-boolean_expr-lookup-trailing_dot
+  template: "{% unless x and x x. %}{% endunless %}"
+  error_path: boolean_expr/lookup
+- id: unless-mut-boolean_expr-lookup-dot_number
+  template: "{% unless x and x x.123 %}{% endunless %}"
+  error_path: boolean_expr/lookup
+- id: unless-mut-boolean_expr-lookup-dot_string
+  template: '{% unless x and x x."y" %}{% endunless %}'
+  error_path: boolean_expr/lookup
+- id: unless-mut-boolean_expr-lookup-unclosed_bracket
+  template: "{% unless x and x x[0 %}{% endunless %}"
+  error_path: boolean_expr/lookup
+- id: unless-mut-boolean_expr-lookup-bracket_wrong_content
+  template: "{% unless x and x x[,] %}{% endunless %}"
+  error_path: boolean_expr/lookup
+- id: unless-mut-boolean_expr-lookup-unclosed_range
+  template: "{% unless x and x (1..5 %}{% endunless %}"
+  error_path: boolean_expr/lookup
+- id: unless-mut-boolean_expr-lookup-range_bad_separator
+  template: "{% unless x and x (1, 5) %}{% endunless %}"
+  error_path: boolean_expr/lookup
+- id: unless-mut-boolean_expr-lookup-range_missing_end
+  template: "{% unless x and x (1..) %}{% endunless %}"
+  error_path: boolean_expr/lookup
+- id: unless-mut-boolean_expr-lexerr-at
+  template: "{% unless x and x @ %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-hash
+  template: "{% unless x and x # %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-dollar
+  template: "{% unless x and x $ %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-caret
+  template: "{% unless x and x ^ %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-ampersand
+  template: "{% unless x and x & %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-asterisk
+  template: "{% unless x and x * %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-tilde
+  template: "{% unless x and x ~ %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-backtick
+  template: "{% unless x and x ` %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-backslash
+  template: "{% unless x and x \\ %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-semicolon
+  template: "{% unless x and x ; %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-unclosed_double_quote
+  template: '{% unless x and x "hello %}{% endunless %}'
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_expr-lexerr-unclosed_single_quote
+  template: "{% unless x and x 'hello %}{% endunless %}"
+  error_path: boolean_expr/lexer
+- id: unless-mut-boolean_comparison_rhs-pipe-000
+  template: "{% unless x and x x == | %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-comma-001
+  template: "{% unless x and x x == , %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-colon-002
+  template: "{% unless x and x x == : %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-close_square-003
+  template: "{% unless x and x x == ] %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-close_round-004
+  template: "{% unless x and x x == ) %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-question-005
+  template: "{% unless x and x x == ? %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-dash-006
+  template: "{% unless x and x x == - %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-dot-007
+  template: "{% unless x and x x == . %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-dotdot-008
+  template: "{% unless x and x x == .. %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-comparison-009
+  template: "{% unless x and x x == == %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-comparison-010
+  template: "{% unless x and x x == != %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-comparison-011
+  template: "{% unless x and x x == < %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-comparison-012
+  template: "{% unless x and x x == > %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-comparison-013
+  template: "{% unless x and x x == <= %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-comparison-014
+  template: "{% unless x and x x == >= %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-comparison-015
+  template: "{% unless x and x x == contains %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-eos-016
+  template: "{% unless x and x x == %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-bare_bracket
+  template: "{% unless x and x x == [0] %}{% endunless %}"
+  error_path: boolean_comparison_rhs/bad_start
+- id: unless-mut-boolean_comparison_rhs-lookup-trailing_dot
+  template: "{% unless x and x x == x. %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: unless-mut-boolean_comparison_rhs-lookup-dot_number
+  template: "{% unless x and x x == x.123 %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: unless-mut-boolean_comparison_rhs-lookup-dot_string
+  template: '{% unless x and x x == x."y" %}{% endunless %}'
+  error_path: boolean_comparison_rhs/lookup
+- id: unless-mut-boolean_comparison_rhs-lookup-unclosed_bracket
+  template: "{% unless x and x x == x[0 %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: unless-mut-boolean_comparison_rhs-lookup-bracket_wrong_content
+  template: "{% unless x and x x == x[,] %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: unless-mut-boolean_comparison_rhs-lookup-unclosed_range
+  template: "{% unless x and x x == (1..5 %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: unless-mut-boolean_comparison_rhs-lookup-range_bad_separator
+  template: "{% unless x and x x == (1, 5) %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: unless-mut-boolean_comparison_rhs-lookup-range_missing_end
+  template: "{% unless x and x x == (1..) %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lookup
+- id: unless-mut-boolean_comparison_rhs-lexerr-at
+  template: "{% unless x and x x == @ %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-hash
+  template: "{% unless x and x x == # %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-dollar
+  template: "{% unless x and x x == $ %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-caret
+  template: "{% unless x and x x == ^ %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-ampersand
+  template: "{% unless x and x x == & %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-asterisk
+  template: "{% unless x and x x == * %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-tilde
+  template: "{% unless x and x x == ~ %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-backtick
+  template: "{% unless x and x x == ` %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-backslash
+  template: "{% unless x and x x == \\ %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-semicolon
+  template: "{% unless x and x x == ; %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% unless x and x x == "hello %}{% endunless %}'
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-boolean_comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% unless x and x x == 'hello %}{% endunless %}"
+  error_path: boolean_comparison_rhs/lexer
+- id: unless-mut-end-trail-id
+  template: "{% unless x extra %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-number
+  template: "{% unless x 42 %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-string
+  template: "{% unless x 'hi' %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-pipe
+  template: "{% unless x | %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-colon
+  template: "{% unless x : %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-comma
+  template: "{% unless x , %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-open_square
+  template: "{% unless x [ %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-close_square
+  template: "{% unless x ] %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-open_round
+  template: "{% unless x ( %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-close_round
+  template: "{% unless x ) %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-question
+  template: "{% unless x ? %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-dot
+  template: "{% unless x . %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-comparison
+  template: "{% unless x == %}{% endunless %}"
+  error_path: end
+- id: unless-mut-end-trail-dash
+  template: "{% unless x - %}{% endunless %}"
+  error_path: end
+- id: unless-mut-valid-000
+  template: "{% unless x %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-001
+  template: "{% unless 42 %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-002
+  template: "{% unless 3.14 %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-003
+  template: "{% unless -5 %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-004
+  template: "{% unless 'hello' %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-005
+  template: "{% unless true %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-006
+  template: "{% unless false %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-007
+  template: "{% unless nil %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-008
+  template: "{% unless blank %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-009
+  template: "{% unless empty %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-010
+  template: "{% unless product.title %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-011
+  template: "{% unless products[0] %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-012
+  template: "{% unless a.b.c %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-013
+  template: "{% unless a[0].b %}{% endunless %}"
+  error_path: valid
+- id: unless-mut-valid-014
+  template: "{% unless (1..5) %}{% endunless %}"
+  error_path: valid
+- id: unless-parity-js-and-operator
+  template: "{% unless x && y %}{% endunless %}"
+  error_path: end/lexer
+- id: unless-parity-js-or-operator
+  template: "{% unless x || y %}{% endunless %}"
+  error_path: end
+- id: unless-parity-non-liquid-operator
+  template: '{% unless x startswith "foo" %}{% endunless %}'
+  error_path: end
+- id: unless-parity-triple-equals
+  template: "{% unless x === y %}{% endunless %}"
+  error_path: end/lexer
+- id: unless-themecheck-whitespace-quote-prefix
+  template: "{% unless ' product.available %}Sold out{% endunless %}"
+  error_path: condition/lexer

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/variable.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/scenarios/variable.yml
@@ -1,0 +1,614 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: variable-mut-value-pipe-000
+  template: "{{ | }}"
+  error_path: value/bad_start
+- id: variable-mut-value-comma-001
+  template: "{{ , }}"
+  error_path: value/bad_start
+- id: variable-mut-value-colon-002
+  template: "{{ : }}"
+  error_path: value/bad_start
+- id: variable-mut-value-close_square-003
+  template: "{{ ] }}"
+  error_path: value/bad_start
+- id: variable-mut-value-close_round-004
+  template: "{{ ) }}"
+  error_path: value/bad_start
+- id: variable-mut-value-question-005
+  template: "{{ ? }}"
+  error_path: value/bad_start
+- id: variable-mut-value-dash-006
+  template: "{{ - }}"
+  error_path: value/bad_start
+- id: variable-mut-value-dot-007
+  template: "{{ . }}"
+  error_path: value/bad_start
+- id: variable-mut-value-dotdot-008
+  template: "{{ .. }}"
+  error_path: value/bad_start
+- id: variable-mut-value-comparison-009
+  template: "{{ == }}"
+  error_path: value/bad_start
+- id: variable-mut-value-comparison-010
+  template: "{{ != }}"
+  error_path: value/bad_start
+- id: variable-mut-value-comparison-011
+  template: "{{ < }}"
+  error_path: value/bad_start
+- id: variable-mut-value-comparison-012
+  template: "{{ > }}"
+  error_path: value/bad_start
+- id: variable-mut-value-comparison-013
+  template: "{{ <= }}"
+  error_path: value/bad_start
+- id: variable-mut-value-comparison-014
+  template: "{{ >= }}"
+  error_path: value/bad_start
+- id: variable-mut-value-comparison-015
+  template: "{{ contains }}"
+  error_path: value/bad_start
+- id: variable-mut-value-eos-016
+  template: "{{  }}"
+  error_path: value/bad_start
+- id: variable-mut-value-bare_bracket
+  template: "{{ [0] }}"
+  error_path: value/bad_start
+- id: variable-mut-value-lookup-trailing_dot
+  template: "{{ x. }}"
+  error_path: value/lookup
+- id: variable-mut-value-lookup-dot_number
+  template: "{{ x.123 }}"
+  error_path: value/lookup
+- id: variable-mut-value-lookup-dot_string
+  template: '{{ x."y" }}'
+  error_path: value/lookup
+- id: variable-mut-value-lookup-unclosed_bracket
+  template: "{{ x[0 }}"
+  error_path: value/lookup
+- id: variable-mut-value-lookup-bracket_wrong_content
+  template: "{{ x[,] }}"
+  error_path: value/lookup
+- id: variable-mut-value-lookup-unclosed_range
+  template: "{{ (1..5 }}"
+  error_path: value/lookup
+- id: variable-mut-value-lookup-range_bad_separator
+  template: "{{ (1, 5) }}"
+  error_path: value/lookup
+- id: variable-mut-value-lookup-range_missing_end
+  template: "{{ (1..) }}"
+  error_path: value/lookup
+- id: variable-mut-value-lexerr-at
+  template: "{{ @ }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-hash
+  template: "{{ # }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-dollar
+  template: "{{ $ }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-caret
+  template: "{{ ^ }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-ampersand
+  template: "{{ & }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-asterisk
+  template: "{{ * }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-tilde
+  template: "{{ ~ }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-backtick
+  template: "{{ ` }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-backslash
+  template: "{{ \\ }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-semicolon
+  template: "{{ ; }}"
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-unclosed_double_quote
+  template: '{{ "hello }}'
+  error_path: value/lexer
+- id: variable-mut-value-lexerr-unclosed_single_quote
+  template: "{{ 'hello }}"
+  error_path: value/lexer
+- id: variable-mut-filter_name-eos
+  template: "{{ x | }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-number
+  template: "{{ x | 42 }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-at
+  template: "{{ x | @ }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-hash
+  template: "{{ x | # }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-dollar
+  template: "{{ x | $ }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-caret
+  template: "{{ x | ^ }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-ampersand
+  template: "{{ x | & }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-asterisk
+  template: "{{ x | * }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-tilde
+  template: "{{ x | ~ }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-backtick
+  template: "{{ x | ` }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-backslash
+  template: "{{ x | \\ }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-semicolon
+  template: "{{ x | ; }}"
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-unclosed_double_quote
+  template: '{{ x | "hello }}'
+  error_path: filter_name
+- id: variable-mut-filter_name-lexerr-unclosed_single_quote
+  template: "{{ x | 'hello }}"
+  error_path: filter_name
+- id: variable-mut-filter_first_arg-pipe-000
+  template: "{{ x | x : | }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-comma-001
+  template: "{{ x | x : , }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-colon-002
+  template: "{{ x | x : : }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-close_square-003
+  template: "{{ x | x : ] }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-close_round-004
+  template: "{{ x | x : ) }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-question-005
+  template: "{{ x | x : ? }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-dash-006
+  template: "{{ x | x : - }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-dot-007
+  template: "{{ x | x : . }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-dotdot-008
+  template: "{{ x | x : .. }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-comparison-009
+  template: "{{ x | x : == }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-comparison-010
+  template: "{{ x | x : != }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-comparison-011
+  template: "{{ x | x : < }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-comparison-012
+  template: "{{ x | x : > }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-comparison-013
+  template: "{{ x | x : <= }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-comparison-014
+  template: "{{ x | x : >= }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-comparison-015
+  template: "{{ x | x : contains }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-eos-016
+  template: "{{ x | x : }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-bare_bracket
+  template: "{{ x | x : [0] }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-mut-filter_first_arg-lookup-trailing_dot
+  template: "{{ x | x : x. }}"
+  error_path: filter_first_arg/lookup
+- id: variable-mut-filter_first_arg-lookup-dot_number
+  template: "{{ x | x : x.123 }}"
+  error_path: filter_first_arg/lookup
+- id: variable-mut-filter_first_arg-lookup-dot_string
+  template: '{{ x | x : x."y" }}'
+  error_path: filter_first_arg/lookup
+- id: variable-mut-filter_first_arg-lookup-unclosed_bracket
+  template: "{{ x | x : x[0 }}"
+  error_path: filter_first_arg/lookup
+- id: variable-mut-filter_first_arg-lookup-bracket_wrong_content
+  template: "{{ x | x : x[,] }}"
+  error_path: filter_first_arg/lookup
+- id: variable-mut-filter_first_arg-lookup-unclosed_range
+  template: "{{ x | x : (1..5 }}"
+  error_path: filter_first_arg/lookup
+- id: variable-mut-filter_first_arg-lookup-range_bad_separator
+  template: "{{ x | x : (1, 5) }}"
+  error_path: filter_first_arg/lookup
+- id: variable-mut-filter_first_arg-lookup-range_missing_end
+  template: "{{ x | x : (1..) }}"
+  error_path: filter_first_arg/lookup
+- id: variable-mut-filter_first_arg-lexerr-at
+  template: "{{ x | x : @ }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-hash
+  template: "{{ x | x : # }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-dollar
+  template: "{{ x | x : $ }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-caret
+  template: "{{ x | x : ^ }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-ampersand
+  template: "{{ x | x : & }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-asterisk
+  template: "{{ x | x : * }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-tilde
+  template: "{{ x | x : ~ }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-backtick
+  template: "{{ x | x : ` }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-backslash
+  template: "{{ x | x : \\ }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-semicolon
+  template: "{{ x | x : ; }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-unclosed_double_quote
+  template: '{{ x | x : "hello }}'
+  error_path: filter_first_arg/lexer
+- id: variable-mut-filter_first_arg-lexerr-unclosed_single_quote
+  template: "{{ x | x : 'hello }}"
+  error_path: filter_first_arg/lexer
+- id: variable-mut-kwarg_colon-eos
+  template: "{{ x | x : x , , x }}"
+  error_path: kwarg_colon
+- id: variable-mut-kwarg_colon-number
+  template: "{{ x | x : x , , x 42 }}"
+  error_path: kwarg_colon
+- id: variable-mut-kwarg_value-pipe-000
+  template: "{{ x | x : x , , x : | }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-comma-001
+  template: "{{ x | x : x , , x : , }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-colon-002
+  template: "{{ x | x : x , , x : : }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-close_square-003
+  template: "{{ x | x : x , , x : ] }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-close_round-004
+  template: "{{ x | x : x , , x : ) }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-question-005
+  template: "{{ x | x : x , , x : ? }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-dash-006
+  template: "{{ x | x : x , , x : - }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-dot-007
+  template: "{{ x | x : x , , x : . }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-dotdot-008
+  template: "{{ x | x : x , , x : .. }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-comparison-009
+  template: "{{ x | x : x , , x : == }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-comparison-010
+  template: "{{ x | x : x , , x : != }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-comparison-011
+  template: "{{ x | x : x , , x : < }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-comparison-012
+  template: "{{ x | x : x , , x : > }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-comparison-013
+  template: "{{ x | x : x , , x : <= }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-comparison-014
+  template: "{{ x | x : x , , x : >= }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-comparison-015
+  template: "{{ x | x : x , , x : contains }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-eos-016
+  template: "{{ x | x : x , , x : }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-bare_bracket
+  template: "{{ x | x : x , , x : [0] }}"
+  error_path: kwarg_value/bad_start
+- id: variable-mut-kwarg_value-lookup-trailing_dot
+  template: "{{ x | x : x , , x : x. }}"
+  error_path: kwarg_value/lookup
+- id: variable-mut-kwarg_value-lookup-dot_number
+  template: "{{ x | x : x , , x : x.123 }}"
+  error_path: kwarg_value/lookup
+- id: variable-mut-kwarg_value-lookup-dot_string
+  template: '{{ x | x : x , , x : x."y" }}'
+  error_path: kwarg_value/lookup
+- id: variable-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{{ x | x : x , , x : x[0 }}"
+  error_path: kwarg_value/lookup
+- id: variable-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{{ x | x : x , , x : x[,] }}"
+  error_path: kwarg_value/lookup
+- id: variable-mut-kwarg_value-lookup-unclosed_range
+  template: "{{ x | x : x , , x : (1..5 }}"
+  error_path: kwarg_value/lookup
+- id: variable-mut-kwarg_value-lookup-range_bad_separator
+  template: "{{ x | x : x , , x : (1, 5) }}"
+  error_path: kwarg_value/lookup
+- id: variable-mut-kwarg_value-lookup-range_missing_end
+  template: "{{ x | x : x , , x : (1..) }}"
+  error_path: kwarg_value/lookup
+- id: variable-mut-kwarg_value-lexerr-at
+  template: "{{ x | x : x , , x : @ }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-hash
+  template: "{{ x | x : x , , x : # }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-dollar
+  template: "{{ x | x : x , , x : $ }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-caret
+  template: "{{ x | x : x , , x : ^ }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-ampersand
+  template: "{{ x | x : x , , x : & }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-asterisk
+  template: "{{ x | x : x , , x : * }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-tilde
+  template: "{{ x | x : x , , x : ~ }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-backtick
+  template: "{{ x | x : x , , x : ` }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-backslash
+  template: "{{ x | x : x , , x : \\ }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-semicolon
+  template: "{{ x | x : x , , x : ; }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{{ x | x : x , , x : "hello }}'
+  error_path: kwarg_value/lexer
+- id: variable-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{{ x | x : x , , x : 'hello }}"
+  error_path: kwarg_value/lexer
+- id: variable-mut-filter_arg_value-pipe-000
+  template: "{{ x | x : x , , | }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-comma-001
+  template: "{{ x | x : x , , , }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-colon-002
+  template: "{{ x | x : x , , : }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-close_square-003
+  template: "{{ x | x : x , , ] }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-close_round-004
+  template: "{{ x | x : x , , ) }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-question-005
+  template: "{{ x | x : x , , ? }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-dash-006
+  template: "{{ x | x : x , , - }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-dot-007
+  template: "{{ x | x : x , , . }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-dotdot-008
+  template: "{{ x | x : x , , .. }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-comparison-009
+  template: "{{ x | x : x , , == }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-comparison-010
+  template: "{{ x | x : x , , != }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-comparison-011
+  template: "{{ x | x : x , , < }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-comparison-012
+  template: "{{ x | x : x , , > }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-comparison-013
+  template: "{{ x | x : x , , <= }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-comparison-014
+  template: "{{ x | x : x , , >= }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-comparison-015
+  template: "{{ x | x : x , , contains }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-eos-016
+  template: "{{ x | x : x , , }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-bare_bracket
+  template: "{{ x | x : x , , [0] }}"
+  error_path: filter_arg_value/bad_start
+- id: variable-mut-filter_arg_value-lookup-trailing_dot
+  template: "{{ x | x : x , , x. }}"
+  error_path: filter_arg_value/lookup
+- id: variable-mut-filter_arg_value-lookup-dot_number
+  template: "{{ x | x : x , , x.123 }}"
+  error_path: filter_arg_value/lookup
+- id: variable-mut-filter_arg_value-lookup-dot_string
+  template: '{{ x | x : x , , x."y" }}'
+  error_path: filter_arg_value/lookup
+- id: variable-mut-filter_arg_value-lookup-unclosed_bracket
+  template: "{{ x | x : x , , x[0 }}"
+  error_path: filter_arg_value/lookup
+- id: variable-mut-filter_arg_value-lookup-bracket_wrong_content
+  template: "{{ x | x : x , , x[,] }}"
+  error_path: filter_arg_value/lookup
+- id: variable-mut-filter_arg_value-lookup-unclosed_range
+  template: "{{ x | x : x , , (1..5 }}"
+  error_path: filter_arg_value/lookup
+- id: variable-mut-filter_arg_value-lookup-range_bad_separator
+  template: "{{ x | x : x , , (1, 5) }}"
+  error_path: filter_arg_value/lookup
+- id: variable-mut-filter_arg_value-lookup-range_missing_end
+  template: "{{ x | x : x , , (1..) }}"
+  error_path: filter_arg_value/lookup
+- id: variable-mut-filter_arg_value-lexerr-at
+  template: "{{ x | x : x , , @ }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-hash
+  template: "{{ x | x : x , , # }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-dollar
+  template: "{{ x | x : x , , $ }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-caret
+  template: "{{ x | x : x , , ^ }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-ampersand
+  template: "{{ x | x : x , , & }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-asterisk
+  template: "{{ x | x : x , , * }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-tilde
+  template: "{{ x | x : x , , ~ }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-backtick
+  template: "{{ x | x : x , , ` }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-backslash
+  template: "{{ x | x : x , , \\ }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-semicolon
+  template: "{{ x | x : x , , ; }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-unclosed_double_quote
+  template: '{{ x | x : x , , "hello }}'
+  error_path: filter_arg_value/lexer
+- id: variable-mut-filter_arg_value-lexerr-unclosed_single_quote
+  template: "{{ x | x : x , , 'hello }}"
+  error_path: filter_arg_value/lexer
+- id: variable-mut-end-trail-id
+  template: "{{ x extra }}"
+  error_path: end
+- id: variable-mut-end-trail-number
+  template: "{{ x 42 }}"
+  error_path: end
+- id: variable-mut-end-trail-string
+  template: "{{ x 'hi' }}"
+  error_path: end
+- id: variable-mut-end-trail-pipe
+  template: "{{ x | }}"
+  error_path: end
+- id: variable-mut-end-trail-colon
+  template: "{{ x : }}"
+  error_path: end
+- id: variable-mut-end-trail-comma
+  template: "{{ x , }}"
+  error_path: end
+- id: variable-mut-end-trail-open_square
+  template: "{{ x [ }}"
+  error_path: end
+- id: variable-mut-end-trail-close_square
+  template: "{{ x ] }}"
+  error_path: end
+- id: variable-mut-end-trail-open_round
+  template: "{{ x ( }}"
+  error_path: end
+- id: variable-mut-end-trail-close_round
+  template: "{{ x ) }}"
+  error_path: end
+- id: variable-mut-end-trail-question
+  template: "{{ x ? }}"
+  error_path: end
+- id: variable-mut-end-trail-dot
+  template: "{{ x . }}"
+  error_path: end
+- id: variable-mut-end-trail-comparison
+  template: "{{ x == }}"
+  error_path: end
+- id: variable-mut-end-trail-dash
+  template: "{{ x - }}"
+  error_path: end
+- id: variable-themecheck-malformed-empty-filter-prefix
+  template: "{{ x y | append: }}"
+  error_path: end
+- id: variable-themecheck-filter-separator-trailing-comma-before-pipe
+  template: "{{ n | filter: 1, 2, 3, | filter2: k1: 1, k2: 2 }}"
+  error_path: valid
+- id: variable-themecheck-filter-separator-mixed-positional-keyword
+  template: "{{ n | filter: 'a', 'b', key1: 1, key2: 2, 'c' }}"
+  error_path: valid
+- id: variable-themecheck-filter-separator-leading-comma
+  template: "{{ n | f1: , }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-themecheck-filter-separator-leading-comma-before-pipe
+  template: "{{ n | f1: , | f2 }}"
+  error_path: filter_first_arg/bad_start
+- id: variable-themecheck-filter-separator-missing-comma
+  template: "{{ n | filter: 1 2, 3 }}"
+  error_path: end
+- id: variable-themecheck-filter-separator-adjacent-colon
+  template: "{{ n | pluralize: 'comment': 'comments' }}"
+  error_path: end
+- id: variable-mut-valid-000
+  template: "{{ x }}"
+  error_path: valid
+- id: variable-mut-valid-001
+  template: "{{ 42 }}"
+  error_path: valid
+- id: variable-mut-valid-002
+  template: "{{ 3.14 }}"
+  error_path: valid
+- id: variable-mut-valid-003
+  template: "{{ -5 }}"
+  error_path: valid
+- id: variable-mut-valid-004
+  template: "{{ 'hello' }}"
+  error_path: valid
+- id: variable-mut-valid-005
+  template: "{{ true }}"
+  error_path: valid
+- id: variable-mut-valid-006
+  template: "{{ false }}"
+  error_path: valid
+- id: variable-mut-valid-007
+  template: "{{ nil }}"
+  error_path: valid
+- id: variable-mut-valid-008
+  template: "{{ blank }}"
+  error_path: valid
+- id: variable-mut-valid-009
+  template: "{{ empty }}"
+  error_path: valid
+- id: variable-mut-valid-010
+  template: "{{ product.title }}"
+  error_path: valid
+- id: variable-mut-valid-011
+  template: "{{ products[0] }}"
+  error_path: valid
+- id: variable-mut-valid-012
+  template: "{{ a.b.c }}"
+  error_path: valid
+- id: variable-mut-valid-013
+  template: "{{ a[0].b }}"
+  error_path: valid
+- id: variable-mut-valid-014
+  template: "{{ (1..5) }}"
+  error_path: valid

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/assign.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/assign.snap.yml
@@ -1,0 +1,1167 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: assign-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    = x )"'
+  type: SyntaxError
+- id: assign-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    = x ]"'
+  type: SyntaxError
+- id: assign-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x = x :"'
+  type: SyntaxError
+- id: assign-mut-end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x = x ,"'
+  type: SyntaxError
+- id: assign-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x =
+    x =="'
+  type: SyntaxError
+- id: assign-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x = x -"'
+  type: SyntaxError
+- id: assign-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x = x ."'
+  type: SyntaxError
+- id: assign-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x = x extra"'
+  type: SyntaxError
+- id: assign-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x = x 42"'
+  type: SyntaxError
+- id: assign-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x =
+    x ("'
+  type: SyntaxError
+- id: assign-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =
+    x ["'
+  type: SyntaxError
+- id: assign-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x = x |"'
+  type: SyntaxError
+- id: assign-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x = x
+    ?"'
+  type: SyntaxError
+- id: assign-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x = x ''hi''"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-bare_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , [0]"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-close_round-004
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , )"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-close_square-003
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , ]"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-colon-002
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , :"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , ,"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-comparison-009
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , =="'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-comparison-010
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , !="'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-comparison-011
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , <"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-comparison-012
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , >"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-comparison-013
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , <="'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-comparison-014
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , >="'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-comparison-015
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , contains"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-dash-006
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , -"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-dot-007
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , ."'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-dotdot-008
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , .."'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-eos-016
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , ,"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x = x | x : x , , &"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x = x | x : x , , *"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x = x | x : x , , @"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x = x | x : x , , \"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x = x | x : x , , `"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x = x | x : x , , ^"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x = x | x : x , , $"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x = x | x : x , , #"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x = x | x : x , , ;"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x = x | x : x , , ~"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x = x | x : x , , "hello"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x = x | x : x , , ''hello"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x[,]"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lookup-dot_number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x.123"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lookup-dot_string
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x."y""'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , (1, 5)"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , (1..)"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x."'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x[0"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , (1..5"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-pipe-000
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , |"'
+  type: SyntaxError
+- id: assign-mut-filter_arg_value-question-005
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , ?"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x = x | x : [0]"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    = x | x : )"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    = x | x : ]"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x = x |
+    x : :"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : ,"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    = x | x : =="'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    = x | x : !="'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    = x | x : <"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    = x | x : >"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    = x | x : <="'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    = x | x : >="'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x = x | x : contains"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x = x |
+    x : -"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x = x | x
+    : ."'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x = x
+    | x : .."'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-eos-016
+  error:
+  type:
+- id: assign-mut-filter_first_arg-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x = x | x : &"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x = x | x : *"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x = x | x : @"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x = x | x : \"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x = x | x : `"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x = x | x : ^"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x = x | x : $"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x = x | x : #"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x = x | x : ;"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x = x | x : ~"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x = x | x : "hello"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x = x | x : ''hello"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x[,]"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x = x | x : x.123"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x = x | x : x."y""'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x = x | x : (1,
+    5)"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    = x | x : (1..)"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x = x | x :
+    x."'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    = x | x : x[0"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    = x | x : (1..5"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-pipe-000
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x = x | x :
+    |"'
+  type: SyntaxError
+- id: assign-mut-filter_first_arg-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x =
+    x | x : ?"'
+  type: SyntaxError
+- id: assign-mut-filter_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x = x |"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x = x | &"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x = x | *"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x = x | @"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x = x | \"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x = x | `"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x = x | ^"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x = x | $"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x = x | #"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x = x | ;"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x = x | ~"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x = x | "hello"'
+  type: SyntaxError
+- id: assign-mut-filter_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x = x | ''hello"'
+  type: SyntaxError
+- id: assign-mut-filter_name-number
+  error: 'Liquid syntax error: Expected id but found number in "x = x | 42"'
+  type: SyntaxError
+- id: assign-mut-kwarg_colon-eos
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x"'
+  type: SyntaxError
+- id: assign-mut-kwarg_colon-number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x 42"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-bare_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : [0]"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-close_round-004
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : )"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-close_square-003
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : ]"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-colon-002
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : :"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : ,"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-comparison-009
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : =="'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-comparison-010
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : !="'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-comparison-011
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : <"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-comparison-012
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : >"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-comparison-013
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : <="'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-comparison-014
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : >="'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-comparison-015
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : contains"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-dash-006
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : -"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-dot-007
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : ."'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-dotdot-008
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : .."'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-eos-016
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x :"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x = x | x : x , , x : &"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x = x | x : x , , x : *"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x = x | x : x , , x : @"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x = x | x : x , , x : \"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x = x | x : x , , x : `"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x = x | x : x , , x : ^"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x = x | x : x , , x : $"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x = x | x : x , , x : #"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x = x | x : x , , x : ;"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x = x | x : x , , x : ~"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x = x | x : x , , x : "hello"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x = x | x : x , , x : ''hello"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : x[,]"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lookup-dot_number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : x.123"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lookup-dot_string
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : x."y""'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : (1, 5)"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : (1..)"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : x."'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : x[0"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : (1..5"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-pipe-000
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : |"'
+  type: SyntaxError
+- id: assign-mut-kwarg_value-question-005
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x |
+    x : x , , x : ?"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-close_round
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "x ) = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-close_square
+  error: 'Liquid syntax error: Expected id but found close_square in "x ] = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-colon
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "x : = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-comma
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "x , = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-comparison
+  error: 'Liquid syntax error: Unexpected character = in "x == = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-dash
+  error: 'Liquid syntax error: Expected id but found dash in "x - = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-dot
+  error: 'Liquid syntax error: Expected id but found dot in "x . = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-id
+  error:
+  type:
+- id: assign-mut-lhs_eos-trail-number
+  error: 'Liquid syntax error: Expected id but found number in "x 42 = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-open_round
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "x ( = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-open_square
+  error: 'Liquid syntax error: Expected id but found open_square in "x [ = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-pipe
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "x | = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-question
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "x ? = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_eos-trail-string
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "x ''hi'' = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-eos
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "= x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-ampersand
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "& = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-asterisk
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "* = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-at
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "@ = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-backslash
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "\ = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-backtick
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "` = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-caret
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "^ = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-dollar
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "$ = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-hash
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "# = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-semicolon
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "; = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-tilde
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "~ = x"'
+  type: SyntaxError
+- id: assign-mut-lhs_id-lexerr-unclosed_double_quote
+  error:
+  type:
+- id: assign-mut-lhs_id-lexerr-unclosed_single_quote
+  error:
+  type:
+- id: assign-mut-lhs_id-number
+  error: 'Liquid syntax error: Expected id but found number in "42 = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-000
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "= x"'
+  type: SyntaxError
+- id: assign-mut-pregate-000-2
+  error:
+  type:
+- id: assign-mut-pregate-001
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "= = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-001-2
+  error: 'Liquid syntax error: Unexpected character = in "x = ="'
+  type: SyntaxError
+- id: assign-mut-pregate-002
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "? = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-002-2
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x =
+    ?"'
+  type: SyntaxError
+- id: assign-mut-pregate-003
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in ""hi" = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-003-2
+  error:
+  type:
+- id: assign-mut-pregate-004
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "@ = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-004-2
+  error: 'Liquid syntax error: Unexpected character @ in "x = @"'
+  type: SyntaxError
+- id: assign-mut-pregate-005
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "# = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-005-2
+  error: 'Liquid syntax error: Unexpected character # in "x = #"'
+  type: SyntaxError
+- id: assign-mut-pregate-006
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "$ = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-006-2
+  error: 'Liquid syntax error: Unexpected character $ in "x = $"'
+  type: SyntaxError
+- id: assign-mut-pregate-007
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "^ = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-007-2
+  error: 'Liquid syntax error: Unexpected character ^ in "x = ^"'
+  type: SyntaxError
+- id: assign-mut-pregate-008
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "& = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-008-2
+  error: 'Liquid syntax error: Unexpected character & in "x = &"'
+  type: SyntaxError
+- id: assign-mut-pregate-009
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "* = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-009-2
+  error: 'Liquid syntax error: Unexpected character * in "x = *"'
+  type: SyntaxError
+- id: assign-mut-pregate-010
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "~ = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-010-2
+  error: 'Liquid syntax error: Unexpected character ~ in "x = ~"'
+  type: SyntaxError
+- id: assign-mut-pregate-011
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "; = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-011-2
+  error: 'Liquid syntax error: Unexpected character ; in "x = ;"'
+  type: SyntaxError
+- id: assign-mut-pregate-012
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in "| = x"'
+  type: SyntaxError
+- id: assign-mut-pregate-012-2
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x = |"'
+  type: SyntaxError
+- id: assign-mut-valid-000
+  error:
+  type:
+- id: assign-mut-valid-001
+  error:
+  type:
+- id: assign-mut-valid-002
+  error:
+  type:
+- id: assign-mut-valid-003
+  error:
+  type:
+- id: assign-mut-valid-004
+  error:
+  type:
+- id: assign-mut-valid-005
+  error:
+  type:
+- id: assign-mut-valid-006
+  error:
+  type:
+- id: assign-mut-valid-007
+  error:
+  type:
+- id: assign-mut-valid-008
+  error:
+  type:
+- id: assign-mut-valid-009
+  error:
+  type:
+- id: assign-mut-valid-010
+  error:
+  type:
+- id: assign-mut-valid-011
+  error:
+  type:
+- id: assign-mut-valid-012
+  error:
+  type:
+- id: assign-mut-valid-013
+  error:
+  type:
+- id: assign-mut-valid-014
+  error:
+  type:
+- id: assign-mut-valid-filter-015
+  error:
+  type:
+- id: assign-mut-valid-filter-016
+  error:
+  type:
+- id: assign-mut-valid-filter-017
+  error:
+  type:
+- id: assign-mut-valid-filter-018
+  error:
+  type:
+- id: assign-mut-valid-filter-019
+  error:
+  type:
+- id: assign-mut-valid-filter-020
+  error:
+  type:
+- id: assign-mut-valid-filter-021
+  error:
+  type:
+- id: assign-mut-valid-filter-022
+  error:
+  type:
+- id: assign-mut-valid-filter-023
+  error:
+  type:
+- id: assign-mut-valid-filter-024
+  error:
+  type:
+- id: assign-mut-valid-filter-025
+  error:
+  type:
+- id: assign-mut-valid-filter-026
+  error:
+  type:
+- id: assign-mut-valid-filter-027
+  error:
+  type:
+- id: assign-mut-valid-filter-028
+  error:
+  type:
+- id: assign-mut-valid-filter-029
+  error:
+  type:
+- id: assign-mut-valid-filter-030
+  error:
+  type:
+- id: assign-mut-valid-filter-031
+  error:
+  type:
+- id: assign-mut-valid-filter-032
+  error:
+  type:
+- id: assign-mut-valid-filter-033
+  error:
+  type:
+- id: assign-mut-valid-filter-034
+  error:
+  type:
+- id: assign-mut-valid-filter-035
+  error:
+  type:
+- id: assign-mut-valid-filter-036
+  error:
+  type:
+- id: assign-mut-valid-filter-037
+  error:
+  type:
+- id: assign-mut-valid-filter-038
+  error:
+  type:
+- id: assign-mut-valid-filter-039
+  error:
+  type:
+- id: assign-mut-valid-filter-040
+  error:
+  type:
+- id: assign-mut-valid-filter-041
+  error:
+  type:
+- id: assign-mut-valid-filter-042
+  error:
+  type:
+- id: assign-mut-valid-filter-043
+  error:
+  type:
+- id: assign-mut-valid-filter-044
+  error:
+  type:
+- id: assign-mut-valid-filter-045
+  error:
+  type:
+- id: assign-mut-valid-filter-046
+  error:
+  type:
+- id: assign-mut-valid-filter-047
+  error:
+  type:
+- id: assign-mut-valid-filter-048
+  error:
+  type:
+- id: assign-mut-valid-filter-049
+  error:
+  type:
+- id: assign-mut-valid-filter-050
+  error:
+  type:
+- id: assign-mut-valid-filter-051
+  error:
+  type:
+- id: assign-mut-valid-filter-052
+  error:
+  type:
+- id: assign-mut-valid-filter-053
+  error:
+  type:
+- id: assign-mut-valid-filter-054
+  error:
+  type:
+- id: assign-mut-valid-filter-055
+  error:
+  type:
+- id: assign-mut-valid-filter-056
+  error:
+  type:
+- id: assign-mut-valid-filter-057
+  error:
+  type:
+- id: assign-mut-valid-filter-058
+  error:
+  type:
+- id: assign-mut-valid-filter-059
+  error:
+  type:
+- id: assign-mut-valid-filter-060
+  error:
+  type:
+- id: assign-mut-valid-filter-061
+  error:
+  type:
+- id: assign-mut-valid-filter-062
+  error:
+  type:
+- id: assign-mut-valid-filter-063
+  error:
+  type:
+- id: assign-mut-valid-filter-064
+  error:
+  type:
+- id: assign-mut-valid-filter-065
+  error:
+  type:
+- id: assign-mut-valid-filter-066
+  error:
+  type:
+- id: assign-mut-valid-filter-067
+  error:
+  type:
+- id: assign-mut-valid-filter-068
+  error:
+  type:
+- id: assign-mut-valid-filter-069
+  error:
+  type:
+- id: assign-mut-valid-filter-070
+  error:
+  type:
+- id: assign-mut-valid-filter-071
+  error:
+  type:
+- id: assign-mut-valid-filter-072
+  error:
+  type:
+- id: assign-mut-valid-filter-073
+  error:
+  type:
+- id: assign-mut-valid-filter-074
+  error:
+  type:
+- id: assign-mut-valid-filter-075
+  error:
+  type:
+- id: assign-mut-valid-filter-076
+  error:
+  type:
+- id: assign-mut-valid-filter-077
+  error:
+  type:
+- id: assign-mut-valid-filter-078
+  error:
+  type:
+- id: assign-mut-valid-filter-079
+  error:
+  type:
+- id: assign-mut-valid-filter-080
+  error:
+  type:
+- id: assign-mut-valid-filter-081
+  error:
+  type:
+- id: assign-mut-valid-filter-082
+  error:
+  type:
+- id: assign-mut-valid-filter-083
+  error:
+  type:
+- id: assign-mut-valid-filter-084
+  error:
+  type:
+- id: assign-mut-valid-filter-085
+  error:
+  type:
+- id: assign-mut-valid-filter-086
+  error:
+  type:
+- id: assign-mut-valid-filter-087
+  error:
+  type:
+- id: assign-mut-valid-filter-088
+  error:
+  type:
+- id: assign-mut-valid-filter-089
+  error:
+  type:
+- id: assign-mut-valid-lhs-000
+  error:
+  type:
+- id: assign-mut-valid-lhs-001
+  error:
+  type:
+- id: assign-mut-valid-lhs-002
+  error:
+  type:
+- id: assign-mut-valid-lhs-003
+  error:
+  type:
+- id: assign-mut-valid-lhs-004
+  error:
+  type:
+- id: assign-mut-valid-lhs-005
+  error:
+  type:
+- id: assign-mut-valid-lhs-006
+  error:
+  type:
+- id: assign-mut-valid-lhs-007
+  error:
+  type:
+- id: assign-mut-valid-lhs-008
+  error:
+  type:
+- id: assign-mut-valid-lhs-009
+  error:
+  type:
+- id: assign-mut-valid-lhs-010
+  error:
+  type:
+- id: assign-mut-value-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x = [0]"'
+  type: SyntaxError
+- id: assign-mut-value-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    = )"'
+  type: SyntaxError
+- id: assign-mut-value-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    = ]"'
+  type: SyntaxError
+- id: assign-mut-value-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x = :"'
+  type: SyntaxError
+- id: assign-mut-value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = ,"'
+  type: SyntaxError
+- id: assign-mut-value-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    = =="'
+  type: SyntaxError
+- id: assign-mut-value-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    = !="'
+  type: SyntaxError
+- id: assign-mut-value-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    = <"'
+  type: SyntaxError
+- id: assign-mut-value-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    = >"'
+  type: SyntaxError
+- id: assign-mut-value-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    = <="'
+  type: SyntaxError
+- id: assign-mut-value-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    = >="'
+  type: SyntaxError
+- id: assign-mut-value-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x = contains"'
+  type: SyntaxError
+- id: assign-mut-value-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x = -"'
+  type: SyntaxError
+- id: assign-mut-value-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x = ."'
+  type: SyntaxError
+- id: assign-mut-value-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x = .."'
+  type: SyntaxError
+- id: assign-mut-value-eos-016
+  error:
+  type:
+- id: assign-mut-value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x = &"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x = *"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x = @"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x = \"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x = `"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x = ^"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x = $"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x = #"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x = ;"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x = ~"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x = "hello"'
+  type: SyntaxError
+- id: assign-mut-value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x = ''hello"'
+  type: SyntaxError
+- id: assign-mut-value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x[,]"'
+  type: SyntaxError
+- id: assign-mut-value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x = x.123"'
+  type: SyntaxError
+- id: assign-mut-value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x = x."y""'
+  type: SyntaxError
+- id: assign-mut-value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x = (1, 5)"'
+  type: SyntaxError
+- id: assign-mut-value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    = (1..)"'
+  type: SyntaxError
+- id: assign-mut-value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x = x."'
+  type: SyntaxError
+- id: assign-mut-value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    = x[0"'
+  type: SyntaxError
+- id: assign-mut-value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    = (1..5"'
+  type: SyntaxError
+- id: assign-mut-value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x = |"'
+  type: SyntaxError
+- id: assign-mut-value-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x =
+    ?"'
+  type: SyntaxError
+- id: assign-themecheck-dotted-lhs
+  error: 'Liquid syntax error: Expected end_of_string but found dot in "x.y = 1"'
+  type: SyntaxError
+- id: assign-themecheck-filter-separator-adjacent-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "out = n
+    | pluralize: ''comment'': ''comments''"'
+  type: SyntaxError
+- id: assign-themecheck-filter-separator-leading-comma
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "out = n
+    | f1: ,"'
+  type: SyntaxError
+- id: assign-themecheck-filter-separator-leading-comma-before-pipe
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "out = n
+    | f1: , | f2"'
+  type: SyntaxError
+- id: assign-themecheck-filter-separator-missing-comma
+  error: 'Liquid syntax error: Expected end_of_string but found number in "out = n
+    | filter: 1 2, 3"'
+  type: SyntaxError
+- id: assign-themecheck-filter-separator-mixed-positional-keyword
+  error:
+  type:
+- id: assign-themecheck-filter-separator-trailing-comma-before-pipe
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/block.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/block.snap.yml
@@ -1,0 +1,60 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: block-mut-attr_colon-eos
+  error: 'Liquid syntax error: Expected colon but found end_of_string'
+  type: SyntaxError
+- id: block-mut-attr_value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression'
+  type: SyntaxError
+- id: block-mut-block_content_property-invalid
+  error: 'Liquid syntax error: in ''block'' - ''block.content'' does not accept further
+    properties'
+  type: SyntaxError
+- id: block-mut-block_content_value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression'
+  type: SyntaxError
+- id: block-mut-block_name-string
+  error: 'Liquid syntax error: Expected string but found id'
+  type: SyntaxError
+- id: block-mut-block_property-invalid
+  error: 'Liquid syntax error: in ''block'' - ''block'' is not a valid property; use
+    ''block.content'' or ''block.settings.<id>'''
+  type: SyntaxError
+- id: block-mut-block_setting_property-invalid
+  error: 'Liquid syntax error: in ''block'' - ''block.settings.heading'' does not
+    accept further properties'
+  type: SyntaxError
+- id: block-mut-block_setting_value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression'
+  type: SyntaxError
+- id: block-mut-block_settings_property-invalid
+  error: 'Liquid syntax error: in ''block'' - ''block.settings'' requires a property
+    name, e.g. block.settings.<id>'
+  type: SyntaxError
+- id: block-mut-block_unknown_property-invalid
+  error: 'Liquid syntax error: in ''block'' - unknown property ''block.unknown'''
+  type: SyntaxError
+- id: block-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id'
+  type: SyntaxError
+- id: block-mut-file_name-eos
+  error: 'Liquid syntax error: Expected string but found end_of_string'
+  type: SyntaxError
+- id: block-mut-file_name-id
+  error: 'Liquid syntax error: Expected string but found id'
+  type: SyntaxError
+- id: block-mut-file_name-invalid
+  error: 'Liquid syntax error: in ''block'' - Valid syntax: block ''[file_name]'''
+  type: SyntaxError
+- id: block-mut-unclosed
+  error: 'Liquid syntax error: ''block'' tag was never closed'
+  type: SyntaxError
+- id: block-themecheck-dotted-file-name
+  error: 'Liquid syntax error: in ''block'' - Valid syntax: block ''[file_name]'''
+  type: SyntaxError
+- id: block-valid-all-properties
+  error:
+  type:
+- id: block-valid-basic
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/break.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/break.snap.yml
@@ -1,0 +1,65 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: break-100
+  error:
+  type:
+- id: break-101
+  error:
+  type:
+- id: break-102
+  error:
+  type:
+- id: break-103
+  error:
+  type:
+- id: break-104
+  error:
+  type:
+- id: break-200
+  error:
+  type:
+- id: break-201
+  error:
+  type:
+- id: break-202
+  error:
+  type:
+- id: break-203
+  error:
+  type:
+- id: break-204
+  error:
+  type:
+- id: break-205
+  error:
+  type:
+- id: break-206
+  error:
+  type:
+- id: break-207
+  error:
+  type:
+- id: break-208
+  error:
+  type:
+- id: break-209
+  error:
+  type:
+- id: break-300
+  error:
+  type:
+- id: break-301
+  error:
+  type:
+- id: break-302
+  error:
+  type:
+- id: break-303
+  error:
+  type:
+- id: break-304
+  error:
+  type:
+- id: break-themecheck-tablerow-interrupt
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/capture.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/capture.snap.yml
@@ -1,0 +1,92 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: capture-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: capture-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: capture-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: capture-mut-end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  type: SyntaxError
+- id: capture-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  type: SyntaxError
+- id: capture-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: capture-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+  type: SyntaxError
+- id: capture-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  type: SyntaxError
+- id: capture-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: capture-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: capture-mut-end-trail-open_square
+  error: 'Liquid syntax error: Expected end_of_string but found open_square in "x
+    ["'
+  type: SyntaxError
+- id: capture-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: capture-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: capture-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: capture-mut-variable_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in ""'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: capture-mut-variable_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: capture-mut-variable_name-number
+  error: 'Liquid syntax error: Expected id but found number in "42"'
+  type: SyntaxError
+- id: capture-themecheck-bare-bracket
+  error: 'Liquid syntax error: Expected id but found open_square in "[0]"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/case.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/case.snap.yml
@@ -1,0 +1,532 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: case-branch-else-valid
+  error:
+  type:
+- id: case-mut-case_expression-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "[0]"'
+  type: SyntaxError
+- id: case-mut-case_expression-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  type: SyntaxError
+- id: case-mut-case_expression-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  type: SyntaxError
+- id: case-mut-case_expression-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  type: SyntaxError
+- id: case-mut-case_expression-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  type: SyntaxError
+- id: case-mut-case_expression-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  type: SyntaxError
+- id: case-mut-case_expression-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  type: SyntaxError
+- id: case-mut-case_expression-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  type: SyntaxError
+- id: case-mut-case_expression-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  type: SyntaxError
+- id: case-mut-case_expression-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  type: SyntaxError
+- id: case-mut-case_expression-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  type: SyntaxError
+- id: case-mut-case_expression-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "contains"'
+  type: SyntaxError
+- id: case-mut-case_expression-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  type: SyntaxError
+- id: case-mut-case_expression-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  type: SyntaxError
+- id: case-mut-case_expression-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  type: SyntaxError
+- id: case-mut-case_expression-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: case-mut-case_expression-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: case-mut-case_expression-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  type: SyntaxError
+- id: case-mut-case_expression-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x.123"'
+  type: SyntaxError
+- id: case-mut-case_expression-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x."y""'
+  type: SyntaxError
+- id: case-mut-case_expression-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  type: SyntaxError
+- id: case-mut-case_expression-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  type: SyntaxError
+- id: case-mut-case_expression-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  type: SyntaxError
+- id: case-mut-case_expression-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  type: SyntaxError
+- id: case-mut-case_expression-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  type: SyntaxError
+- id: case-mut-case_expression-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  type: SyntaxError
+- id: case-mut-case_expression-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  type: SyntaxError
+- id: case-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: case-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: case-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: case-mut-end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  type: SyntaxError
+- id: case-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  type: SyntaxError
+- id: case-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: case-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  type: SyntaxError
+- id: case-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  type: SyntaxError
+- id: case-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: case-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: case-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  type: SyntaxError
+- id: case-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: case-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: case-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: case-mut-valid-000
+  error:
+  type:
+- id: case-mut-valid-000-2
+  error:
+  type:
+- id: case-mut-valid-001
+  error:
+  type:
+- id: case-mut-valid-001-2
+  error:
+  type:
+- id: case-mut-valid-002
+  error:
+  type:
+- id: case-mut-valid-002-2
+  error:
+  type:
+- id: case-mut-valid-003
+  error:
+  type:
+- id: case-mut-valid-003-2
+  error:
+  type:
+- id: case-mut-valid-004
+  error:
+  type:
+- id: case-mut-valid-004-2
+  error:
+  type:
+- id: case-mut-valid-005
+  error:
+  type:
+- id: case-mut-valid-005-2
+  error:
+  type:
+- id: case-mut-valid-006
+  error:
+  type:
+- id: case-mut-valid-006-2
+  error:
+  type:
+- id: case-mut-valid-007
+  error:
+  type:
+- id: case-mut-valid-007-2
+  error:
+  type:
+- id: case-mut-valid-008
+  error:
+  type:
+- id: case-mut-valid-008-2
+  error:
+  type:
+- id: case-mut-valid-009
+  error:
+  type:
+- id: case-mut-valid-009-2
+  error:
+  type:
+- id: case-mut-valid-010
+  error:
+  type:
+- id: case-mut-valid-010-2
+  error:
+  type:
+- id: case-mut-valid-011
+  error:
+  type:
+- id: case-mut-valid-011-2
+  error:
+  type:
+- id: case-mut-valid-012
+  error:
+  type:
+- id: case-mut-valid-012-2
+  error:
+  type:
+- id: case-mut-valid-013
+  error:
+  type:
+- id: case-mut-valid-013-2
+  error:
+  type:
+- id: case-mut-valid-014
+  error:
+  type:
+- id: case-mut-valid-014-2
+  error:
+  type:
+- id: case-mut-when_end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round'
+  type: SyntaxError
+- id: case-mut-when_end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square'
+  type: SyntaxError
+- id: case-mut-when_end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon'
+  type: SyntaxError
+- id: case-mut-when_end-trail-comma
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison'
+  type: SyntaxError
+- id: case-mut-when_end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash'
+  type: SyntaxError
+- id: case-mut-when_end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string'
+  type: SyntaxError
+- id: case-mut-when_end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id'
+  type: SyntaxError
+- id: case-mut-when_end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number'
+  type: SyntaxError
+- id: case-mut-when_end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round'
+  type: SyntaxError
+- id: case-mut-when_end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe'
+  type: SyntaxError
+- id: case-mut-when_end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question'
+  type: SyntaxError
+- id: case-mut-when_end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string'
+  type: SyntaxError
+- id: case-mut-when_next_value-bare_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-close_round-004
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-close_square-003
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-colon-002
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-comparison-009
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-comparison-010
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-comparison-011
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-comparison-012
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-comparison-013
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-comparison-014
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-comparison-015
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-dash-006
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-dot-007
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-dotdot-008
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-eos-016
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character &'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character *'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character `'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character #'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ;'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character "'
+  type: SyntaxError
+- id: case-mut-when_next_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '''
+  type: SyntaxError
+- id: case-mut-when_next_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-lookup-dot_number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-lookup-dot_string
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-lookup-trailing_dot
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-lookup-unclosed_range
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-pipe-000
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_next_value-question-005
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead'
+  type: SyntaxError
+- id: case-mut-when_value-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character &'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character *'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character `'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character #'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ;'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character "'
+  type: SyntaxError
+- id: case-mut-when_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '''
+  type: SyntaxError
+- id: case-mut-when_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number'
+  type: SyntaxError
+- id: case-mut-when_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string'
+  type: SyntaxError
+- id: case-mut-when_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma'
+  type: SyntaxError
+- id: case-mut-when_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string'
+  type: SyntaxError
+- id: case-mut-when_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string'
+  type: SyntaxError
+- id: case-mut-when_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string'
+  type: SyntaxError
+- id: case-mut-when_value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression'
+  type: SyntaxError
+- id: case-mut-when_value-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression'
+  type: SyntaxError
+- id: case-parity-elsif-in-case
+  error: 'Liquid syntax error: Unknown tag ''elsif'''
+  type: SyntaxError
+- id: case-themecheck-unclosed-when-string
+  error: 'Liquid syntax error: Unexpected character '''
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/comment.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/comment.snap.yml
@@ -1,0 +1,107 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: comment-001
+  error: 'Liquid syntax error: ''comment'' tag was never closed'
+  type: SyntaxError
+- id: comment-002
+  error: 'Liquid syntax error: ''comment'' tag was never closed'
+  type: SyntaxError
+- id: comment-003
+  error: 'Liquid syntax error: ''comment'' tag was never closed'
+  type: SyntaxError
+- id: comment-004
+  error: 'Liquid syntax error: ''comment'' tag was never closed'
+  type: SyntaxError
+- id: comment-005
+  error: 'Liquid syntax error: ''comment'' tag was never closed'
+  type: SyntaxError
+- id: comment-020
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: comment-021
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: comment-100
+  error:
+  type:
+- id: comment-101
+  error:
+  type:
+- id: comment-102
+  error:
+  type:
+- id: comment-103
+  error:
+  type:
+- id: comment-104
+  error:
+  type:
+- id: comment-105
+  error:
+  type:
+- id: comment-106
+  error:
+  type:
+- id: comment-107
+  error:
+  type:
+- id: comment-108
+  error:
+  type:
+- id: comment-109
+  error:
+  type:
+- id: comment-110
+  error:
+  type:
+- id: comment-111
+  error:
+  type:
+- id: comment-120
+  error:
+  type:
+- id: comment-121
+  error: 'Liquid syntax error: ''comment'' tag was never closed'
+  type: SyntaxError
+- id: comment-122
+  error:
+  type:
+- id: comment-123
+  error:
+  type:
+- id: comment-130
+  error:
+  type:
+- id: comment-131
+  error:
+  type:
+- id: comment-140
+  error:
+  type:
+- id: comment-141
+  error:
+  type:
+- id: comment-150
+  error:
+  type:
+- id: comment-151
+  error:
+  type:
+- id: comment-160
+  error:
+  type:
+- id: comment-161
+  error: 'Liquid syntax error: Unknown tag ''endcomment'''
+  type: SyntaxError
+- id: comment-themecheck-invalid-liquid-body
+  error: 'Liquid syntax error: ''comment'' tag was never closed'
+  type: SyntaxError
+- id: comment-themecheck-nested-followed-by-independent
+  error: 'Liquid syntax error: ''comment'' tag was never closed'
+  type: SyntaxError
+- id: comment-themecheck-raw-followed-by-independent
+  error: 'Liquid syntax error: ''comment'' tag was never closed'
+  type: SyntaxError
+- id: comment-themecheck-whitespace-control-raw-body
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/content_for.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/content_for.snap.yml
@@ -1,0 +1,153 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: content_for-100
+  error:
+  type:
+- id: content_for-101
+  error:
+  type:
+- id: content_for-102
+  error:
+  type:
+- id: content_for-103
+  error:
+  type:
+- id: content_for-104
+  error:
+  type:
+- id: content_for-200
+  error: 'Liquid syntax error: in ''content_for'' - ''type'' must be a quoted string.
+    in "blocks"'
+  type: SyntaxError
+- id: content_for-201
+  error: 'Liquid syntax error: in ''content_for'' - ''type'' must be a quoted string.
+    in "???"'
+  type: SyntaxError
+- id: content_for-202
+  error: 'Liquid syntax error: Expected id but found colon in "''block'', closest.:
+    ''text''"'
+  type: SyntaxError
+- id: content_for-203
+  error: 'Liquid syntax error: Expected colon but found string in "''blocks'', type
+    "text""'
+  type: SyntaxError
+- id: content_for-204
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "''blocks'',
+    closest.product: |"'
+  type: SyntaxError
+- id: content_for-205
+  error: 'Liquid syntax error: Expected end_of_string but found id in "''blocks''
+    trailing garbage"'
+  type: SyntaxError
+- id: content_for-206
+  error: 'Liquid syntax error: Unexpected character = in "''block'', type: foo=>bar"'
+  type: SyntaxError
+- id: content_for-300
+  error: 'Liquid syntax error: in ''content_for'' - Valid syntax: content_for ''[type]'''
+  type: SyntaxError
+- id: content_for-301
+  error: 'Liquid error: in ''content_for'' - "invalid" must be one of []'
+  type: ArgumentError
+- id: content_for-302
+  error: 'Liquid syntax error: Error in tag ''content_for "block"'' - Duplicated attribute:
+    color in "''block'', type: ''text'', id: ''x'', color: ''red'', color: ''blue''"'
+  type: SyntaxError
+- id: content_for-303
+  error: 'Liquid syntax error: Error in tag ''content_for ''block'' - The following
+    attributes are reserved and cannot be used: schema in "''block'', type: ''text'',
+    id: ''x'', schema: ''y''"'
+  type: SyntaxError
+- id: content_for-304
+  error: |-
+    Liquid syntax error: Error in tag 'content_for 'block' - Valid syntax:
+     {% content_for 'block', type: '[block_type]', id: '[block_id]' %}
+     Or
+     {% content_for 'block', id: '[block_id]', type: '[block_type]' %} in "'block', type: myvar, id: 'x'"
+  type: SyntaxError
+- id: content_for-305
+  error: 'Liquid syntax error: Error in tag ''content_for ''block'' - Value must be
+    set for key: type in "''block'', type: '''', id: ''x''"'
+  type: SyntaxError
+- id: content_for-306
+  error: 'Liquid syntax error: Error in tag ''content_for ''block'' - Value must be
+    set for key: id in "''block'', id: '''', type: ''x''"'
+  type: SyntaxError
+- id: content_for-307
+  error: 'Liquid syntax error: Error in tag ''content_for "blocks"'' - String is not
+    allowed for closest.<type> argument. Use compatible variable instead in "''blocks'',
+    closest.product: ''invalid''"'
+  type: SyntaxError
+- id: content_for-308
+  error: 'Liquid syntax error: Error in tag ''content_for "blocks"'' - Unknown attributes:
+    extra in "''blocks'', extra: ''val''"'
+  type: SyntaxError
+- id: content_for-309
+  error: 'Liquid syntax error: Error in tag ''content_for "blocks"'' - Only one closest.<type>
+    argument is allowed in "''blocks'', closest.product: p, closest.article: a"'
+  type: SyntaxError
+- id: content_for-310
+  error: 'Liquid syntax error: Error in tag ''content_for "blocks"'' - Only one of
+    the following context arguments is allowed in this format: closest.article, closest.blog,
+    closest.collection, closest.page, closest.product or closest.metaobject.<metaobject
+    type> in "''blocks'', closest.settings: true"'
+  type: SyntaxError
+- id: content_for-311
+  error: |-
+    Liquid syntax error: Error in tag 'content_for 'block' - Valid syntax:
+     {% content_for 'block', type: '[block_type]', id: '[block_id]' %}
+     Or
+     {% content_for 'block', id: '[block_id]', type: '[block_type]' %} in "'block', type: 'text'"
+  type: SyntaxError
+- id: content_for-312
+  error: |-
+    Liquid syntax error: Error in tag 'content_for 'block' - Valid syntax:
+     {% content_for 'block', type: '[block_type]', id: '[block_id]' %}
+     Or
+     {% content_for 'block', id: '[block_id]', type: '[block_type]' %} in "'block', id: 'x'"
+  type: SyntaxError
+- id: content_for-313
+  error: 'Liquid syntax error: Error in tag ''content_for ''block'' - The following
+    attributes are reserved and cannot be used: block in "''block'', type: ''text'',
+    id: ''x'', block: ''y''"'
+  type: SyntaxError
+- id: content_for-314
+  error:
+  type:
+- id: content_for-llm-900
+  error: 'Liquid syntax error: in ''content_for'' - ''type'' must be a quoted string.
+    in "block"'
+  type: SyntaxError
+- id: content_for-themecheck-block-closest-metaobject-custom-type
+  error:
+  type:
+- id: content_for-themecheck-block-closest-metaobject-without-type
+  error: 'Liquid syntax error: Error in tag ''content_for "block"'' - Only one of
+    the following context arguments is allowed in this format: closest.article, closest.blog,
+    closest.collection, closest.page, closest.product or closest.metaobject.<metaobject
+    type> in "''block'', type: ''text'', id: ''x'', closest.metaobject: metaobject"'
+  type: SyntaxError
+- id: content_for-themecheck-block-closest-product
+  error:
+  type:
+- id: content_for-themecheck-block-closest-product-property
+  error: 'Liquid syntax error: Error in tag ''content_for "block"'' - Only one of
+    the following context arguments is allowed in this format: closest.article, closest.blog,
+    closest.collection, closest.page, closest.product or closest.metaobject.<metaobject
+    type> in "''block'', type: ''text'', id: ''x'', closest.product.s: product"'
+  type: SyntaxError
+- id: content_for-themecheck-block-closest-settings
+  error: 'Liquid syntax error: Error in tag ''content_for "block"'' - Only one of
+    the following context arguments is allowed in this format: closest.article, closest.blog,
+    closest.collection, closest.page, closest.product or closest.metaobject.<metaobject
+    type> in "''block'', type: ''text'', id: ''x'', closest.settings: settings"'
+  type: SyntaxError
+- id: content_for-themecheck-block-multiple-closest
+  error: 'Liquid syntax error: Error in tag ''content_for "block"'' - Only one closest.<type>
+    argument is allowed in "''block'', type: ''text'', id: ''x'', closest.product:
+    product, closest.article: article"'
+  type: SyntaxError
+- id: content_for-themecheck-block-quoted-closest
+  error: 'Liquid syntax error: Error in tag ''content_for "block"'' - String is not
+    allowed for closest.<type> argument. Use compatible variable instead in "''block'',
+    type: ''text'', id: ''x'', closest.product: ''invalid''"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/continue.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/continue.snap.yml
@@ -1,0 +1,65 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: continue-100
+  error:
+  type:
+- id: continue-101
+  error:
+  type:
+- id: continue-102
+  error:
+  type:
+- id: continue-103
+  error:
+  type:
+- id: continue-104
+  error:
+  type:
+- id: continue-200
+  error:
+  type:
+- id: continue-201
+  error:
+  type:
+- id: continue-202
+  error:
+  type:
+- id: continue-203
+  error:
+  type:
+- id: continue-204
+  error:
+  type:
+- id: continue-205
+  error:
+  type:
+- id: continue-206
+  error:
+  type:
+- id: continue-207
+  error:
+  type:
+- id: continue-208
+  error:
+  type:
+- id: continue-209
+  error:
+  type:
+- id: continue-300
+  error:
+  type:
+- id: continue-301
+  error:
+  type:
+- id: continue-302
+  error:
+  type:
+- id: continue-303
+  error:
+  type:
+- id: continue-304
+  error:
+  type:
+- id: continue-themecheck-liquid-statement
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/cycle.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/cycle.snap.yml
@@ -1,0 +1,598 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: cycle-mut-cycle_value-bare_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , [0]"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-bare_bracket-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , [0]"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-close_round-004
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , )"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-close_round-004-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , )"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-close_square-003
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , ]"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-close_square-003-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ]"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-colon-002
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , :"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-colon-002-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , :"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , ,"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comma-001-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ,"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-009
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , =="'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-009-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , =="'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-010
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , !="'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-010-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , !="'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-011
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , <"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-011-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , <"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-012
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , >"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-012-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , >"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-013
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , <="'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-013-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , <="'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-014
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , >="'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-014-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , >="'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-015
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , contains"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-comparison-015-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , contains"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-dash-006
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , -"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-dash-006-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , -"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-dot-007
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , ."'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-dot-007-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ."'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-dotdot-008
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , .."'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-dotdot-008-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , .."'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-eos-016
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    ,"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-eos-016-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , ,"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x : x , , &"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-ampersand-2
+  error: 'Liquid syntax error: Unexpected character & in "x , , &"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x : x , , *"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-asterisk-2
+  error: 'Liquid syntax error: Unexpected character * in "x , , *"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x : x , , @"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-at-2
+  error: 'Liquid syntax error: Unexpected character @ in "x , , @"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x : x , , \"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-backslash-2
+  error: 'Liquid syntax error: Unexpected character \ in "x , , \"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x : x , , `"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-backtick-2
+  error: 'Liquid syntax error: Unexpected character ` in "x , , `"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x : x , , ^"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-caret-2
+  error: 'Liquid syntax error: Unexpected character ^ in "x , , ^"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x : x , , $"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-dollar-2
+  error: 'Liquid syntax error: Unexpected character $ in "x , , $"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x : x , , #"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-hash-2
+  error: 'Liquid syntax error: Unexpected character # in "x , , #"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x : x , , ;"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-semicolon-2
+  error: 'Liquid syntax error: Unexpected character ; in "x , , ;"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x : x , , ~"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-tilde-2
+  error: 'Liquid syntax error: Unexpected character ~ in "x , , ~"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x : x , , "hello"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-unclosed_double_quote-2
+  error: 'Liquid syntax error: Unexpected character " in "x , , "hello"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x : x , , ''hello"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lexerr-unclosed_single_quote-2
+  error: 'Liquid syntax error: Unexpected character '' in "x , , ''hello"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , x[,]"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-bracket_wrong_content-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x[,]"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-dot_number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , x.123"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-dot_number-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x.123"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-dot_string
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , x."y""'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-dot_string-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x."y""'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , (1, 5)"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-range_bad_separator-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , (1,
+    5)"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , (1..)"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-range_missing_end-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , (1..)"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-trailing_dot
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , x."'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-trailing_dot-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x."'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , x[0"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-unclosed_bracket-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x[0"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-unclosed_range
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , (1..5"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-lookup-unclosed_range-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , (1..5"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-pipe-000
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , |"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-pipe-000-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , |"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-question-005
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x ,
+    , ?"'
+  type: SyntaxError
+- id: cycle-mut-cycle_value-question-005-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ?"'
+  type: SyntaxError
+- id: cycle-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: cycle-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: cycle-mut-end-trail-colon
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x :"'
+  type: SyntaxError
+- id: cycle-mut-end-trail-comma
+  error:
+  type:
+- id: cycle-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  type: SyntaxError
+- id: cycle-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: cycle-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  type: SyntaxError
+- id: cycle-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  type: SyntaxError
+- id: cycle-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: cycle-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: cycle-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  type: SyntaxError
+- id: cycle-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: cycle-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: cycle-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x : [0]"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    : )"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    : ]"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x : :"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : ,"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    : =="'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    : !="'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    : <"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    : >"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    : <="'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    : >="'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x : contains"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x : -"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x : ."'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x : .."'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x :"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x : &"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x : *"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x : @"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x : \"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x : `"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x : ^"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x : $"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x : #"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x : ;"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x : ~"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x : "hello"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x : ''hello"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x[,]"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x : x.123"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x : x."y""'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x : (1, 5)"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    : (1..)"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x : x."'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    : x[0"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    : (1..5"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x : |"'
+  type: SyntaxError
+- id: cycle-mut-first_cycle_value-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x :
+    ?"'
+  type: SyntaxError
+- id: cycle-mut-first_value-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "[0]"'
+  type: SyntaxError
+- id: cycle-mut-first_value-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  type: SyntaxError
+- id: cycle-mut-first_value-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  type: SyntaxError
+- id: cycle-mut-first_value-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  type: SyntaxError
+- id: cycle-mut-first_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  type: SyntaxError
+- id: cycle-mut-first_value-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  type: SyntaxError
+- id: cycle-mut-first_value-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  type: SyntaxError
+- id: cycle-mut-first_value-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  type: SyntaxError
+- id: cycle-mut-first_value-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  type: SyntaxError
+- id: cycle-mut-first_value-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  type: SyntaxError
+- id: cycle-mut-first_value-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  type: SyntaxError
+- id: cycle-mut-first_value-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "contains"'
+  type: SyntaxError
+- id: cycle-mut-first_value-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  type: SyntaxError
+- id: cycle-mut-first_value-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  type: SyntaxError
+- id: cycle-mut-first_value-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  type: SyntaxError
+- id: cycle-mut-first_value-eos-016
+  error: 'Liquid syntax error: Syntax Error in ''cycle'' - Valid syntax: cycle [name
+    :] var [, var2, var3 ...] in ""'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x.123"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x."y""'
+  type: SyntaxError
+- id: cycle-mut-first_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  type: SyntaxError
+- id: cycle-mut-first_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  type: SyntaxError
+- id: cycle-mut-first_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  type: SyntaxError
+- id: cycle-mut-first_value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  type: SyntaxError
+- id: cycle-mut-first_value-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  type: SyntaxError
+- id: cycle-mut-pregate-000
+  error: 'Liquid syntax error: Syntax Error in ''cycle'' - Valid syntax: cycle [name
+    :] var [, var2, var3 ...] in ""'
+  type: SyntaxError
+- id: cycle-mut-valid-000
+  error:
+  type:
+- id: cycle-mut-valid-001
+  error:
+  type:
+- id: cycle-mut-valid-002
+  error:
+  type:
+- id: cycle-mut-valid-003
+  error:
+  type:
+- id: cycle-mut-valid-004
+  error:
+  type:
+- id: cycle-mut-valid-005
+  error:
+  type:
+- id: cycle-mut-valid-006
+  error:
+  type:
+- id: cycle-mut-valid-007
+  error:
+  type:
+- id: cycle-mut-valid-008
+  error:
+  type:
+- id: cycle-mut-valid-009
+  error:
+  type:
+- id: cycle-mut-valid-010
+  error:
+  type:
+- id: cycle-mut-valid-011
+  error:
+  type:
+- id: cycle-mut-valid-012
+  error:
+  type:
+- id: cycle-mut-valid-013
+  error:
+  type:
+- id: cycle-mut-valid-014
+  error:
+  type:
+- id: cycle-themecheck-trailing-comma-lookup
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/decrement.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/decrement.snap.yml
@@ -1,0 +1,92 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: decrement-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: decrement-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: decrement-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: decrement-mut-end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  type: SyntaxError
+- id: decrement-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  type: SyntaxError
+- id: decrement-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: decrement-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+  type: SyntaxError
+- id: decrement-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  type: SyntaxError
+- id: decrement-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: decrement-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: decrement-mut-end-trail-open_square
+  error: 'Liquid syntax error: Expected end_of_string but found open_square in "x
+    ["'
+  type: SyntaxError
+- id: decrement-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: decrement-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: decrement-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in ""'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: decrement-mut-variable_name-number
+  error: 'Liquid syntax error: Expected id but found number in "42"'
+  type: SyntaxError
+- id: decrement-themecheck-bare-bracket
+  error: 'Liquid syntax error: Expected id but found open_square in "[0]"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/doc.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/doc.snap.yml
@@ -1,0 +1,147 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: doc-001
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-002
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-003
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-004
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-005
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-006
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-007
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-008
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-009
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-010
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{%
+    enddoc %}'
+  type: SyntaxError
+- id: doc-020
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  type: SyntaxError
+- id: doc-021
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  type: SyntaxError
+- id: doc-022
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  type: SyntaxError
+- id: doc-023
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  type: SyntaxError
+- id: doc-024
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  type: SyntaxError
+- id: doc-025
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  type: SyntaxError
+- id: doc-040
+  error: 'Liquid syntax error: ''doc'' tag was never closed'
+  type: SyntaxError
+- id: doc-041
+  error: 'Liquid syntax error: ''doc'' tag was never closed'
+  type: SyntaxError
+- id: doc-042
+  error: 'Liquid syntax error: ''doc'' tag was never closed'
+  type: SyntaxError
+- id: doc-043
+  error: 'Liquid syntax error: ''doc'' tag was never closed'
+  type: SyntaxError
+- id: doc-044
+  error: 'Liquid syntax error: ''doc'' tag was never closed'
+  type: SyntaxError
+- id: doc-045
+  error: 'Liquid syntax error: ''doc'' tag was never closed'
+  type: SyntaxError
+- id: doc-100
+  error:
+  type:
+- id: doc-101
+  error:
+  type:
+- id: doc-102
+  error:
+  type:
+- id: doc-103
+  error:
+  type:
+- id: doc-104
+  error:
+  type:
+- id: doc-105
+  error:
+  type:
+- id: doc-106
+  error:
+  type:
+- id: doc-107
+  error:
+  type:
+- id: doc-108
+  error:
+  type:
+- id: doc-109
+  error:
+  type:
+- id: doc-110
+  error:
+  type:
+- id: doc-111
+  error:
+  type:
+- id: doc-112
+  error:
+  type:
+- id: doc-113
+  error:
+  type:
+- id: doc-114
+  error: 'Liquid syntax error: Unknown tag ''enddoc'''
+  type: SyntaxError
+- id: doc-115
+  error:
+  type:
+- id: doc-116
+  error:
+  type:
+- id: doc-117
+  error:
+  type:
+- id: doc-themecheck-marked-closer-then-balanced
+  error:
+  type:
+- id: doc-themecheck-marked-closer-then-unclosed
+  error: 'Liquid syntax error: ''doc'' tag was never closed'
+  type: SyntaxError
+- id: doc-themecheck-nested-whitespace-control
+  error: 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  type: SyntaxError
+- id: doc-themecheck-similar-prefix
+  error:
+  type:
+- id: doc-themecheck-whitespace-control-marked-closer
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/echo.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/echo.snap.yml
@@ -1,0 +1,722 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: echo-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "{{x
+    ) }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "{{x
+    ] }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "{{x : }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "{{x , }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "{{x
+    == }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "{{x - }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{x . }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "{{x extra }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "{{x 42
+    }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "{{x
+    ( }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "{{x
+    [ }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{x | }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "{{x ?
+    }}"'
+  type: SyntaxError
+- id: echo-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "{{x ''hi''
+    }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-bare_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , [0] }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-close_round-004
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , ) }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-close_square-003
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , ] }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-colon-002
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , : }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , , }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-comparison-009
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , == }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-comparison-010
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , != }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-comparison-011
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , < }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-comparison-012
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , > }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-comparison-013
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , <= }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-comparison-014
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , >= }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-comparison-015
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , contains }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-dash-006
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , - }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-dot-007
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , . }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-dotdot-008
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , .. }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-eos-016
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{x | x : x , , & }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{x | x : x , , * }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{x | x : x , , @ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{x | x : x , , \ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{x | x : x , , ` }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{x | x : x , , ^ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{x | x : x , , $ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{x | x : x , , # }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{x | x : x , , ; }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{x | x : x , , ~ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{x | x : x , , "hello }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{x | x : x , , ''hello
+    }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x[,] }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lookup-dot_number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x.123 }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lookup-dot_string
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x."y" }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , (1, 5) }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , (1..) }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x. }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x[0 }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , (1..5 }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-pipe-000
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , | }}"'
+  type: SyntaxError
+- id: echo-mut-filter_arg_value-question-005
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , ? }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "{{x | x : [0] }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{x
+    | x : ) }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{x
+    | x : ] }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{x | x
+    : : }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : , }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{x
+    | x : == }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{x
+    | x : != }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{x
+    | x : < }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{x
+    | x : > }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{x
+    | x : <= }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{x
+    | x : >= }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "{{x | x : contains }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{x | x
+    : - }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{x | x :
+    . }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{x |
+    x : .. }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-eos-016
+  error:
+  type:
+- id: echo-mut-filter_first_arg-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{x | x : & }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{x | x : * }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{x | x : @ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{x | x : \ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{x | x : ` }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{x | x : ^ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{x | x : $ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{x | x : # }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{x | x : ; }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{x | x : ~ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{x | x : "hello }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{x | x : ''hello }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x[,] }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "{{x | x : x.123 }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "{{x | x : x."y" }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "{{x | x : (1, 5)
+    }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{x
+    | x : (1..) }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{x | x : x.
+    }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "{{x
+    | x : x[0 }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "{{x
+    | x : (1..5 }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-pipe-000
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{x | x : |
+    }}"'
+  type: SyntaxError
+- id: echo-mut-filter_first_arg-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{x
+    | x : ? }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{x | }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{x | & }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{x | * }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{x | @ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{x | \ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{x | ` }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{x | ^ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{x | $ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{x | # }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{x | ; }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{x | ~ }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{x | "hello }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{x | ''hello }}"'
+  type: SyntaxError
+- id: echo-mut-filter_name-number
+  error: 'Liquid syntax error: Expected id but found number in "{{x | 42 }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_colon-eos
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_colon-number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x 42 }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-bare_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : [0] }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-close_round-004
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : ) }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-close_square-003
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : ] }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-colon-002
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : : }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : , }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-comparison-009
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : == }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-comparison-010
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : != }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-comparison-011
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : < }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-comparison-012
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : > }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-comparison-013
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : <= }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-comparison-014
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : >= }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-comparison-015
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : contains }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-dash-006
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : - }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-dot-007
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : . }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-dotdot-008
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : .. }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-eos-016
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{x | x : x , , x : & }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{x | x : x , , x : * }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{x | x : x , , x : @ }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{x | x : x , , x : \ }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{x | x : x , , x : ` }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{x | x : x , , x : ^ }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{x | x : x , , x : $ }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{x | x : x , , x : # }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{x | x : x , , x : ; }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{x | x : x , , x : ~ }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{x | x : x , , x : "hello
+    }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{x | x : x , , x : ''hello
+    }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : x[,] }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lookup-dot_number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : x.123 }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lookup-dot_string
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : x."y" }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : (1, 5) }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : (1..) }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : x. }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : x[0 }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : (1..5 }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-pipe-000
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : | }}"'
+  type: SyntaxError
+- id: echo-mut-kwarg_value-question-005
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x
+    : x , , x : ? }}"'
+  type: SyntaxError
+- id: echo-mut-valid-000
+  error:
+  type:
+- id: echo-mut-valid-001
+  error:
+  type:
+- id: echo-mut-valid-002
+  error:
+  type:
+- id: echo-mut-valid-003
+  error:
+  type:
+- id: echo-mut-valid-004
+  error:
+  type:
+- id: echo-mut-valid-005
+  error:
+  type:
+- id: echo-mut-valid-006
+  error:
+  type:
+- id: echo-mut-valid-007
+  error:
+  type:
+- id: echo-mut-valid-008
+  error:
+  type:
+- id: echo-mut-valid-009
+  error:
+  type:
+- id: echo-mut-valid-010
+  error:
+  type:
+- id: echo-mut-valid-011
+  error:
+  type:
+- id: echo-mut-valid-012
+  error:
+  type:
+- id: echo-mut-valid-013
+  error:
+  type:
+- id: echo-mut-valid-014
+  error:
+  type:
+- id: echo-mut-value-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "{{[0] }}"'
+  type: SyntaxError
+- id: echo-mut-value-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{)
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{]
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{: }}"'
+  type: SyntaxError
+- id: echo-mut-value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{, }}"'
+  type: SyntaxError
+- id: echo-mut-value-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{==
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{!=
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{<
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{>
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{<=
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{>=
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "{{contains }}"'
+  type: SyntaxError
+- id: echo-mut-value-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{- }}"'
+  type: SyntaxError
+- id: echo-mut-value-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{. }}"'
+  type: SyntaxError
+- id: echo-mut-value-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{..
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-eos-016
+  error:
+  type:
+- id: echo-mut-value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{& }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{* }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{@ }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{\ }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{` }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{^ }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{$ }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{# }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{; }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{~ }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{"hello }}"'
+  type: SyntaxError
+- id: echo-mut-value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{''hello }}"'
+  type: SyntaxError
+- id: echo-mut-value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x[,]
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "{{x.123 }}"'
+  type: SyntaxError
+- id: echo-mut-value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "{{x."y" }}"'
+  type: SyntaxError
+- id: echo-mut-value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "{{(1, 5) }}"'
+  type: SyntaxError
+- id: echo-mut-value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{(1..)
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{x. }}"'
+  type: SyntaxError
+- id: echo-mut-value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "{{x[0
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "{{(1..5
+    }}"'
+  type: SyntaxError
+- id: echo-mut-value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "{{| }}"'
+  type: SyntaxError
+- id: echo-mut-value-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{?
+    }}"'
+  type: SyntaxError
+- id: echo-themecheck-empty-first-filter-arg
+  error:
+  type:
+- id: echo-themecheck-filter-separator-adjacent-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "{{n | pluralize:
+    ''comment'': ''comments'' }}"'
+  type: SyntaxError
+- id: echo-themecheck-filter-separator-leading-comma
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{n | f1:
+    , }}"'
+  type: SyntaxError
+- id: echo-themecheck-filter-separator-leading-comma-before-pipe
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{n | f1:
+    , | f2 }}"'
+  type: SyntaxError
+- id: echo-themecheck-filter-separator-missing-comma
+  error: 'Liquid syntax error: Expected end_of_string but found number in "{{n | filter:
+    1 2, 3 }}"'
+  type: SyntaxError
+- id: echo-themecheck-filter-separator-mixed-positional-keyword
+  error:
+  type:
+- id: echo-themecheck-filter-separator-trailing-comma-before-pipe
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/elsif.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/elsif.snap.yml
@@ -1,0 +1,650 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: elsif-mut-elsif_boolean_comparison_rhs-bare_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    [0]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-close_round-004
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    )"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-close_square-003
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-colon-002
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    :"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-comma-001
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ,"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-009
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    =="'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-010
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    !="'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-011
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    <"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-012
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    >"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-013
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    <="'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-014
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    >="'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-comparison-015
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    contains"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-dash-006
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    -"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-dot-007
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ."'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-dotdot-008
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    .."'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-eos-016
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x =="'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and x x == &"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and x x == *"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and x x == @"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and x x == \"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and x x == `"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and x x == ^"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and x x == $"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and x x == #"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and x x == ;"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and x x == ~"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and x x == "hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and x x == ''hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x[,]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-dot_number
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x.123"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-dot_string
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x."y""'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1, 5)"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1..)"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x."'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x[0"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1..5"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-pipe-000
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    |"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_comparison_rhs-question-005
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ?"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-bare_bracket
+  error:
+  type:
+- id: elsif-mut-elsif_boolean_expr-close_round-004
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    and x )"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-close_square-003
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    and x ]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-colon-002
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x and x
+    :"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-comma-001
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x and x
+    ,"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-comparison-009
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x =="'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-comparison-010
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x !="'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-comparison-011
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x <"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-comparison-012
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x >"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-comparison-013
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x <="'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-comparison-014
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x >="'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-comparison-015
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x contains"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-dash-006
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x and x -"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-dot-007
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x and x ."'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-dotdot-008
+  error: 'Liquid syntax error: Expected end_of_string but found dotdot in "x and x
+    .."'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-eos-016
+  error:
+  type:
+- id: elsif-mut-elsif_boolean_expr-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and x &"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and x *"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and x @"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and x \"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and x `"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and x ^"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and x $"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and x #"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and x ;"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and x ~"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and x "hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and x ''hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x[,]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lookup-dot_number
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x.123"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lookup-dot_string
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x."y""'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1, 5)"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1..)"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x."'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x[0"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1..5"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-pipe-000
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x and x |"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_expr-question-005
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x and
+    x ?"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-eos
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and &"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and *"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and @"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and \"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and `"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and ^"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and $"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and #"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and ;"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and ~"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and "hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and ''hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_boolean_op-number
+  error:
+  type:
+- id: elsif-mut-elsif_comparison_rhs-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x == [0]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    == )"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    == ]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x == :"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == ,"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    == =="'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    == !="'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    == <"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    == >"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    == <="'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    == >="'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x == contains"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x == -"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x == ."'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x ==
+    .."'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x == &"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x == *"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x == @"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x == \"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x == `"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x == ^"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x == $"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x == #"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x == ;"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x == ~"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x == "hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x == ''hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == x[,]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x == x.123"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x == x."y""'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x == (1, 5)"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    == (1..)"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x == x."'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    == x[0"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    == (1..5"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x == |"'
+  type: SyntaxError
+- id: elsif-mut-elsif_comparison_rhs-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x ==
+    ?"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "[0]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "contains"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x.123"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x."y""'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  type: SyntaxError
+- id: elsif-mut-elsif_condition-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-comparison
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: elsif-mut-elsif_end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: elsif-mut-valid-000
+  error:
+  type:
+- id: elsif-mut-valid-001
+  error:
+  type:
+- id: elsif-mut-valid-002
+  error:
+  type:
+- id: elsif-mut-valid-003
+  error:
+  type:
+- id: elsif-mut-valid-004
+  error:
+  type:
+- id: elsif-mut-valid-005
+  error:
+  type:
+- id: elsif-mut-valid-006
+  error:
+  type:
+- id: elsif-mut-valid-007
+  error:
+  type:
+- id: elsif-mut-valid-008
+  error:
+  type:
+- id: elsif-mut-valid-009
+  error:
+  type:
+- id: elsif-mut-valid-010
+  error:
+  type:
+- id: elsif-mut-valid-011
+  error:
+  type:
+- id: elsif-mut-valid-012
+  error:
+  type:
+- id: elsif-mut-valid-013
+  error:
+  type:
+- id: elsif-mut-valid-014
+  error:
+  type:
+- id: elsif-themecheck-misplaced-branch
+  error: 'Liquid syntax error: Unknown tag ''elsif'''
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/for.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/for.snap.yml
@@ -1,0 +1,440 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: for-branch-else-valid
+  error:
+  type:
+- id: for-branch-when-in-for
+  error: 'Liquid syntax error: Unknown tag ''when'''
+  type: SyntaxError
+- id: for-mut-attr_colon-eos
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step ,"'
+  type: SyntaxError
+- id: for-mut-attr_colon-number
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , 42"'
+  type: SyntaxError
+- id: for-mut-attr_value-bare_bracket
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : [0]"'
+  type: SyntaxError
+- id: for-mut-attr_value-close_round-004
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : )"'
+  type: SyntaxError
+- id: for-mut-attr_value-close_square-003
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : ]"'
+  type: SyntaxError
+- id: for-mut-attr_value-colon-002
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : :"'
+  type: SyntaxError
+- id: for-mut-attr_value-comma-001
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : ,"'
+  type: SyntaxError
+- id: for-mut-attr_value-comparison-009
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : =="'
+  type: SyntaxError
+- id: for-mut-attr_value-comparison-010
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : !="'
+  type: SyntaxError
+- id: for-mut-attr_value-comparison-011
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : <"'
+  type: SyntaxError
+- id: for-mut-attr_value-comparison-012
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : >"'
+  type: SyntaxError
+- id: for-mut-attr_value-comparison-013
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : <="'
+  type: SyntaxError
+- id: for-mut-attr_value-comparison-014
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : >="'
+  type: SyntaxError
+- id: for-mut-attr_value-comparison-015
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : contains"'
+  type: SyntaxError
+- id: for-mut-attr_value-dash-006
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : -"'
+  type: SyntaxError
+- id: for-mut-attr_value-dot-007
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : ."'
+  type: SyntaxError
+- id: for-mut-attr_value-dotdot-008
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : .."'
+  type: SyntaxError
+- id: for-mut-attr_value-eos-016
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , :"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x in x step , : &"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x in x step , : *"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x in x step , : @"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x in x step , : \"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x in x step , : `"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x in x step , : ^"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x in x step , : $"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x in x step , : #"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x in x step , : ;"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x in x step , : ~"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x in x step , : "hello"'
+  type: SyntaxError
+- id: for-mut-attr_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x in x step , : ''hello"'
+  type: SyntaxError
+- id: for-mut-attr_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : x[,]"'
+  type: SyntaxError
+- id: for-mut-attr_value-lookup-dot_number
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : x.123"'
+  type: SyntaxError
+- id: for-mut-attr_value-lookup-dot_string
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : x."y""'
+  type: SyntaxError
+- id: for-mut-attr_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : (1, 5)"'
+  type: SyntaxError
+- id: for-mut-attr_value-lookup-range_missing_end
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : (1..)"'
+  type: SyntaxError
+- id: for-mut-attr_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : x."'
+  type: SyntaxError
+- id: for-mut-attr_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : x[0"'
+  type: SyntaxError
+- id: for-mut-attr_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : (1..5"'
+  type: SyntaxError
+- id: for-mut-attr_value-pipe-000
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : |"'
+  type: SyntaxError
+- id: for-mut-attr_value-question-005
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step , : ?"'
+  type: SyntaxError
+- id: for-mut-collection-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x in [0]"'
+  type: SyntaxError
+- id: for-mut-collection-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    in )"'
+  type: SyntaxError
+- id: for-mut-collection-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    in ]"'
+  type: SyntaxError
+- id: for-mut-collection-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x in :"'
+  type: SyntaxError
+- id: for-mut-collection-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in ,"'
+  type: SyntaxError
+- id: for-mut-collection-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    in =="'
+  type: SyntaxError
+- id: for-mut-collection-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    in !="'
+  type: SyntaxError
+- id: for-mut-collection-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    in <"'
+  type: SyntaxError
+- id: for-mut-collection-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    in >"'
+  type: SyntaxError
+- id: for-mut-collection-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    in <="'
+  type: SyntaxError
+- id: for-mut-collection-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    in >="'
+  type: SyntaxError
+- id: for-mut-collection-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x in contains"'
+  type: SyntaxError
+- id: for-mut-collection-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x in -"'
+  type: SyntaxError
+- id: for-mut-collection-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x in ."'
+  type: SyntaxError
+- id: for-mut-collection-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x in
+    .."'
+  type: SyntaxError
+- id: for-mut-collection-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x in &"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x in *"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x in @"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x in \"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x in `"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x in ^"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x in $"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x in #"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x in ;"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x in ~"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x in "hello"'
+  type: SyntaxError
+- id: for-mut-collection-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x in ''hello"'
+  type: SyntaxError
+- id: for-mut-collection-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in x[,]"'
+  type: SyntaxError
+- id: for-mut-collection-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x in x.123"'
+  type: SyntaxError
+- id: for-mut-collection-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x in x."y""'
+  type: SyntaxError
+- id: for-mut-collection-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x in (1, 5)"'
+  type: SyntaxError
+- id: for-mut-collection-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    in (1..)"'
+  type: SyntaxError
+- id: for-mut-collection-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x in x."'
+  type: SyntaxError
+- id: for-mut-collection-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    in x[0"'
+  type: SyntaxError
+- id: for-mut-collection-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    in (1..5"'
+  type: SyntaxError
+- id: for-mut-collection-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x in |"'
+  type: SyntaxError
+- id: for-mut-collection-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x in
+    ?"'
+  type: SyntaxError
+- id: for-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    in x )"'
+  type: SyntaxError
+- id: for-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    in x ]"'
+  type: SyntaxError
+- id: for-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x in x :"'
+  type: SyntaxError
+- id: for-mut-end-trail-comma
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x ,"'
+  type: SyntaxError
+- id: for-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x in
+    x =="'
+  type: SyntaxError
+- id: for-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x in x -"'
+  type: SyntaxError
+- id: for-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x in x ."'
+  type: SyntaxError
+- id: for-mut-end-trail-id
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x extra"'
+  type: SyntaxError
+- id: for-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x in x
+    42"'
+  type: SyntaxError
+- id: for-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x in
+    x ("'
+  type: SyntaxError
+- id: for-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in
+    x ["'
+  type: SyntaxError
+- id: for-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x in x |"'
+  type: SyntaxError
+- id: for-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x in
+    x ?"'
+  type: SyntaxError
+- id: for-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x in x
+    ''hi''"'
+  type: SyntaxError
+- id: for-mut-in_keyword-eos
+  error: 'Liquid syntax error: For loops require an ''in'' clause in "x"'
+  type: SyntaxError
+- id: for-mut-in_keyword-id
+  error: 'Liquid syntax error: For loops require an ''in'' clause in "x of"'
+  type: SyntaxError
+- id: for-mut-invalid_attribute-invalid
+  error: 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are
+    limit and offset in "x in x step ,"'
+  type: SyntaxError
+- id: for-mut-valid-000
+  error:
+  type:
+- id: for-mut-valid-001
+  error:
+  type:
+- id: for-mut-valid-002
+  error:
+  type:
+- id: for-mut-valid-003
+  error:
+  type:
+- id: for-mut-valid-004
+  error:
+  type:
+- id: for-mut-valid-005
+  error:
+  type:
+- id: for-mut-valid-006
+  error:
+  type:
+- id: for-mut-valid-007
+  error:
+  type:
+- id: for-mut-valid-008
+  error:
+  type:
+- id: for-mut-valid-009
+  error:
+  type:
+- id: for-mut-valid-010
+  error:
+  type:
+- id: for-mut-valid-011
+  error:
+  type:
+- id: for-mut-valid-012
+  error:
+  type:
+- id: for-mut-valid-013
+  error:
+  type:
+- id: for-mut-valid-014
+  error:
+  type:
+- id: for-mut-variable_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in ""'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: for-mut-variable_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: for-mut-variable_name-number
+  error: 'Liquid syntax error: Expected id but found number in "42"'
+  type: SyntaxError
+- id: for-parity-elsif-in-for
+  error: 'Liquid syntax error: Unknown tag ''elsif'''
+  type: SyntaxError
+- id: for-themecheck-skipped-prefix
+  error: 'Liquid syntax error: Unexpected character ! in "!x in xs"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/form.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/form.snap.yml
@@ -1,0 +1,509 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: form-mut-attrs_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x, y: x."'
+  type: SyntaxError
+- id: form-mut-attrs_value-pipe
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x, y: |"'
+  type: SyntaxError
+- id: form-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: form-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: form-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: form-mut-end-trail-comma
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ,"'
+  type: SyntaxError
+- id: form-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  type: SyntaxError
+- id: form-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: form-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  type: SyntaxError
+- id: form-mut-end-trail-id
+  error: 'Liquid syntax error: Expected colon but found end_of_string in "x extra"'
+  type: SyntaxError
+- id: form-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: form-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: form-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  type: SyntaxError
+- id: form-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: form-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: form-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: form-mut-kwarg_colon-eos
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x"'
+  type: SyntaxError
+- id: form-mut-kwarg_colon-number
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x 42"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-eos
+  error: 'Liquid syntax error: Expected colon but found comma in "x step ,"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x step , &"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x step , *"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x step , @"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x step , \"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x step , `"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x step , ^"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x step , $"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x step , #"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x step , ;"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x step , ~"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x step , "hello"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x step , ''hello"'
+  type: SyntaxError
+- id: form-mut-kwarg_name-number
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , 42"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-bare_bracket
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : [0]"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-close_round-004
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : )"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-close_square-003
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ]"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-colon-002
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : :"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-comma-001
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ,"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-comparison-009
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : =="'
+  type: SyntaxError
+- id: form-mut-kwarg_value-comparison-010
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : !="'
+  type: SyntaxError
+- id: form-mut-kwarg_value-comparison-011
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : <"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-comparison-012
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : >"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-comparison-013
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : <="'
+  type: SyntaxError
+- id: form-mut-kwarg_value-comparison-014
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : >="'
+  type: SyntaxError
+- id: form-mut-kwarg_value-comparison-015
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : contains"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-dash-006
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : -"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-dot-007
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ."'
+  type: SyntaxError
+- id: form-mut-kwarg_value-dotdot-008
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : .."'
+  type: SyntaxError
+- id: form-mut-kwarg_value-eos-016
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x :"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x step , x : &"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x step , x : *"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x step , x : @"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x step , x : \"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x step , x : `"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x step , x : ^"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x step , x : $"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x step , x : #"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x step , x : ;"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x step , x : ~"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x step , x : "hello"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x step , x : ''hello"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x[,]"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x.123"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x."y""'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : (1,
+    5)"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..)"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x."'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x[0"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..5"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-pipe-000
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : |"'
+  type: SyntaxError
+- id: form-mut-kwarg_value-question-005
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ?"'
+  type: SyntaxError
+- id: form-mut-type_expr-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "[0]"'
+  type: SyntaxError
+- id: form-mut-type_expr-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  type: SyntaxError
+- id: form-mut-type_expr-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  type: SyntaxError
+- id: form-mut-type_expr-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  type: SyntaxError
+- id: form-mut-type_expr-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  type: SyntaxError
+- id: form-mut-type_expr-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  type: SyntaxError
+- id: form-mut-type_expr-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  type: SyntaxError
+- id: form-mut-type_expr-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  type: SyntaxError
+- id: form-mut-type_expr-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  type: SyntaxError
+- id: form-mut-type_expr-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  type: SyntaxError
+- id: form-mut-type_expr-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  type: SyntaxError
+- id: form-mut-type_expr-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "contains"'
+  type: SyntaxError
+- id: form-mut-type_expr-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  type: SyntaxError
+- id: form-mut-type_expr-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  type: SyntaxError
+- id: form-mut-type_expr-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  type: SyntaxError
+- id: form-mut-type_expr-eos-016
+  error: 'Liquid syntax error: in ''form'' - Valid syntax: form ''type''[, object]
+    in ""'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: form-mut-type_expr-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: form-mut-type_expr-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  type: SyntaxError
+- id: form-mut-type_expr-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x.123"'
+  type: SyntaxError
+- id: form-mut-type_expr-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x."y""'
+  type: SyntaxError
+- id: form-mut-type_expr-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  type: SyntaxError
+- id: form-mut-type_expr-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  type: SyntaxError
+- id: form-mut-type_expr-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  type: SyntaxError
+- id: form-mut-type_expr-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  type: SyntaxError
+- id: form-mut-type_expr-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  type: SyntaxError
+- id: form-mut-type_expr-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  type: SyntaxError
+- id: form-mut-type_expr-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  type: SyntaxError
+- id: form-mut-valid-000
+  error:
+  type:
+- id: form-mut-valid-001
+  error:
+  type:
+- id: form-mut-valid-002
+  error:
+  type:
+- id: form-mut-valid-003
+  error:
+  type:
+- id: form-mut-valid-004
+  error:
+  type:
+- id: form-mut-valid-005
+  error:
+  type:
+- id: form-mut-valid-006
+  error:
+  type:
+- id: form-mut-valid-007
+  error:
+  type:
+- id: form-mut-valid-008
+  error:
+  type:
+- id: form-mut-valid-009
+  error:
+  type:
+- id: form-mut-valid-010
+  error:
+  type:
+- id: form-mut-valid-011
+  error:
+  type:
+- id: form-mut-valid-012
+  error:
+  type:
+- id: form-mut-valid-013
+  error:
+  type:
+- id: form-mut-valid-014
+  error:
+  type:
+- id: form-mut-variable_name-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x , [0]"'
+  type: SyntaxError
+- id: form-mut-variable_name-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    , )"'
+  type: SyntaxError
+- id: form-mut-variable_name-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    , ]"'
+  type: SyntaxError
+- id: form-mut-variable_name-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x , :"'
+  type: SyntaxError
+- id: form-mut-variable_name-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , ,"'
+  type: SyntaxError
+- id: form-mut-variable_name-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    , =="'
+  type: SyntaxError
+- id: form-mut-variable_name-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    , !="'
+  type: SyntaxError
+- id: form-mut-variable_name-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    , <"'
+  type: SyntaxError
+- id: form-mut-variable_name-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    , >"'
+  type: SyntaxError
+- id: form-mut-variable_name-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    , <="'
+  type: SyntaxError
+- id: form-mut-variable_name-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    , >="'
+  type: SyntaxError
+- id: form-mut-variable_name-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x , contains"'
+  type: SyntaxError
+- id: form-mut-variable_name-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x , -"'
+  type: SyntaxError
+- id: form-mut-variable_name-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x , ."'
+  type: SyntaxError
+- id: form-mut-variable_name-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x , .."'
+  type: SyntaxError
+- id: form-mut-variable_name-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ,"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x , &"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x , *"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x , @"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x , \"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x , `"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x , ^"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x , $"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x , #"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x , ;"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x , ~"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x , "hello"'
+  type: SyntaxError
+- id: form-mut-variable_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x , ''hello"'
+  type: SyntaxError
+- id: form-mut-variable_name-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , x[,]"'
+  type: SyntaxError
+- id: form-mut-variable_name-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x , x.123"'
+  type: SyntaxError
+- id: form-mut-variable_name-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x , x."y""'
+  type: SyntaxError
+- id: form-mut-variable_name-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x , (1, 5)"'
+  type: SyntaxError
+- id: form-mut-variable_name-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    , (1..)"'
+  type: SyntaxError
+- id: form-mut-variable_name-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x , x."'
+  type: SyntaxError
+- id: form-mut-variable_name-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    , x[0"'
+  type: SyntaxError
+- id: form-mut-variable_name-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    , (1..5"'
+  type: SyntaxError
+- id: form-mut-variable_name-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x , |"'
+  type: SyntaxError
+- id: form-mut-variable_name-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x ,
+    ?"'
+  type: SyntaxError
+- id: form-themecheck-positional-after-named
+  error: 'Liquid syntax error: Expected colon but found end_of_string in "''contact'',
+    id: ''login'', customer"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/if.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/if.snap.yml
@@ -1,0 +1,1301 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: if-branch-else-valid
+  error:
+  type:
+- id: if-branch-when-in-if
+  error: 'Liquid syntax error: Unknown tag ''when'''
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-bare_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    [0]"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-close_round-004
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    )"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-close_square-003
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ]"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-colon-002
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    :"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-comma-001
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ,"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-comparison-009
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    =="'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-comparison-010
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    !="'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-comparison-011
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    <"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-comparison-012
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    >"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-comparison-013
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    <="'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-comparison-014
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    >="'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-comparison-015
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    contains"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-dash-006
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    -"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-dot-007
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ."'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-dotdot-008
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    .."'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-eos-016
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x =="'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and x x == &"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and x x == *"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and x x == @"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and x x == \"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and x x == `"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and x x == ^"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and x x == $"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and x x == #"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and x x == ;"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and x x == ~"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and x x == "hello"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and x x == ''hello"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x[,]"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lookup-dot_number
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x.123"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lookup-dot_string
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x."y""'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1, 5)"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1..)"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x."'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x[0"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1..5"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-pipe-000
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    |"'
+  type: SyntaxError
+- id: if-mut-boolean_comparison_rhs-question-005
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ?"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-bare_bracket
+  error:
+  type:
+- id: if-mut-boolean_expr-close_round-004
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    and x )"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-close_square-003
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    and x ]"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-colon-002
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x and x
+    :"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-comma-001
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x and x
+    ,"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-comparison-009
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x =="'
+  type: SyntaxError
+- id: if-mut-boolean_expr-comparison-010
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x !="'
+  type: SyntaxError
+- id: if-mut-boolean_expr-comparison-011
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x <"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-comparison-012
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x >"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-comparison-013
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x <="'
+  type: SyntaxError
+- id: if-mut-boolean_expr-comparison-014
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x >="'
+  type: SyntaxError
+- id: if-mut-boolean_expr-comparison-015
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x contains"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-dash-006
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x and x -"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-dot-007
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x and x ."'
+  type: SyntaxError
+- id: if-mut-boolean_expr-dotdot-008
+  error: 'Liquid syntax error: Expected end_of_string but found dotdot in "x and x
+    .."'
+  type: SyntaxError
+- id: if-mut-boolean_expr-eos-016
+  error:
+  type:
+- id: if-mut-boolean_expr-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and x &"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and x *"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and x @"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and x \"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and x `"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and x ^"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and x $"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and x #"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and x ;"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and x ~"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and x "hello"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and x ''hello"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x[,]"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lookup-dot_number
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x.123"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lookup-dot_string
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x."y""'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1, 5)"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1..)"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x."'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x[0"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1..5"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-pipe-000
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x and x |"'
+  type: SyntaxError
+- id: if-mut-boolean_expr-question-005
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x and
+    x ?"'
+  type: SyntaxError
+- id: if-mut-boolean_op-eos
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and &"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and *"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and @"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and \"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and `"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and ^"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and $"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and #"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and ;"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and ~"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and "hello"'
+  type: SyntaxError
+- id: if-mut-boolean_op-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and ''hello"'
+  type: SyntaxError
+- id: if-mut-boolean_op-number
+  error:
+  type:
+- id: if-mut-comparison_rhs-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x == [0]"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    == )"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    == ]"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x == :"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == ,"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    == =="'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    == !="'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    == <"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    == >"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    == <="'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    == >="'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x == contains"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x == -"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x == ."'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x ==
+    .."'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x == &"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x == *"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x == @"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x == \"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x == `"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x == ^"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x == $"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x == #"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x == ;"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x == ~"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x == "hello"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x == ''hello"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == x[,]"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x == x.123"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x == x."y""'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x == (1, 5)"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    == (1..)"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x == x."'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    == x[0"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    == (1..5"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x == |"'
+  type: SyntaxError
+- id: if-mut-comparison_rhs-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x ==
+    ?"'
+  type: SyntaxError
+- id: if-mut-condition-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "[0]"'
+  type: SyntaxError
+- id: if-mut-condition-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  type: SyntaxError
+- id: if-mut-condition-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  type: SyntaxError
+- id: if-mut-condition-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  type: SyntaxError
+- id: if-mut-condition-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  type: SyntaxError
+- id: if-mut-condition-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  type: SyntaxError
+- id: if-mut-condition-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  type: SyntaxError
+- id: if-mut-condition-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  type: SyntaxError
+- id: if-mut-condition-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  type: SyntaxError
+- id: if-mut-condition-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  type: SyntaxError
+- id: if-mut-condition-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  type: SyntaxError
+- id: if-mut-condition-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "contains"'
+  type: SyntaxError
+- id: if-mut-condition-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  type: SyntaxError
+- id: if-mut-condition-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  type: SyntaxError
+- id: if-mut-condition-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  type: SyntaxError
+- id: if-mut-condition-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: if-mut-condition-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: if-mut-condition-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  type: SyntaxError
+- id: if-mut-condition-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x.123"'
+  type: SyntaxError
+- id: if-mut-condition-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x."y""'
+  type: SyntaxError
+- id: if-mut-condition-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  type: SyntaxError
+- id: if-mut-condition-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  type: SyntaxError
+- id: if-mut-condition-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  type: SyntaxError
+- id: if-mut-condition-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  type: SyntaxError
+- id: if-mut-condition-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  type: SyntaxError
+- id: if-mut-condition-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  type: SyntaxError
+- id: if-mut-condition-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  type: SyntaxError
+- id: if-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: if-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: if-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: if-mut-end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  type: SyntaxError
+- id: if-mut-end-trail-comparison
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  type: SyntaxError
+- id: if-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: if-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  type: SyntaxError
+- id: if-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  type: SyntaxError
+- id: if-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: if-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: if-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  type: SyntaxError
+- id: if-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: if-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: if-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: if-mut-valid-000
+  error:
+  type:
+- id: if-mut-valid-001
+  error:
+  type:
+- id: if-mut-valid-002
+  error:
+  type:
+- id: if-mut-valid-003
+  error:
+  type:
+- id: if-mut-valid-004
+  error:
+  type:
+- id: if-mut-valid-005
+  error:
+  type:
+- id: if-mut-valid-006
+  error:
+  type:
+- id: if-mut-valid-007
+  error:
+  type:
+- id: if-mut-valid-008
+  error:
+  type:
+- id: if-mut-valid-009
+  error:
+  type:
+- id: if-mut-valid-010
+  error:
+  type:
+- id: if-mut-valid-011
+  error:
+  type:
+- id: if-mut-valid-012
+  error:
+  type:
+- id: if-mut-valid-013
+  error:
+  type:
+- id: if-mut-valid-014
+  error:
+  type:
+- id: if-themecheck-skipped-prefix
+  error: 'Liquid syntax error: Unexpected character ! in "!product.available"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-bare_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    [0]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-close_round-004
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    )"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-close_square-003
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-colon-002
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    :"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comma-001
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ,"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-009
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    =="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-010
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    !="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-011
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    <"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-012
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    >"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-013
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    <="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-014
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    >="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-comparison-015
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    contains"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-dash-006
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    -"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-dot-007
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-dotdot-008
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    .."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-eos-016
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x =="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and x x == &"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and x x == *"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and x x == @"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and x x == \"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and x x == `"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and x x == ^"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and x x == $"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and x x == #"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and x x == ;"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and x x == ~"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and x x == "hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and x x == ''hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x[,]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-dot_number
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x.123"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-dot_string
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x."y""'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1, 5)"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1..)"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x[0"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1..5"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-pipe-000
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    |"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_comparison_rhs-question-005
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ?"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-bare_bracket
+  error:
+  type:
+- id: if_elsif-mut-elsif_boolean_expr-close_round-004
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    and x )"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-close_square-003
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    and x ]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-colon-002
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x and x
+    :"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-comma-001
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x and x
+    ,"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-comparison-009
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x =="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-comparison-010
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x !="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-comparison-011
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x <"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-comparison-012
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x >"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-comparison-013
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x <="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-comparison-014
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x >="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-comparison-015
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x contains"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-dash-006
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x and x -"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-dot-007
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x and x ."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-dotdot-008
+  error: 'Liquid syntax error: Expected end_of_string but found dotdot in "x and x
+    .."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-eos-016
+  error:
+  type:
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and x &"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and x *"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and x @"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and x \"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and x `"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and x ^"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and x $"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and x #"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and x ;"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and x ~"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and x "hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and x ''hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x[,]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lookup-dot_number
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x.123"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lookup-dot_string
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x."y""'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1, 5)"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1..)"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x[0"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1..5"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-pipe-000
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x and x |"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_expr-question-005
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x and
+    x ?"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-eos
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and &"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and *"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and @"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and \"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and `"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and ^"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and $"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and #"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and ;"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and ~"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and "hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and ''hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_boolean_op-number
+  error:
+  type:
+- id: if_elsif-mut-elsif_comparison_rhs-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x == [0]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    == )"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    == ]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x == :"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == ,"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    == =="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    == !="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    == <"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    == >"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    == <="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    == >="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x == contains"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x == -"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x == ."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x ==
+    .."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x == &"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x == *"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x == @"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x == \"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x == `"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x == ^"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x == $"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x == #"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x == ;"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x == ~"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x == "hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x == ''hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == x[,]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x == x.123"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x == x."y""'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x == (1, 5)"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    == (1..)"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x == x."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    == x[0"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    == (1..5"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x == |"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_comparison_rhs-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x ==
+    ?"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "[0]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "contains"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x.123"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x."y""'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_condition-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-comparison
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: if_elsif-mut-elsif_end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: if_elsif-mut-valid-000
+  error:
+  type:
+- id: if_elsif-mut-valid-001
+  error:
+  type:
+- id: if_elsif-mut-valid-002
+  error:
+  type:
+- id: if_elsif-mut-valid-003
+  error:
+  type:
+- id: if_elsif-mut-valid-004
+  error:
+  type:
+- id: if_elsif-mut-valid-005
+  error:
+  type:
+- id: if_elsif-mut-valid-006
+  error:
+  type:
+- id: if_elsif-mut-valid-007
+  error:
+  type:
+- id: if_elsif-mut-valid-008
+  error:
+  type:
+- id: if_elsif-mut-valid-009
+  error:
+  type:
+- id: if_elsif-mut-valid-010
+  error:
+  type:
+- id: if_elsif-mut-valid-011
+  error:
+  type:
+- id: if_elsif-mut-valid-012
+  error:
+  type:
+- id: if_elsif-mut-valid-013
+  error:
+  type:
+- id: if_elsif-mut-valid-014
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/ifchanged.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/ifchanged.snap.yml
@@ -1,0 +1,62 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: ifchanged-100
+  error:
+  type:
+- id: ifchanged-101
+  error:
+  type:
+- id: ifchanged-102
+  error:
+  type:
+- id: ifchanged-103
+  error:
+  type:
+- id: ifchanged-104
+  error:
+  type:
+- id: ifchanged-200
+  error:
+  type:
+- id: ifchanged-201
+  error:
+  type:
+- id: ifchanged-202
+  error:
+  type:
+- id: ifchanged-203
+  error:
+  type:
+- id: ifchanged-204
+  error:
+  type:
+- id: ifchanged-205
+  error:
+  type:
+- id: ifchanged-206
+  error:
+  type:
+- id: ifchanged-207
+  error:
+  type:
+- id: ifchanged-208
+  error:
+  type:
+- id: ifchanged-209
+  error:
+  type:
+- id: ifchanged-300
+  error:
+  type:
+- id: ifchanged-301
+  error:
+  type:
+- id: ifchanged-302
+  error:
+  type:
+- id: ifchanged-303
+  error:
+  type:
+- id: ifchanged-themecheck-nested-block
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/include.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/include.snap.yml
@@ -1,0 +1,547 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: include-mut-alias_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x as"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x as &"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x as *"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x as @"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x as \"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x as `"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x as ^"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x as $"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x as #"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x as ;"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x as ~"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x as "hello"'
+  type: SyntaxError
+- id: include-mut-alias_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x as ''hello"'
+  type: SyntaxError
+- id: include-mut-alias_name-number
+  error: 'Liquid syntax error: Expected id but found number in "x as 42"'
+  type: SyntaxError
+- id: include-mut-binding_keyword-id
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x with"'
+  type: SyntaxError
+- id: include-mut-binding_value-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x for [0]"'
+  type: SyntaxError
+- id: include-mut-binding_value-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    for )"'
+  type: SyntaxError
+- id: include-mut-binding_value-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    for ]"'
+  type: SyntaxError
+- id: include-mut-binding_value-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x for :"'
+  type: SyntaxError
+- id: include-mut-binding_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x for ,"'
+  type: SyntaxError
+- id: include-mut-binding_value-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    for =="'
+  type: SyntaxError
+- id: include-mut-binding_value-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    for !="'
+  type: SyntaxError
+- id: include-mut-binding_value-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    for <"'
+  type: SyntaxError
+- id: include-mut-binding_value-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    for >"'
+  type: SyntaxError
+- id: include-mut-binding_value-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    for <="'
+  type: SyntaxError
+- id: include-mut-binding_value-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    for >="'
+  type: SyntaxError
+- id: include-mut-binding_value-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x for contains"'
+  type: SyntaxError
+- id: include-mut-binding_value-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x for -"'
+  type: SyntaxError
+- id: include-mut-binding_value-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x for ."'
+  type: SyntaxError
+- id: include-mut-binding_value-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x for
+    .."'
+  type: SyntaxError
+- id: include-mut-binding_value-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x for"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x for &"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x for *"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x for @"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x for \"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x for `"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x for ^"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x for $"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x for #"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x for ;"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x for ~"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x for "hello"'
+  type: SyntaxError
+- id: include-mut-binding_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x for ''hello"'
+  type: SyntaxError
+- id: include-mut-binding_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x for x[,]"'
+  type: SyntaxError
+- id: include-mut-binding_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x for x.123"'
+  type: SyntaxError
+- id: include-mut-binding_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x for x."y""'
+  type: SyntaxError
+- id: include-mut-binding_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x for (1, 5)"'
+  type: SyntaxError
+- id: include-mut-binding_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    for (1..)"'
+  type: SyntaxError
+- id: include-mut-binding_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x for x."'
+  type: SyntaxError
+- id: include-mut-binding_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    for x[0"'
+  type: SyntaxError
+- id: include-mut-binding_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    for (1..5"'
+  type: SyntaxError
+- id: include-mut-binding_value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x for |"'
+  type: SyntaxError
+- id: include-mut-binding_value-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x for
+    ?"'
+  type: SyntaxError
+- id: include-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: include-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: include-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: include-mut-end-trail-comma
+  error:
+  type:
+- id: include-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  type: SyntaxError
+- id: include-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: include-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  type: SyntaxError
+- id: include-mut-end-trail-id
+  error: 'Liquid syntax error: Expected colon but found end_of_string in "x extra"'
+  type: SyntaxError
+- id: include-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: include-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: include-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  type: SyntaxError
+- id: include-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: include-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: include-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: include-mut-kwarg_colon-eos
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x"'
+  type: SyntaxError
+- id: include-mut-kwarg_colon-number
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x 42"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-eos
+  error: 'Liquid syntax error: Expected colon but found comma in "x step ,"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x step , &"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x step , *"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x step , @"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x step , \"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x step , `"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x step , ^"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x step , $"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x step , #"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x step , ;"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x step , ~"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x step , "hello"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x step , ''hello"'
+  type: SyntaxError
+- id: include-mut-kwarg_name-number
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , 42"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-bare_bracket
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : [0]"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-close_round-004
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : )"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-close_square-003
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ]"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-colon-002
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : :"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-comma-001
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ,"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-comparison-009
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : =="'
+  type: SyntaxError
+- id: include-mut-kwarg_value-comparison-010
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : !="'
+  type: SyntaxError
+- id: include-mut-kwarg_value-comparison-011
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : <"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-comparison-012
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : >"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-comparison-013
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : <="'
+  type: SyntaxError
+- id: include-mut-kwarg_value-comparison-014
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : >="'
+  type: SyntaxError
+- id: include-mut-kwarg_value-comparison-015
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : contains"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-dash-006
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : -"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-dot-007
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ."'
+  type: SyntaxError
+- id: include-mut-kwarg_value-dotdot-008
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : .."'
+  type: SyntaxError
+- id: include-mut-kwarg_value-eos-016
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x :"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x step , x : &"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x step , x : *"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x step , x : @"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x step , x : \"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x step , x : `"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x step , x : ^"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x step , x : $"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x step , x : #"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x step , x : ;"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x step , x : ~"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x step , x : "hello"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x step , x : ''hello"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x[,]"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x.123"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x."y""'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : (1,
+    5)"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..)"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x."'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x[0"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..5"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-pipe-000
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : |"'
+  type: SyntaxError
+- id: include-mut-kwarg_value-question-005
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ?"'
+  type: SyntaxError
+- id: include-mut-template_expr-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "[0]"'
+  type: SyntaxError
+- id: include-mut-template_expr-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  type: SyntaxError
+- id: include-mut-template_expr-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  type: SyntaxError
+- id: include-mut-template_expr-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  type: SyntaxError
+- id: include-mut-template_expr-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  type: SyntaxError
+- id: include-mut-template_expr-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  type: SyntaxError
+- id: include-mut-template_expr-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  type: SyntaxError
+- id: include-mut-template_expr-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  type: SyntaxError
+- id: include-mut-template_expr-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  type: SyntaxError
+- id: include-mut-template_expr-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  type: SyntaxError
+- id: include-mut-template_expr-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  type: SyntaxError
+- id: include-mut-template_expr-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "contains"'
+  type: SyntaxError
+- id: include-mut-template_expr-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  type: SyntaxError
+- id: include-mut-template_expr-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  type: SyntaxError
+- id: include-mut-template_expr-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  type: SyntaxError
+- id: include-mut-template_expr-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: include-mut-template_expr-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: include-mut-template_expr-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  type: SyntaxError
+- id: include-mut-template_expr-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x.123"'
+  type: SyntaxError
+- id: include-mut-template_expr-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x."y""'
+  type: SyntaxError
+- id: include-mut-template_expr-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  type: SyntaxError
+- id: include-mut-template_expr-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  type: SyntaxError
+- id: include-mut-template_expr-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  type: SyntaxError
+- id: include-mut-template_expr-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  type: SyntaxError
+- id: include-mut-template_expr-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  type: SyntaxError
+- id: include-mut-template_expr-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  type: SyntaxError
+- id: include-mut-template_expr-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  type: SyntaxError
+- id: include-mut-valid-000
+  error:
+  type:
+- id: include-mut-valid-001
+  error:
+  type:
+- id: include-mut-valid-002
+  error:
+  type:
+- id: include-mut-valid-003
+  error:
+  type:
+- id: include-mut-valid-004
+  error:
+  type:
+- id: include-mut-valid-005
+  error:
+  type:
+- id: include-mut-valid-006
+  error:
+  type:
+- id: include-mut-valid-007
+  error:
+  type:
+- id: include-mut-valid-008
+  error:
+  type:
+- id: include-mut-valid-009
+  error:
+  type:
+- id: include-mut-valid-010
+  error:
+  type:
+- id: include-mut-valid-011
+  error:
+  type:
+- id: include-mut-valid-012
+  error:
+  type:
+- id: include-mut-valid-013
+  error:
+  type:
+- id: include-mut-valid-014
+  error:
+  type:
+- id: include-themecheck-range-snippet-with-binding
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/increment.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/increment.snap.yml
@@ -1,0 +1,92 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: increment-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: increment-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: increment-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: increment-mut-end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  type: SyntaxError
+- id: increment-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  type: SyntaxError
+- id: increment-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: increment-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+  type: SyntaxError
+- id: increment-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  type: SyntaxError
+- id: increment-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: increment-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: increment-mut-end-trail-open_square
+  error: 'Liquid syntax error: Expected end_of_string but found open_square in "x
+    ["'
+  type: SyntaxError
+- id: increment-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: increment-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: increment-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: increment-mut-variable_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in ""'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: increment-mut-variable_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: increment-mut-variable_name-number
+  error: 'Liquid syntax error: Expected id but found number in "42"'
+  type: SyntaxError
+- id: increment-themecheck-bare-bracket
+  error: 'Liquid syntax error: Expected id but found open_square in "[0]"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/inline_comment.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/inline_comment.snap.yml
@@ -1,0 +1,128 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: inline_comment-001
+  error:
+  type:
+- id: inline_comment-002
+  error:
+  type:
+- id: inline_comment-003
+  error: 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+    be prefixed by the ''#'' character'
+  type: SyntaxError
+- id: inline_comment-004
+  error: 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+    be prefixed by the ''#'' character'
+  type: SyntaxError
+- id: inline_comment-005
+  error: 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+    be prefixed by the ''#'' character'
+  type: SyntaxError
+- id: inline_comment-006
+  error:
+  type:
+- id: inline_comment-007
+  error: 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+    be prefixed by the ''#'' character'
+  type: SyntaxError
+- id: inline_comment-008
+  error: 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+    be prefixed by the ''#'' character'
+  type: SyntaxError
+- id: inline_comment-009
+  error:
+  type:
+- id: inline_comment-010
+  error:
+  type:
+- id: inline_comment-011
+  error:
+  type:
+- id: inline_comment-012
+  error:
+  type:
+- id: inline_comment-013
+  error:
+  type:
+- id: inline_comment-014
+  error: 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+    be prefixed by the ''#'' character'
+  type: SyntaxError
+- id: inline_comment-100
+  error:
+  type:
+- id: inline_comment-101
+  error:
+  type:
+- id: inline_comment-102
+  error:
+  type:
+- id: inline_comment-103
+  error:
+  type:
+- id: inline_comment-104
+  error:
+  type:
+- id: inline_comment-105
+  error:
+  type:
+- id: inline_comment-106
+  error:
+  type:
+- id: inline_comment-107
+  error:
+  type:
+- id: inline_comment-108
+  error:
+  type:
+- id: inline_comment-109
+  error:
+  type:
+- id: inline_comment-110
+  error:
+  type:
+- id: inline_comment-111
+  error:
+  type:
+- id: inline_comment-112
+  error:
+  type:
+- id: inline_comment-113
+  error:
+  type:
+- id: inline_comment-114
+  error:
+  type:
+- id: inline_comment-115
+  error:
+  type:
+- id: inline_comment-116
+  error:
+  type:
+- id: inline_comment-117
+  error:
+  type:
+- id: inline_comment-118
+  error:
+  type:
+- id: inline_comment-200
+  error:
+  type:
+- id: inline_comment-201
+  error:
+  type:
+- id: inline_comment-202
+  error:
+  type:
+- id: inline_comment-203
+  error:
+  type:
+- id: inline_comment-204
+  error:
+  type:
+- id: inline_comment-205
+  error:
+  type:
+- id: inline_comment-themecheck-no-space-prefixed-continuation
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/javascript.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/javascript.snap.yml
@@ -1,0 +1,95 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: javascript-001
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-002
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-003
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-004
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-005
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-006
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-007
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-008
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-009
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-010
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-011
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-012
+  error: 'Liquid syntax error: Syntax Error in ''javascript'' - Valid syntax: javascript'
+  type: SyntaxError
+- id: javascript-020
+  error: 'Liquid syntax error: ''javascript'' tag was never closed'
+  type: SyntaxError
+- id: javascript-021
+  error: 'Liquid syntax error: ''javascript'' tag was never closed'
+  type: SyntaxError
+- id: javascript-022
+  error: 'Liquid syntax error: ''javascript'' tag was never closed'
+  type: SyntaxError
+- id: javascript-023
+  error: 'Liquid syntax error: ''javascript'' tag was never closed'
+  type: SyntaxError
+- id: javascript-024
+  error: 'Liquid syntax error: ''javascript'' tag was never closed'
+  type: SyntaxError
+- id: javascript-025
+  error: 'Liquid syntax error: ''javascript'' tag was never closed'
+  type: SyntaxError
+- id: javascript-026
+  error: 'Liquid syntax error: ''javascript'' tag was never closed'
+  type: SyntaxError
+- id: javascript-100
+  error:
+  type:
+- id: javascript-101
+  error:
+  type:
+- id: javascript-102
+  error:
+  type:
+- id: javascript-103
+  error:
+  type:
+- id: javascript-104
+  error:
+  type:
+- id: javascript-105
+  error:
+  type:
+- id: javascript-106
+  error:
+  type:
+- id: javascript-107
+  error:
+  type:
+- id: javascript-108
+  error:
+  type:
+- id: javascript-109
+  error:
+  type:
+- id: javascript-200
+  error: 'Liquid syntax error: Unknown tag ''endjavascript'''
+  type: SyntaxError
+- id: javascript-themecheck-prefixed-closing
+  error: 'Liquid syntax error: ''javascript'' tag was never closed'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/layout.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/layout.snap.yml
@@ -1,0 +1,259 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: layout-mut-end-trail-close_round
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x )"'
+  type: SyntaxError
+- id: layout-mut-end-trail-close_square
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x ]"'
+  type: SyntaxError
+- id: layout-mut-end-trail-colon
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x :"'
+  type: SyntaxError
+- id: layout-mut-end-trail-comma
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x ,"'
+  type: SyntaxError
+- id: layout-mut-end-trail-comparison
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x =="'
+  type: SyntaxError
+- id: layout-mut-end-trail-dash
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x -"'
+  type: SyntaxError
+- id: layout-mut-end-trail-dot
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x ."'
+  type: SyntaxError
+- id: layout-mut-end-trail-id
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x extra"'
+  type: SyntaxError
+- id: layout-mut-end-trail-number
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x 42"'
+  type: SyntaxError
+- id: layout-mut-end-trail-open_round
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x ("'
+  type: SyntaxError
+- id: layout-mut-end-trail-open_square
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x ["'
+  type: SyntaxError
+- id: layout-mut-end-trail-pipe
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x |"'
+  type: SyntaxError
+- id: layout-mut-end-trail-question
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x ?"'
+  type: SyntaxError
+- id: layout-mut-end-trail-string
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x ''hi''"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-bare_bracket
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "[0]"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-close_round-004
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in ")"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-close_square-003
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "]"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-colon-002
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in ":"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-comma-001
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in ","'
+  type: SyntaxError
+- id: layout-mut-layout_expr-comparison-009
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "=="'
+  type: SyntaxError
+- id: layout-mut-layout_expr-comparison-010
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "!="'
+  type: SyntaxError
+- id: layout-mut-layout_expr-comparison-011
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "<"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-comparison-012
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in ">"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-comparison-013
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "<="'
+  type: SyntaxError
+- id: layout-mut-layout_expr-comparison-014
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in ">="'
+  type: SyntaxError
+- id: layout-mut-layout_expr-comparison-015
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "contains"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-dash-006
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "-"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-dot-007
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "."'
+  type: SyntaxError
+- id: layout-mut-layout_expr-dotdot-008
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in ".."'
+  type: SyntaxError
+- id: layout-mut-layout_expr-eos-016
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in ""'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-ampersand
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "&"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-asterisk
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "*"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-at
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "@"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-backslash
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "\"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-backtick
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "`"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-caret
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "^"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-dollar
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "$"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-hash
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "#"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-semicolon
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in ";"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-tilde
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "~"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in ""hello"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "''hello"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x[,]"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lookup-dot_number
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x.123"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lookup-dot_string
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x."y""'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lookup-range_bad_separator
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "(1, 5)"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lookup-range_missing_end
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "(1..)"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lookup-trailing_dot
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x."'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lookup-unclosed_bracket
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "x[0"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-lookup-unclosed_range
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "(1..5"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-pipe-000
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "|"'
+  type: SyntaxError
+- id: layout-mut-layout_expr-question-005
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "?"'
+  type: SyntaxError
+- id: layout-mut-valid-000
+  error:
+  type:
+- id: layout-mut-valid-001
+  error:
+  type:
+- id: layout-mut-valid-002
+  error:
+  type:
+- id: layout-mut-valid-003
+  error:
+  type:
+- id: layout-mut-valid-004
+  error:
+  type:
+- id: layout-mut-valid-005
+  error:
+  type:
+- id: layout-mut-valid-006
+  error:
+  type:
+- id: layout-mut-valid-007
+  error:
+  type:
+- id: layout-mut-valid-008
+  error:
+  type:
+- id: layout-mut-valid-009
+  error:
+  type:
+- id: layout-mut-valid-010
+  error:
+  type:
+- id: layout-mut-valid-011
+  error:
+  type:
+- id: layout-mut-valid-012
+  error:
+  type:
+- id: layout-mut-valid-013
+  error:
+  type:
+- id: layout-mut-valid-014
+  error:
+  type:
+- id: layout-themecheck-false-trailing-markup
+  error: 'Liquid syntax error: in ''layout'' - Valid syntax: layout (none|[layout_name])
+    in "false extra"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/liquid.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/liquid.snap.yml
@@ -1,0 +1,56 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: liquid-100
+  error:
+  type:
+- id: liquid-101
+  error:
+  type:
+- id: liquid-102
+  error:
+  type:
+- id: liquid-103
+  error:
+  type:
+- id: liquid-104
+  error:
+  type:
+- id: liquid-105
+  error:
+  type:
+- id: liquid-200
+  error: 'Liquid syntax error: Unknown tag ''hello'''
+  type: SyntaxError
+- id: liquid-201
+  error: 'Liquid syntax error: Unknown tag ''foobar'''
+  type: SyntaxError
+- id: liquid-203
+  error: 'Liquid syntax error: ''endfor'' is not a valid delimiter for liquid tags.
+    use %}'
+  type: SyntaxError
+- id: liquid-204
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in ""'
+  type: SyntaxError
+- id: liquid-205
+  error: 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+    = [source] in ""'
+  type: SyntaxError
+- id: liquid-206
+  error:
+  type:
+- id: liquid-207
+  error: 'Liquid syntax error: For loops require an ''in'' clause in "i"'
+  type: SyntaxError
+- id: liquid-208
+  error: 'Liquid syntax error: ''for'' tag was never closed'
+  type: SyntaxError
+- id: liquid-branch-else-top-level
+  error: 'Liquid syntax error: Unexpected outer ''else'' tag'
+  type: SyntaxError
+- id: liquid-branch-when-top-level
+  error: 'Liquid syntax error: Unknown tag ''when'''
+  type: SyntaxError
+- id: liquid-themecheck-capture-block
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/paginate.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/paginate.snap.yml
@@ -1,0 +1,514 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: paginate-mut-by_keyword-eos
+  error: 'Liquid syntax error: Expected ''by'' but found '''' in "x"'
+  type: SyntaxError
+- id: paginate-mut-by_keyword-id
+  error: 'Liquid syntax error: Expected ''by'' but found ''of'' in "x of"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "[0]"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "contains"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x.123"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x."y""'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  type: SyntaxError
+- id: paginate-mut-collection_expr-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  type: SyntaxError
+- id: paginate-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    by x )"'
+  type: SyntaxError
+- id: paginate-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    by x ]"'
+  type: SyntaxError
+- id: paginate-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x by x :"'
+  type: SyntaxError
+- id: paginate-mut-end-trail-comma
+  error:
+  type:
+- id: paginate-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x by
+    x =="'
+  type: SyntaxError
+- id: paginate-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x by x -"'
+  type: SyntaxError
+- id: paginate-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x by x ."'
+  type: SyntaxError
+- id: paginate-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x by x extra"'
+  type: SyntaxError
+- id: paginate-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x by x
+    42"'
+  type: SyntaxError
+- id: paginate-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x by
+    x ("'
+  type: SyntaxError
+- id: paginate-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x by
+    x ["'
+  type: SyntaxError
+- id: paginate-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x by x |"'
+  type: SyntaxError
+- id: paginate-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x by
+    x ?"'
+  type: SyntaxError
+- id: paginate-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x by x
+    ''hi''"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_colon-eos
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_colon-number
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x 42"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-eos
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , ,"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x by x , , &"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x by x , , *"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x by x , , @"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x by x , , \"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x by x , , `"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x by x , , ^"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x by x , , $"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x by x , , #"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x by x , , ;"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x by x , , ~"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x by x , , "hello"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x by x , , ''hello"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_name-number
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , 42"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-bare_bracket
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : [0]"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-close_round-004
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : )"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-close_square-003
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : ]"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-colon-002
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : :"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-comma-001
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : ,"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-comparison-009
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : =="'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-comparison-010
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : !="'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-comparison-011
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : <"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-comparison-012
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : >"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-comparison-013
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : <="'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-comparison-014
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : >="'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-comparison-015
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : contains"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-dash-006
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : -"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-dot-007
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : ."'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-dotdot-008
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : .."'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-eos-016
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x :"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x by x , , x : &"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x by x , , x : *"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x by x , , x : @"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x by x , , x : \"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x by x , , x : `"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x by x , , x : ^"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x by x , , x : $"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x by x , , x : #"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x by x , , x : ;"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x by x , , x : ~"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x by x , , x : "hello"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x by x , , x : ''hello"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : x[,]"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : x.123"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : x."y""'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : (1,
+    5)"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : (1..)"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : x."'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : x[0"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : (1..5"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-pipe-000
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : |"'
+  type: SyntaxError
+- id: paginate-mut-kwarg_value-question-005
+  error: 'Liquid syntax error: Expected id but found comma in "x by x , , x : ?"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x by [0]"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    by )"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    by ]"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x by :"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x by ,"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    by =="'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    by !="'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    by <"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    by >"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    by <="'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    by >="'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x by contains"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x by -"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x by ."'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x by
+    .."'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x by"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x by &"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x by *"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x by @"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x by \"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x by `"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x by ^"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x by $"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x by #"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x by ;"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x by ~"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x by "hello"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x by ''hello"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x by x[,]"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x by x.123"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x by x."y""'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x by (1, 5)"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    by (1..)"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x by x."'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    by x[0"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    by (1..5"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x by |"'
+  type: SyntaxError
+- id: paginate-mut-page_size_expr-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x by
+    ?"'
+  type: SyntaxError
+- id: paginate-mut-valid-000
+  error:
+  type:
+- id: paginate-mut-valid-001
+  error:
+  type:
+- id: paginate-mut-valid-002
+  error:
+  type:
+- id: paginate-mut-valid-003
+  error:
+  type:
+- id: paginate-mut-valid-004
+  error:
+  type:
+- id: paginate-mut-valid-005
+  error:
+  type:
+- id: paginate-mut-valid-006
+  error:
+  type:
+- id: paginate-mut-valid-007
+  error:
+  type:
+- id: paginate-mut-valid-008
+  error:
+  type:
+- id: paginate-mut-valid-009
+  error:
+  type:
+- id: paginate-mut-valid-010
+  error:
+  type:
+- id: paginate-mut-valid-011
+  error:
+  type:
+- id: paginate-mut-valid-012
+  error:
+  type:
+- id: paginate-mut-valid-013
+  error:
+  type:
+- id: paginate-mut-valid-014
+  error:
+  type:
+- id: paginate-themecheck-trailing-comma
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/partial.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/partial.snap.yml
@@ -1,0 +1,23 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: partial-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id'
+  type: SyntaxError
+- id: partial-mut-partial_name-eos
+  error: 'Liquid syntax error: Expected string but found end_of_string'
+  type: SyntaxError
+- id: partial-mut-partial_name-id
+  error: 'Liquid syntax error: Expected string but found id'
+  type: SyntaxError
+- id: partial-mut-partial_name-invalid
+  error: 'Liquid syntax error: Error in tag ''partial'' - Valid syntax: partial ''[name]'''
+  type: SyntaxError
+- id: partial-mut-unclosed
+  error: 'Liquid syntax error: ''partial'' tag was never closed'
+  type: SyntaxError
+- id: partial-themecheck-empty-name
+  error: 'Liquid syntax error: Error in tag ''partial'' - Valid syntax: partial ''[name]'''
+  type: SyntaxError
+- id: partial-valid-basic
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/raw.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/raw.snap.yml
@@ -1,0 +1,117 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: liquid-endraw
+  error: 'Liquid syntax error: ''endraw'' is not a valid delimiter for liquid tags.
+    use %}'
+  type: SyntaxError
+- id: raw-001
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-002
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-003
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-004
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-005
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-006
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-007
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-008
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-009
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-010
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-011
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-012
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-020
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-021
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-022
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-023
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-024
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-025
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-026
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-100
+  error:
+  type:
+- id: raw-101
+  error:
+  type:
+- id: raw-102
+  error:
+  type:
+- id: raw-103
+  error:
+  type:
+- id: raw-104
+  error:
+  type:
+- id: raw-105
+  error:
+  type:
+- id: raw-106
+  error:
+  type:
+- id: raw-107
+  error: 'Liquid syntax error: Unknown tag ''endraw'''
+  type: SyntaxError
+- id: raw-108
+  error:
+  type:
+- id: raw-109
+  error:
+  type:
+- id: raw-110
+  error:
+  type:
+- id: raw-111
+  error:
+  type:
+- id: raw-themecheck-liquid-line-unclosed
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-themecheck-marked-closer-then-balanced
+  error:
+  type:
+- id: raw-themecheck-marked-closer-then-unclosed
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-themecheck-prefixed-closing
+  error: 'Liquid syntax error: ''raw'' tag was never closed'
+  type: SyntaxError
+- id: raw-themecheck-unclosed-quoted-opening
+  error: 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  type: SyntaxError
+- id: raw-themecheck-whitespace-control-marked-closer
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/render.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/render.snap.yml
@@ -1,0 +1,446 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: render-mut-alias_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in "''snippet''
+    as"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "''snippet'' as &"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "''snippet'' as *"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "''snippet'' as @"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "''snippet'' as \"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "''snippet'' as `"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "''snippet'' as ^"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "''snippet'' as $"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "''snippet'' as #"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "''snippet'' as ;"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "''snippet'' as ~"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "''snippet'' as "hello"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''snippet'' as ''hello"'
+  type: SyntaxError
+- id: render-mut-alias_name-number
+  error: 'Liquid syntax error: Expected id but found number in "''snippet'' as 42"'
+  type: SyntaxError
+- id: render-mut-binding_keyword-id
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "''snippet''
+    with"'
+  type: SyntaxError
+- id: render-mut-binding_value-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "''snippet'' for [0]"'
+  type: SyntaxError
+- id: render-mut-binding_value-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "''snippet''
+    for )"'
+  type: SyntaxError
+- id: render-mut-binding_value-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "''snippet''
+    for ]"'
+  type: SyntaxError
+- id: render-mut-binding_value-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "''snippet''
+    for :"'
+  type: SyntaxError
+- id: render-mut-binding_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "''snippet''
+    for ,"'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "''snippet''
+    for =="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "''snippet''
+    for !="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "''snippet''
+    for <"'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "''snippet''
+    for >"'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "''snippet''
+    for <="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "''snippet''
+    for >="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "''snippet'' for contains"'
+  type: SyntaxError
+- id: render-mut-binding_value-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "''snippet''
+    for -"'
+  type: SyntaxError
+- id: render-mut-binding_value-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "''snippet''
+    for ."'
+  type: SyntaxError
+- id: render-mut-binding_value-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "''snippet''
+    for .."'
+  type: SyntaxError
+- id: render-mut-binding_value-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "''snippet''
+    for"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "''snippet'' for &"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "''snippet'' for *"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "''snippet'' for @"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "''snippet'' for \"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "''snippet'' for `"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "''snippet'' for ^"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "''snippet'' for $"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "''snippet'' for #"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "''snippet'' for ;"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "''snippet'' for ~"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "''snippet'' for "hello"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''snippet'' for ''hello"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "''snippet''
+    for x[,]"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "''snippet'' for x.123"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "''snippet'' for x."y""'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "''snippet'' for
+    (1, 5)"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "''snippet''
+    for (1..)"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "''snippet''
+    for x."'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "''snippet''
+    for x[0"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "''snippet''
+    for (1..5"'
+  type: SyntaxError
+- id: render-mut-binding_value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "''snippet''
+    for |"'
+  type: SyntaxError
+- id: render-mut-binding_value-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "''snippet''
+    for ?"'
+  type: SyntaxError
+- id: render-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "''snippet''
+    )"'
+  type: SyntaxError
+- id: render-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "''snippet''
+    ]"'
+  type: SyntaxError
+- id: render-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "''snippet''
+    :"'
+  type: SyntaxError
+- id: render-mut-end-trail-comma
+  error:
+  type:
+- id: render-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "''snippet''
+    =="'
+  type: SyntaxError
+- id: render-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "''snippet''
+    -"'
+  type: SyntaxError
+- id: render-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected end_of_string but found dot in "''snippet''
+    ."'
+  type: SyntaxError
+- id: render-mut-end-trail-id
+  error: 'Liquid syntax error: Expected colon but found end_of_string in "''snippet''
+    extra"'
+  type: SyntaxError
+- id: render-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "''snippet''
+    42"'
+  type: SyntaxError
+- id: render-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "''snippet''
+    ("'
+  type: SyntaxError
+- id: render-mut-end-trail-open_square
+  error: 'Liquid syntax error: Expected end_of_string but found open_square in "''snippet''
+    ["'
+  type: SyntaxError
+- id: render-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "''snippet''
+    |"'
+  type: SyntaxError
+- id: render-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "''snippet''
+    ?"'
+  type: SyntaxError
+- id: render-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "''snippet''
+    ''hi''"'
+  type: SyntaxError
+- id: render-mut-kwarg_colon-eos
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x"'
+  type: SyntaxError
+- id: render-mut-kwarg_colon-number
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x 42"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-eos
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    ,"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "''snippet'' step , &"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "''snippet'' step , *"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "''snippet'' step , @"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "''snippet'' step , \"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "''snippet'' step , `"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "''snippet'' step , ^"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "''snippet'' step , $"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "''snippet'' step , #"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "''snippet'' step , ;"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "''snippet'' step , ~"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "''snippet'' step , "hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''snippet'' step , ''hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-number
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , 42"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-bare_bracket
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : [0]"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-close_round-004
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : )"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-close_square-003
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : ]"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-colon-002
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : :"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comma-001
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : ,"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-009
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : =="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-010
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : !="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-011
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : <"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-012
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : >"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-013
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : <="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-014
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : >="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-015
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : contains"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-dash-006
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : -"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-dot-007
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : ."'
+  type: SyntaxError
+- id: render-mut-kwarg_value-dotdot-008
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : .."'
+  type: SyntaxError
+- id: render-mut-kwarg_value-eos-016
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x :"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "''snippet'' step , x : &"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "''snippet'' step , x : *"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "''snippet'' step , x : @"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "''snippet'' step , x : \"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "''snippet'' step , x : `"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "''snippet'' step , x : ^"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "''snippet'' step , x : $"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "''snippet'' step , x : #"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "''snippet'' step , x : ;"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "''snippet'' step , x : ~"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "''snippet'' step , x : "hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''snippet'' step , x :
+    ''hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x[,]"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x.123"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x."y""'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : (1, 5)"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : (1..)"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x."'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x[0"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : (1..5"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-pipe-000
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : |"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-question-005
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : ?"'
+  type: SyntaxError
+- id: render-mut-template_name-eos
+  error: 'Liquid syntax error: Syntax error in tag ''render'' - Expected a string
+    or identifier, found nothing in ""'
+  type: SyntaxError
+- id: render-mut-template_name-id
+  error:
+  type:
+- id: render-themecheck-bare-bracket-snippet
+  error: 'Liquid syntax error: Syntax error in tag ''render'' - Expected a string
+    or identifier, found [ in "[0]"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/schema.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/schema.snap.yml
@@ -1,0 +1,47 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: schema-mut-end-trail-close_round
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-close_square
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-colon
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-comma
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-comparison
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-dash
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-dot
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-id
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-number
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-open_round
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-open_square
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-pipe
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-question
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-mut-end-trail-string
+  error: 'Liquid syntax error: Syntax Error in ''schema'' - Valid syntax: schema'
+  type: SyntaxError
+- id: schema-themecheck-valid-json-body
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/section.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/section.snap.yml
@@ -1,0 +1,76 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: section-mut-end-trail-close_round
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' )"'
+  type: SyntaxError
+- id: section-mut-end-trail-close_square
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' ]"'
+  type: SyntaxError
+- id: section-mut-end-trail-colon
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' :"'
+  type: SyntaxError
+- id: section-mut-end-trail-comma
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' ,"'
+  type: SyntaxError
+- id: section-mut-end-trail-comparison
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' =="'
+  type: SyntaxError
+- id: section-mut-end-trail-dash
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' -"'
+  type: SyntaxError
+- id: section-mut-end-trail-dot
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' ."'
+  type: SyntaxError
+- id: section-mut-end-trail-id
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' extra"'
+  type: SyntaxError
+- id: section-mut-end-trail-number
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' 42"'
+  type: SyntaxError
+- id: section-mut-end-trail-open_round
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' ("'
+  type: SyntaxError
+- id: section-mut-end-trail-open_square
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' ["'
+  type: SyntaxError
+- id: section-mut-end-trail-pipe
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' |"'
+  type: SyntaxError
+- id: section-mut-end-trail-question
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' ?"'
+  type: SyntaxError
+- id: section-mut-end-trail-string
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''snippet'' ''hi''"'
+  type: SyntaxError
+- id: section-mut-section_name-eos
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in ""'
+  type: SyntaxError
+- id: section-mut-section_name-id
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "x"'
+  type: SyntaxError
+- id: section-themecheck-bare-bracket-arg
+  error: 'Liquid syntax error: Error in tag ''section'' - Valid syntax: section ''[type]''
+    in "''header'', foo: [0]"'
+  type: SyntaxError
+- id: section-themecheck-block-form-empty
+  error: 'Liquid syntax error: Unknown tag ''endsection'''
+  type: SyntaxError
+- id: section-themecheck-block-form-with-body
+  error: 'Liquid syntax error: Unknown tag ''endsection'''
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/sections.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/sections.snap.yml
@@ -1,0 +1,69 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: sections-mut-end-trail-close_round
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' )"'
+  type: SyntaxError
+- id: sections-mut-end-trail-close_square
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' ]"'
+  type: SyntaxError
+- id: sections-mut-end-trail-colon
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' :"'
+  type: SyntaxError
+- id: sections-mut-end-trail-comma
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' ,"'
+  type: SyntaxError
+- id: sections-mut-end-trail-comparison
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' =="'
+  type: SyntaxError
+- id: sections-mut-end-trail-dash
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' -"'
+  type: SyntaxError
+- id: sections-mut-end-trail-dot
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' ."'
+  type: SyntaxError
+- id: sections-mut-end-trail-id
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' extra"'
+  type: SyntaxError
+- id: sections-mut-end-trail-number
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' 42"'
+  type: SyntaxError
+- id: sections-mut-end-trail-open_round
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' ("'
+  type: SyntaxError
+- id: sections-mut-end-trail-open_square
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' ["'
+  type: SyntaxError
+- id: sections-mut-end-trail-pipe
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' |"'
+  type: SyntaxError
+- id: sections-mut-end-trail-question
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' ?"'
+  type: SyntaxError
+- id: sections-mut-end-trail-string
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "''snippet'' ''hi''"'
+  type: SyntaxError
+- id: sections-mut-section_group_name-eos
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in ""'
+  type: SyntaxError
+- id: sections-mut-section_group_name-id
+  error: 'Liquid syntax error: Error in tag ''sections'' - Valid syntax: sections
+    ''[type]'' in "x"'
+  type: SyntaxError
+- id: sections-themecheck-valid-double-quoted-group
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/shopify_render.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/shopify_render.snap.yml
@@ -1,0 +1,871 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: render-mut-alias_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in "''snippet''
+    as"'
+  type: SyntaxError
+- id: render-mut-alias_name-eos-2
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x as"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "''snippet'' as &"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-ampersand-2
+  error: 'Liquid syntax error: Unexpected character & in "x as &"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "''snippet'' as *"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-asterisk-2
+  error: 'Liquid syntax error: Unexpected character * in "x as *"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "''snippet'' as @"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-at-2
+  error: 'Liquid syntax error: Unexpected character @ in "x as @"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "''snippet'' as \"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-backslash-2
+  error: 'Liquid syntax error: Unexpected character \ in "x as \"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "''snippet'' as `"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-backtick-2
+  error: 'Liquid syntax error: Unexpected character ` in "x as `"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "''snippet'' as ^"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-caret-2
+  error: 'Liquid syntax error: Unexpected character ^ in "x as ^"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "''snippet'' as $"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-dollar-2
+  error: 'Liquid syntax error: Unexpected character $ in "x as $"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "''snippet'' as #"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-hash-2
+  error: 'Liquid syntax error: Unexpected character # in "x as #"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "''snippet'' as ;"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-semicolon-2
+  error: 'Liquid syntax error: Unexpected character ; in "x as ;"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "''snippet'' as ~"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-tilde-2
+  error: 'Liquid syntax error: Unexpected character ~ in "x as ~"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "''snippet'' as "hello"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-unclosed_double_quote-2
+  error: 'Liquid syntax error: Unexpected character " in "x as "hello"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''snippet'' as ''hello"'
+  type: SyntaxError
+- id: render-mut-alias_name-lexerr-unclosed_single_quote-2
+  error: 'Liquid syntax error: Unexpected character '' in "x as ''hello"'
+  type: SyntaxError
+- id: render-mut-alias_name-number
+  error: 'Liquid syntax error: Expected id but found number in "''snippet'' as 42"'
+  type: SyntaxError
+- id: render-mut-alias_name-number-2
+  error: 'Liquid syntax error: Expected id but found number in "x as 42"'
+  type: SyntaxError
+- id: render-mut-binding_keyword-id
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "''snippet''
+    with"'
+  type: SyntaxError
+- id: render-mut-binding_keyword-id-2
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x with"'
+  type: SyntaxError
+- id: render-mut-binding_value-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "''snippet'' for [0]"'
+  type: SyntaxError
+- id: render-mut-binding_value-bare_bracket-2
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x for [0]"'
+  type: SyntaxError
+- id: render-mut-binding_value-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "''snippet''
+    for )"'
+  type: SyntaxError
+- id: render-mut-binding_value-close_round-004-2
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    for )"'
+  type: SyntaxError
+- id: render-mut-binding_value-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "''snippet''
+    for ]"'
+  type: SyntaxError
+- id: render-mut-binding_value-close_square-003-2
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    for ]"'
+  type: SyntaxError
+- id: render-mut-binding_value-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "''snippet''
+    for :"'
+  type: SyntaxError
+- id: render-mut-binding_value-colon-002-2
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x for :"'
+  type: SyntaxError
+- id: render-mut-binding_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "''snippet''
+    for ,"'
+  type: SyntaxError
+- id: render-mut-binding_value-comma-001-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x for ,"'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "''snippet''
+    for =="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-009-2
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    for =="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "''snippet''
+    for !="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-010-2
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    for !="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "''snippet''
+    for <"'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-011-2
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    for <"'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "''snippet''
+    for >"'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-012-2
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    for >"'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "''snippet''
+    for <="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-013-2
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    for <="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "''snippet''
+    for >="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-014-2
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    for >="'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "''snippet'' for contains"'
+  type: SyntaxError
+- id: render-mut-binding_value-comparison-015-2
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x for contains"'
+  type: SyntaxError
+- id: render-mut-binding_value-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "''snippet''
+    for -"'
+  type: SyntaxError
+- id: render-mut-binding_value-dash-006-2
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x for -"'
+  type: SyntaxError
+- id: render-mut-binding_value-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "''snippet''
+    for ."'
+  type: SyntaxError
+- id: render-mut-binding_value-dot-007-2
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x for ."'
+  type: SyntaxError
+- id: render-mut-binding_value-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "''snippet''
+    for .."'
+  type: SyntaxError
+- id: render-mut-binding_value-dotdot-008-2
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x for
+    .."'
+  type: SyntaxError
+- id: render-mut-binding_value-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "''snippet''
+    for"'
+  type: SyntaxError
+- id: render-mut-binding_value-eos-016-2
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x for"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "''snippet'' for &"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-ampersand-2
+  error: 'Liquid syntax error: Unexpected character & in "x for &"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "''snippet'' for *"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-asterisk-2
+  error: 'Liquid syntax error: Unexpected character * in "x for *"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "''snippet'' for @"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-at-2
+  error: 'Liquid syntax error: Unexpected character @ in "x for @"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "''snippet'' for \"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-backslash-2
+  error: 'Liquid syntax error: Unexpected character \ in "x for \"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "''snippet'' for `"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-backtick-2
+  error: 'Liquid syntax error: Unexpected character ` in "x for `"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "''snippet'' for ^"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-caret-2
+  error: 'Liquid syntax error: Unexpected character ^ in "x for ^"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "''snippet'' for $"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-dollar-2
+  error: 'Liquid syntax error: Unexpected character $ in "x for $"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "''snippet'' for #"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-hash-2
+  error: 'Liquid syntax error: Unexpected character # in "x for #"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "''snippet'' for ;"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-semicolon-2
+  error: 'Liquid syntax error: Unexpected character ; in "x for ;"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "''snippet'' for ~"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-tilde-2
+  error: 'Liquid syntax error: Unexpected character ~ in "x for ~"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "''snippet'' for "hello"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-unclosed_double_quote-2
+  error: 'Liquid syntax error: Unexpected character " in "x for "hello"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''snippet'' for ''hello"'
+  type: SyntaxError
+- id: render-mut-binding_value-lexerr-unclosed_single_quote-2
+  error: 'Liquid syntax error: Unexpected character '' in "x for ''hello"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "''snippet''
+    for x[,]"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-bracket_wrong_content-2
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x for x[,]"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "''snippet'' for x.123"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-dot_number-2
+  error: 'Liquid syntax error: Expected id but found number in "x for x.123"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "''snippet'' for x."y""'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-dot_string-2
+  error: 'Liquid syntax error: Expected id but found string in "x for x."y""'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "''snippet'' for
+    (1, 5)"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-range_bad_separator-2
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x for (1, 5)"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "''snippet''
+    for (1..)"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-range_missing_end-2
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    for (1..)"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "''snippet''
+    for x."'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-trailing_dot-2
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x for x."'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "''snippet''
+    for x[0"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-unclosed_bracket-2
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    for x[0"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "''snippet''
+    for (1..5"'
+  type: SyntaxError
+- id: render-mut-binding_value-lookup-unclosed_range-2
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    for (1..5"'
+  type: SyntaxError
+- id: render-mut-binding_value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "''snippet''
+    for |"'
+  type: SyntaxError
+- id: render-mut-binding_value-pipe-000-2
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x for |"'
+  type: SyntaxError
+- id: render-mut-binding_value-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "''snippet''
+    for ?"'
+  type: SyntaxError
+- id: render-mut-binding_value-question-005-2
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x for
+    ?"'
+  type: SyntaxError
+- id: render-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "''snippet''
+    )"'
+  type: SyntaxError
+- id: render-mut-end-trail-close_round-2
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: render-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "''snippet''
+    ]"'
+  type: SyntaxError
+- id: render-mut-end-trail-close_square-2
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: render-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "''snippet''
+    :"'
+  type: SyntaxError
+- id: render-mut-end-trail-colon-2
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: render-mut-end-trail-comma
+  error:
+  type:
+- id: render-mut-end-trail-comma-2
+  error:
+  type:
+- id: render-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "''snippet''
+    =="'
+  type: SyntaxError
+- id: render-mut-end-trail-comparison-2
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  type: SyntaxError
+- id: render-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "''snippet''
+    -"'
+  type: SyntaxError
+- id: render-mut-end-trail-dash-2
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: render-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected end_of_string but found dot in "''snippet''
+    ."'
+  type: SyntaxError
+- id: render-mut-end-trail-dot-2
+  error: 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+  type: SyntaxError
+- id: render-mut-end-trail-id
+  error: 'Liquid syntax error: Expected colon but found end_of_string in "''snippet''
+    extra"'
+  type: SyntaxError
+- id: render-mut-end-trail-id-2
+  error: 'Liquid syntax error: Expected colon but found end_of_string in "x extra"'
+  type: SyntaxError
+- id: render-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "''snippet''
+    42"'
+  type: SyntaxError
+- id: render-mut-end-trail-number-2
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: render-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "''snippet''
+    ("'
+  type: SyntaxError
+- id: render-mut-end-trail-open_round-2
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: render-mut-end-trail-open_square
+  error: 'Liquid syntax error: Expected end_of_string but found open_square in "''snippet''
+    ["'
+  type: SyntaxError
+- id: render-mut-end-trail-open_square-2
+  error: 'Liquid syntax error: Expected end_of_string but found open_square in "x
+    ["'
+  type: SyntaxError
+- id: render-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "''snippet''
+    |"'
+  type: SyntaxError
+- id: render-mut-end-trail-pipe-2
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: render-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "''snippet''
+    ?"'
+  type: SyntaxError
+- id: render-mut-end-trail-question-2
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: render-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "''snippet''
+    ''hi''"'
+  type: SyntaxError
+- id: render-mut-end-trail-string-2
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: render-mut-kwarg_colon-eos
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x"'
+  type: SyntaxError
+- id: render-mut-kwarg_colon-eos-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x"'
+  type: SyntaxError
+- id: render-mut-kwarg_colon-number
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x 42"'
+  type: SyntaxError
+- id: render-mut-kwarg_colon-number-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x 42"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-eos
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    ,"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-eos-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step ,"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "''snippet'' step , &"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-ampersand-2
+  error: 'Liquid syntax error: Unexpected character & in "x step , &"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "''snippet'' step , *"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-asterisk-2
+  error: 'Liquid syntax error: Unexpected character * in "x step , *"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "''snippet'' step , @"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-at-2
+  error: 'Liquid syntax error: Unexpected character @ in "x step , @"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "''snippet'' step , \"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-backslash-2
+  error: 'Liquid syntax error: Unexpected character \ in "x step , \"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "''snippet'' step , `"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-backtick-2
+  error: 'Liquid syntax error: Unexpected character ` in "x step , `"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "''snippet'' step , ^"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-caret-2
+  error: 'Liquid syntax error: Unexpected character ^ in "x step , ^"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "''snippet'' step , $"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-dollar-2
+  error: 'Liquid syntax error: Unexpected character $ in "x step , $"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "''snippet'' step , #"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-hash-2
+  error: 'Liquid syntax error: Unexpected character # in "x step , #"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "''snippet'' step , ;"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-semicolon-2
+  error: 'Liquid syntax error: Unexpected character ; in "x step , ;"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "''snippet'' step , ~"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-tilde-2
+  error: 'Liquid syntax error: Unexpected character ~ in "x step , ~"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "''snippet'' step , "hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-unclosed_double_quote-2
+  error: 'Liquid syntax error: Unexpected character " in "x step , "hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''snippet'' step , ''hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-lexerr-unclosed_single_quote-2
+  error: 'Liquid syntax error: Unexpected character '' in "x step , ''hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-number
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , 42"'
+  type: SyntaxError
+- id: render-mut-kwarg_name-number-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , 42"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-bare_bracket
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : [0]"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-bare_bracket-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : [0]"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-close_round-004
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : )"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-close_round-004-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : )"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-close_square-003
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : ]"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-close_square-003-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ]"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-colon-002
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : :"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-colon-002-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : :"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comma-001
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : ,"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comma-001-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ,"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-009
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : =="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-009-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : =="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-010
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : !="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-010-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : !="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-011
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : <"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-011-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : <"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-012
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : >"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-012-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : >"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-013
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : <="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-013-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : <="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-014
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : >="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-014-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : >="'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-015
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : contains"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-comparison-015-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : contains"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-dash-006
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : -"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-dash-006-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : -"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-dot-007
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : ."'
+  type: SyntaxError
+- id: render-mut-kwarg_value-dot-007-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ."'
+  type: SyntaxError
+- id: render-mut-kwarg_value-dotdot-008
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : .."'
+  type: SyntaxError
+- id: render-mut-kwarg_value-dotdot-008-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : .."'
+  type: SyntaxError
+- id: render-mut-kwarg_value-eos-016
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x :"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-eos-016-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x :"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "''snippet'' step , x : &"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-ampersand-2
+  error: 'Liquid syntax error: Unexpected character & in "x step , x : &"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "''snippet'' step , x : *"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-asterisk-2
+  error: 'Liquid syntax error: Unexpected character * in "x step , x : *"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "''snippet'' step , x : @"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-at-2
+  error: 'Liquid syntax error: Unexpected character @ in "x step , x : @"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "''snippet'' step , x : \"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-backslash-2
+  error: 'Liquid syntax error: Unexpected character \ in "x step , x : \"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "''snippet'' step , x : `"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-backtick-2
+  error: 'Liquid syntax error: Unexpected character ` in "x step , x : `"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "''snippet'' step , x : ^"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-caret-2
+  error: 'Liquid syntax error: Unexpected character ^ in "x step , x : ^"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "''snippet'' step , x : $"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-dollar-2
+  error: 'Liquid syntax error: Unexpected character $ in "x step , x : $"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "''snippet'' step , x : #"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-hash-2
+  error: 'Liquid syntax error: Unexpected character # in "x step , x : #"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "''snippet'' step , x : ;"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-semicolon-2
+  error: 'Liquid syntax error: Unexpected character ; in "x step , x : ;"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "''snippet'' step , x : ~"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-tilde-2
+  error: 'Liquid syntax error: Unexpected character ~ in "x step , x : ~"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "''snippet'' step , x : "hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-unclosed_double_quote-2
+  error: 'Liquid syntax error: Unexpected character " in "x step , x : "hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''snippet'' step , x :
+    ''hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lexerr-unclosed_single_quote-2
+  error: 'Liquid syntax error: Unexpected character '' in "x step , x : ''hello"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x[,]"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-bracket_wrong_content-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x[,]"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-dot_number
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x.123"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-dot_number-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x.123"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-dot_string
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x."y""'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-dot_string-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x."y""'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : (1, 5)"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-range_bad_separator-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : (1,
+    5)"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : (1..)"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-range_missing_end-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..)"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x."'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-trailing_dot-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x."'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : x[0"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-unclosed_bracket-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : x[0"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : (1..5"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-lookup-unclosed_range-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..5"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-pipe-000
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : |"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-pipe-000-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : |"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-question-005
+  error: 'Liquid syntax error: Expected colon but found comma in "''snippet'' step
+    , x : ?"'
+  type: SyntaxError
+- id: render-mut-kwarg_value-question-005-2
+  error: 'Liquid syntax error: Expected colon but found comma in "x step , x : ?"'
+  type: SyntaxError
+- id: render-mut-template_name-eos
+  error: 'Liquid syntax error: Syntax error in tag ''render'' - Expected a string
+    or identifier, found nothing in ""'
+  type: SyntaxError
+- id: render-mut-template_name-id
+  error:
+  type:
+- id: render-mut-template_name_id-eos
+  error: 'Liquid syntax error: Syntax error in tag ''render'' - Expected a string
+    or identifier, found nothing in ""'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: render-mut-template_name_id-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: render-mut-template_name_id-number
+  error: 'Liquid syntax error: Syntax error in tag ''render'' - Expected a string
+    or identifier, found 42 in "42"'
+  type: SyntaxError
+- id: shopify_render-themecheck-skipped-quote-prefix
+  error: 'Liquid syntax error: Unexpected character " in ""''snippet''"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/style.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/style.snap.yml
@@ -1,0 +1,50 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: style-mut-end-trail-close_round
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in ")"'
+  type: SyntaxError
+- id: style-mut-end-trail-close_square
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "]"'
+  type: SyntaxError
+- id: style-mut-end-trail-colon
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in ":"'
+  type: SyntaxError
+- id: style-mut-end-trail-comma
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in ","'
+  type: SyntaxError
+- id: style-mut-end-trail-comparison
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "=="'
+  type: SyntaxError
+- id: style-mut-end-trail-dash
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "-"'
+  type: SyntaxError
+- id: style-mut-end-trail-dot
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "."'
+  type: SyntaxError
+- id: style-mut-end-trail-id
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "extra"'
+  type: SyntaxError
+- id: style-mut-end-trail-number
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "42"'
+  type: SyntaxError
+- id: style-mut-end-trail-open_round
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "("'
+  type: SyntaxError
+- id: style-mut-end-trail-open_square
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "["'
+  type: SyntaxError
+- id: style-mut-end-trail-pipe
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "|"'
+  type: SyntaxError
+- id: style-mut-end-trail-question
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "?"'
+  type: SyntaxError
+- id: style-mut-end-trail-string
+  error: 'Liquid syntax error: ''style'' tag does not accept any arguments in "''hi''"'
+  type: SyntaxError
+- id: style-themecheck-empty-markup
+  error:
+  type:
+- id: style-themecheck-empty-spaced-markup
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/stylesheet.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/stylesheet.snap.yml
@@ -1,0 +1,72 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: stylesheet-mut-end-trail-close_round
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' )"'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-close_square
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' ]"'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-colon
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' :"'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-comma
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' ,"'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-comparison
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' =="'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-dash
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' -"'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-dot
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' ."'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-id
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' extra"'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-number
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' 42"'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-open_round
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' ("'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-open_square
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' ["'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-pipe
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' |"'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-question
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' ?"'
+  type: SyntaxError
+- id: stylesheet-mut-end-trail-string
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "''snippet'' ''hi''"'
+  type: SyntaxError
+- id: stylesheet-mut-scss_arg-eos
+  error:
+  type:
+- id: stylesheet-mut-scss_arg-id
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "x"'
+  type: SyntaxError
+- id: stylesheet-themecheck-valid-quoted-scss
+  error:
+  type:
+- id: stylesheet-themecheck-valid-scss
+  error: 'Liquid syntax error: ''stylesheet'' tag can only accept the argument ''scss''
+    in "scss"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/table_row.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/table_row.snap.yml
@@ -1,0 +1,430 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: table_row-mut-attr_colon-eos
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step ,"'
+  type: SyntaxError
+- id: table_row-mut-attr_colon-number
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , 42"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-bare_bracket
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : [0]"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-close_round-004
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : )"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-close_square-003
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : ]"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-colon-002
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : :"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-comma-001
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : ,"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-comparison-009
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : =="'
+  type: SyntaxError
+- id: table_row-mut-attr_value-comparison-010
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : !="'
+  type: SyntaxError
+- id: table_row-mut-attr_value-comparison-011
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : <"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-comparison-012
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : >"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-comparison-013
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : <="'
+  type: SyntaxError
+- id: table_row-mut-attr_value-comparison-014
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : >="'
+  type: SyntaxError
+- id: table_row-mut-attr_value-comparison-015
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : contains"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-dash-006
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : -"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-dot-007
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : ."'
+  type: SyntaxError
+- id: table_row-mut-attr_value-dotdot-008
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : .."'
+  type: SyntaxError
+- id: table_row-mut-attr_value-eos-016
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , :"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x in x step , : &"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x in x step , : *"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x in x step , : @"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x in x step , : \"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x in x step , : `"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x in x step , : ^"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x in x step , : $"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x in x step , : #"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x in x step , : ;"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x in x step , : ~"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x in x step , : "hello"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x in x step , : ''hello"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : x[,]"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lookup-dot_number
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : x.123"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lookup-dot_string
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : x."y""'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : (1, 5)"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lookup-range_missing_end
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : (1..)"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lookup-trailing_dot
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : x."'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : x[0"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-lookup-unclosed_range
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : (1..5"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-pipe-000
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : |"'
+  type: SyntaxError
+- id: table_row-mut-attr_value-question-005
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step , : ?"'
+  type: SyntaxError
+- id: table_row-mut-collection-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x in [0]"'
+  type: SyntaxError
+- id: table_row-mut-collection-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    in )"'
+  type: SyntaxError
+- id: table_row-mut-collection-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    in ]"'
+  type: SyntaxError
+- id: table_row-mut-collection-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x in :"'
+  type: SyntaxError
+- id: table_row-mut-collection-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in ,"'
+  type: SyntaxError
+- id: table_row-mut-collection-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    in =="'
+  type: SyntaxError
+- id: table_row-mut-collection-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    in !="'
+  type: SyntaxError
+- id: table_row-mut-collection-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    in <"'
+  type: SyntaxError
+- id: table_row-mut-collection-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    in >"'
+  type: SyntaxError
+- id: table_row-mut-collection-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    in <="'
+  type: SyntaxError
+- id: table_row-mut-collection-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    in >="'
+  type: SyntaxError
+- id: table_row-mut-collection-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x in contains"'
+  type: SyntaxError
+- id: table_row-mut-collection-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x in -"'
+  type: SyntaxError
+- id: table_row-mut-collection-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x in ."'
+  type: SyntaxError
+- id: table_row-mut-collection-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x in
+    .."'
+  type: SyntaxError
+- id: table_row-mut-collection-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x in &"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x in *"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x in @"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x in \"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x in `"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x in ^"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x in $"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x in #"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x in ;"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x in ~"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x in "hello"'
+  type: SyntaxError
+- id: table_row-mut-collection-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x in ''hello"'
+  type: SyntaxError
+- id: table_row-mut-collection-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in x[,]"'
+  type: SyntaxError
+- id: table_row-mut-collection-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x in x.123"'
+  type: SyntaxError
+- id: table_row-mut-collection-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x in x."y""'
+  type: SyntaxError
+- id: table_row-mut-collection-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x in (1, 5)"'
+  type: SyntaxError
+- id: table_row-mut-collection-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    in (1..)"'
+  type: SyntaxError
+- id: table_row-mut-collection-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x in x."'
+  type: SyntaxError
+- id: table_row-mut-collection-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    in x[0"'
+  type: SyntaxError
+- id: table_row-mut-collection-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    in (1..5"'
+  type: SyntaxError
+- id: table_row-mut-collection-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x in |"'
+  type: SyntaxError
+- id: table_row-mut-collection-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x in
+    ?"'
+  type: SyntaxError
+- id: table_row-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    in x )"'
+  type: SyntaxError
+- id: table_row-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    in x ]"'
+  type: SyntaxError
+- id: table_row-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x in x :"'
+  type: SyntaxError
+- id: table_row-mut-end-trail-comma
+  error:
+  type:
+- id: table_row-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "x in
+    x =="'
+  type: SyntaxError
+- id: table_row-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x in x -"'
+  type: SyntaxError
+- id: table_row-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x in x ."'
+  type: SyntaxError
+- id: table_row-mut-end-trail-id
+  error: 'Liquid syntax error: Invalid attribute ''extra'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x extra"'
+  type: SyntaxError
+- id: table_row-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x in x
+    42"'
+  type: SyntaxError
+- id: table_row-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x in
+    x ("'
+  type: SyntaxError
+- id: table_row-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in
+    x ["'
+  type: SyntaxError
+- id: table_row-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x in x |"'
+  type: SyntaxError
+- id: table_row-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x in
+    x ?"'
+  type: SyntaxError
+- id: table_row-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x in x
+    ''hi''"'
+  type: SyntaxError
+- id: table_row-mut-in_keyword-eos
+  error: 'Liquid syntax error: For loops require an ''in'' clause in "x"'
+  type: SyntaxError
+- id: table_row-mut-in_keyword-id
+  error: 'Liquid syntax error: For loops require an ''in'' clause in "x of"'
+  type: SyntaxError
+- id: table_row-mut-invalid_attribute-invalid
+  error: 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid
+    attributes are cols, limit, offset, and range in "x in x step ,"'
+  type: SyntaxError
+- id: table_row-mut-valid-000
+  error:
+  type:
+- id: table_row-mut-valid-001
+  error:
+  type:
+- id: table_row-mut-valid-002
+  error:
+  type:
+- id: table_row-mut-valid-003
+  error:
+  type:
+- id: table_row-mut-valid-004
+  error:
+  type:
+- id: table_row-mut-valid-005
+  error:
+  type:
+- id: table_row-mut-valid-006
+  error:
+  type:
+- id: table_row-mut-valid-007
+  error:
+  type:
+- id: table_row-mut-valid-008
+  error:
+  type:
+- id: table_row-mut-valid-009
+  error:
+  type:
+- id: table_row-mut-valid-010
+  error:
+  type:
+- id: table_row-mut-valid-011
+  error:
+  type:
+- id: table_row-mut-valid-012
+  error:
+  type:
+- id: table_row-mut-valid-013
+  error:
+  type:
+- id: table_row-mut-valid-014
+  error:
+  type:
+- id: table_row-mut-variable_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in ""'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: table_row-mut-variable_name-number
+  error: 'Liquid syntax error: Expected id but found number in "42"'
+  type: SyntaxError
+- id: table_row-themecheck-trailing-comma
+  error:
+  type:

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/unless.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/unless.snap.yml
@@ -1,0 +1,663 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: unless-mut-boolean_comparison_rhs-bare_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    [0]"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-close_round-004
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    )"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-close_square-003
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ]"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-colon-002
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    :"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-comma-001
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ,"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-comparison-009
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    =="'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-comparison-010
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    !="'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-comparison-011
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    <"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-comparison-012
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    >"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-comparison-013
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    <="'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-comparison-014
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    >="'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-comparison-015
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    contains"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-dash-006
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    -"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-dot-007
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ."'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-dotdot-008
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    .."'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-eos-016
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x =="'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and x x == &"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and x x == *"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and x x == @"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and x x == \"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and x x == `"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and x x == ^"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and x x == $"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and x x == #"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and x x == ;"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and x x == ~"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and x x == "hello"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and x x == ''hello"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x[,]"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lookup-dot_number
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x.123"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lookup-dot_string
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x."y""'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1, 5)"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1..)"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x."'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    x[0"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    (1..5"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-pipe-000
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    |"'
+  type: SyntaxError
+- id: unless-mut-boolean_comparison_rhs-question-005
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x ==
+    ?"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-bare_bracket
+  error:
+  type:
+- id: unless-mut-boolean_expr-close_round-004
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    and x )"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-close_square-003
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    and x ]"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-colon-002
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x and x
+    :"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-comma-001
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x and x
+    ,"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-comparison-009
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x =="'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-comparison-010
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x !="'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-comparison-011
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x <"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-comparison-012
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x >"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-comparison-013
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x <="'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-comparison-014
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x >="'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-comparison-015
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and
+    x contains"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-dash-006
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x and x -"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-dot-007
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x and x ."'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-dotdot-008
+  error: 'Liquid syntax error: Expected end_of_string but found dotdot in "x and x
+    .."'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-eos-016
+  error:
+  type:
+- id: unless-mut-boolean_expr-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and x &"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and x *"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and x @"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and x \"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and x `"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and x ^"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and x $"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and x #"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and x ;"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and x ~"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and x "hello"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and x ''hello"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x[,]"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lookup-dot_number
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x.123"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lookup-dot_string
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x."y""'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1, 5)"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lookup-range_missing_end
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1..)"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x."'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x and x x[0"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+    x (1..5"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-pipe-000
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x and x |"'
+  type: SyntaxError
+- id: unless-mut-boolean_expr-question-005
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x and
+    x ?"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-eos
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x and &"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x and *"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x and @"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x and \"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x and `"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x and ^"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x and $"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x and #"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x and ;"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x and ~"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x and "hello"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x and ''hello"'
+  type: SyntaxError
+- id: unless-mut-boolean_op-number
+  error:
+  type:
+- id: unless-mut-comparison_rhs-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "x == [0]"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    == )"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x
+    == ]"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x == :"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == ,"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x
+    == =="'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x
+    == !="'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x
+    == <"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x
+    == >"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x
+    == <="'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x
+    == >="'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "x == contains"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x == -"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "x == ."'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x ==
+    .."'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "x == &"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "x == *"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "x == @"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "x == \"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "x == `"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "x == ^"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "x == $"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "x == #"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "x == ;"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "x == ~"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "x == "hello"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "x == ''hello"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == x[,]"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x == x.123"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x == x."y""'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "x == (1, 5)"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x
+    == (1..)"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x == x."'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x
+    == x[0"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "x
+    == (1..5"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x == |"'
+  type: SyntaxError
+- id: unless-mut-comparison_rhs-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "x ==
+    ?"'
+  type: SyntaxError
+- id: unless-mut-condition-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "[0]"'
+  type: SyntaxError
+- id: unless-mut-condition-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  type: SyntaxError
+- id: unless-mut-condition-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  type: SyntaxError
+- id: unless-mut-condition-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  type: SyntaxError
+- id: unless-mut-condition-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  type: SyntaxError
+- id: unless-mut-condition-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  type: SyntaxError
+- id: unless-mut-condition-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  type: SyntaxError
+- id: unless-mut-condition-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  type: SyntaxError
+- id: unless-mut-condition-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  type: SyntaxError
+- id: unless-mut-condition-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  type: SyntaxError
+- id: unless-mut-condition-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  type: SyntaxError
+- id: unless-mut-condition-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "contains"'
+  type: SyntaxError
+- id: unless-mut-condition-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  type: SyntaxError
+- id: unless-mut-condition-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  type: SyntaxError
+- id: unless-mut-condition-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  type: SyntaxError
+- id: unless-mut-condition-eos-016
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "&"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "*"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "@"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "\"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "`"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "^"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "$"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "#"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in ";"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "~"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in ""hello"'
+  type: SyntaxError
+- id: unless-mut-condition-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "''hello"'
+  type: SyntaxError
+- id: unless-mut-condition-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  type: SyntaxError
+- id: unless-mut-condition-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "x.123"'
+  type: SyntaxError
+- id: unless-mut-condition-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "x."y""'
+  type: SyntaxError
+- id: unless-mut-condition-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  type: SyntaxError
+- id: unless-mut-condition-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  type: SyntaxError
+- id: unless-mut-condition-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  type: SyntaxError
+- id: unless-mut-condition-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  type: SyntaxError
+- id: unless-mut-condition-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  type: SyntaxError
+- id: unless-mut-condition-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  type: SyntaxError
+- id: unless-mut-condition-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  type: SyntaxError
+- id: unless-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "x
+    )"'
+  type: SyntaxError
+- id: unless-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "x
+    ]"'
+  type: SyntaxError
+- id: unless-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  type: SyntaxError
+- id: unless-mut-end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  type: SyntaxError
+- id: unless-mut-end-trail-comparison
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  type: SyntaxError
+- id: unless-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  type: SyntaxError
+- id: unless-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  type: SyntaxError
+- id: unless-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  type: SyntaxError
+- id: unless-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  type: SyntaxError
+- id: unless-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  type: SyntaxError
+- id: unless-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  type: SyntaxError
+- id: unless-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  type: SyntaxError
+- id: unless-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  type: SyntaxError
+- id: unless-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  type: SyntaxError
+- id: unless-mut-valid-000
+  error:
+  type:
+- id: unless-mut-valid-001
+  error:
+  type:
+- id: unless-mut-valid-002
+  error:
+  type:
+- id: unless-mut-valid-003
+  error:
+  type:
+- id: unless-mut-valid-004
+  error:
+  type:
+- id: unless-mut-valid-005
+  error:
+  type:
+- id: unless-mut-valid-006
+  error:
+  type:
+- id: unless-mut-valid-007
+  error:
+  type:
+- id: unless-mut-valid-008
+  error:
+  type:
+- id: unless-mut-valid-009
+  error:
+  type:
+- id: unless-mut-valid-010
+  error:
+  type:
+- id: unless-mut-valid-011
+  error:
+  type:
+- id: unless-mut-valid-012
+  error:
+  type:
+- id: unless-mut-valid-013
+  error:
+  type:
+- id: unless-mut-valid-014
+  error:
+  type:
+- id: unless-parity-js-and-operator
+  error: 'Liquid syntax error: Unexpected character & in "x && y"'
+  type: SyntaxError
+- id: unless-parity-js-or-operator
+  error: 'Liquid syntax error: Expected end_of_string but found pipe in "x || y"'
+  type: SyntaxError
+- id: unless-parity-non-liquid-operator
+  error: 'Liquid syntax error: Expected end_of_string but found id in "x startswith
+    "foo""'
+  type: SyntaxError
+- id: unless-parity-triple-equals
+  error: 'Liquid syntax error: Unexpected character = in "x === y"'
+  type: SyntaxError
+- id: unless-themecheck-whitespace-quote-prefix
+  error: 'Liquid syntax error: Unexpected character '' in "'' product.available"'
+  type: SyntaxError

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/variable.snap.yml
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/parity/snapshots/variable.snap.yml
@@ -1,0 +1,725 @@
+# Auto-generated Ruby Liquid parity corpus — do not edit by hand.
+---
+- id: variable-mut-end-trail-close_round
+  error: 'Liquid syntax error: Expected end_of_string but found close_round in "{{
+    x ) }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-close_square
+  error: 'Liquid syntax error: Expected end_of_string but found close_square in "{{
+    x ] }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "{{ x : }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-comma
+  error: 'Liquid syntax error: Expected end_of_string but found comma in "{{ x , }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-comparison
+  error: 'Liquid syntax error: Expected end_of_string but found comparison in "{{
+    x == }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-dash
+  error: 'Liquid syntax error: Expected end_of_string but found dash in "{{ x - }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{ x . }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-id
+  error: 'Liquid syntax error: Expected end_of_string but found id in "{{ x extra
+    }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-number
+  error: 'Liquid syntax error: Expected end_of_string but found number in "{{ x 42
+    }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-open_round
+  error: 'Liquid syntax error: Expected end_of_string but found open_round in "{{
+    x ( }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-open_square
+  error: 'Liquid syntax error: [:end_of_string] is not a valid expression in "{{ x
+    [ }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-pipe
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{ x | }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-question
+  error: 'Liquid syntax error: Expected end_of_string but found question in "{{ x
+    ? }}"'
+  type: SyntaxError
+- id: variable-mut-end-trail-string
+  error: 'Liquid syntax error: Expected end_of_string but found string in "{{ x ''hi''
+    }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-bare_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , [0] }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-close_round-004
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , ) }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-close_square-003
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , ] }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-colon-002
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , : }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , , }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-comparison-009
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , == }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-comparison-010
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , != }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-comparison-011
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , < }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-comparison-012
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , > }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-comparison-013
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , <= }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-comparison-014
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , >= }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-comparison-015
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , contains }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-dash-006
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , - }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-dot-007
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , . }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-dotdot-008
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , .. }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-eos-016
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{ x | x : x , , & }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{ x | x : x , , * }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{ x | x : x , , @ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{ x | x : x , , \ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{ x | x : x , , ` }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{ x | x : x , , ^ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{ x | x : x , , $ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{ x | x : x , , # }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{ x | x : x , , ; }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{ x | x : x , , ~ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{ x | x : x , , "hello
+    }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{ x | x : x , , ''hello
+    }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x[,] }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lookup-dot_number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x.123 }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lookup-dot_string
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x."y" }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , (1, 5) }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , (1..) }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x. }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x[0 }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , (1..5 }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-pipe-000
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , | }}"'
+  type: SyntaxError
+- id: variable-mut-filter_arg_value-question-005
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , ? }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "{{ x | x : [0] }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{
+    x | x : ) }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{
+    x | x : ] }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{ x |
+    x : : }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : , }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{
+    x | x : == }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{
+    x | x : != }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{
+    x | x : < }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{
+    x | x : > }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{
+    x | x : <= }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{
+    x | x : >= }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "{{ x | x : contains }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{ x | x
+    : - }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{ x | x
+    : . }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{ x
+    | x : .. }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-eos-016
+  error:
+  type:
+- id: variable-mut-filter_first_arg-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{ x | x : & }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{ x | x : * }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{ x | x : @ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{ x | x : \ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{ x | x : ` }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{ x | x : ^ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{ x | x : $ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{ x | x : # }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{ x | x : ; }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{ x | x : ~ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{ x | x : "hello }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{ x | x : ''hello }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x[,] }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "{{ x | x : x.123 }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "{{ x | x : x."y" }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "{{ x | x : (1,
+    5) }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{
+    x | x : (1..) }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{ x | x :
+    x. }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "{{
+    x | x : x[0 }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "{{
+    x | x : (1..5 }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-pipe-000
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{ x | x :
+    | }}"'
+  type: SyntaxError
+- id: variable-mut-filter_first_arg-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{ x
+    | x : ? }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-eos
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{ x | }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{ x | & }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{ x | * }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{ x | @ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{ x | \ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{ x | ` }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{ x | ^ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{ x | $ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{ x | # }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{ x | ; }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{ x | ~ }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{ x | "hello }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{ x | ''hello }}"'
+  type: SyntaxError
+- id: variable-mut-filter_name-number
+  error: 'Liquid syntax error: Expected id but found number in "{{ x | 42 }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_colon-eos
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_colon-number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x 42 }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-bare_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : [0] }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-close_round-004
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : ) }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-close_square-003
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : ] }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-colon-002
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : : }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : , }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-comparison-009
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : == }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-comparison-010
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : != }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-comparison-011
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : < }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-comparison-012
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : > }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-comparison-013
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : <= }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-comparison-014
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : >= }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-comparison-015
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : contains }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-dash-006
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : - }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-dot-007
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : . }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-dotdot-008
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : .. }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-eos-016
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{ x | x : x , , x : & }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{ x | x : x , , x : * }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{ x | x : x , , x : @ }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{ x | x : x , , x : \ }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{ x | x : x , , x : ` }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{ x | x : x , , x : ^ }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{ x | x : x , , x : $ }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{ x | x : x , , x : # }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{ x | x : x , , x : ; }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{ x | x : x , , x : ~ }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{ x | x : x , , x : "hello
+    }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{ x | x : x , , x : ''hello
+    }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : x[,] }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lookup-dot_number
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : x.123 }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lookup-dot_string
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : x."y" }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lookup-range_bad_separator
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : (1, 5) }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : (1..) }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lookup-trailing_dot
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : x. }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : x[0 }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-lookup-unclosed_range
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : (1..5 }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-pipe-000
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : | }}"'
+  type: SyntaxError
+- id: variable-mut-kwarg_value-question-005
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x |
+    x : x , , x : ? }}"'
+  type: SyntaxError
+- id: variable-mut-valid-000
+  error:
+  type:
+- id: variable-mut-valid-001
+  error:
+  type:
+- id: variable-mut-valid-002
+  error:
+  type:
+- id: variable-mut-valid-003
+  error:
+  type:
+- id: variable-mut-valid-004
+  error:
+  type:
+- id: variable-mut-valid-005
+  error:
+  type:
+- id: variable-mut-valid-006
+  error:
+  type:
+- id: variable-mut-valid-007
+  error:
+  type:
+- id: variable-mut-valid-008
+  error:
+  type:
+- id: variable-mut-valid-009
+  error:
+  type:
+- id: variable-mut-valid-010
+  error:
+  type:
+- id: variable-mut-valid-011
+  error:
+  type:
+- id: variable-mut-valid-012
+  error:
+  type:
+- id: variable-mut-valid-013
+  error:
+  type:
+- id: variable-mut-valid-014
+  error:
+  type:
+- id: variable-mut-value-bare_bracket
+  error: 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode.
+    Use self[''...''] instead in "{{ [0] }}"'
+  type: SyntaxError
+- id: variable-mut-value-close_round-004
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{
+    ) }}"'
+  type: SyntaxError
+- id: variable-mut-value-close_square-003
+  error: 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{
+    ] }}"'
+  type: SyntaxError
+- id: variable-mut-value-colon-002
+  error: 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{ : }}"'
+  type: SyntaxError
+- id: variable-mut-value-comma-001
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ , }}"'
+  type: SyntaxError
+- id: variable-mut-value-comparison-009
+  error: 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{
+    == }}"'
+  type: SyntaxError
+- id: variable-mut-value-comparison-010
+  error: 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{
+    != }}"'
+  type: SyntaxError
+- id: variable-mut-value-comparison-011
+  error: 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{
+    < }}"'
+  type: SyntaxError
+- id: variable-mut-value-comparison-012
+  error: 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{
+    > }}"'
+  type: SyntaxError
+- id: variable-mut-value-comparison-013
+  error: 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{
+    <= }}"'
+  type: SyntaxError
+- id: variable-mut-value-comparison-014
+  error: 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{
+    >= }}"'
+  type: SyntaxError
+- id: variable-mut-value-comparison-015
+  error: 'Liquid syntax error: [:comparison, "contains"] is not a valid expression
+    in "{{ contains }}"'
+  type: SyntaxError
+- id: variable-mut-value-dash-006
+  error: 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{ - }}"'
+  type: SyntaxError
+- id: variable-mut-value-dot-007
+  error: 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{ . }}"'
+  type: SyntaxError
+- id: variable-mut-value-dotdot-008
+  error: 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{ ..
+    }}"'
+  type: SyntaxError
+- id: variable-mut-value-eos-016
+  error:
+  type:
+- id: variable-mut-value-lexerr-ampersand
+  error: 'Liquid syntax error: Unexpected character & in "{{ & }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-asterisk
+  error: 'Liquid syntax error: Unexpected character * in "{{ * }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-at
+  error: 'Liquid syntax error: Unexpected character @ in "{{ @ }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-backslash
+  error: 'Liquid syntax error: Unexpected character \ in "{{ \ }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-backtick
+  error: 'Liquid syntax error: Unexpected character ` in "{{ ` }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-caret
+  error: 'Liquid syntax error: Unexpected character ^ in "{{ ^ }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-dollar
+  error: 'Liquid syntax error: Unexpected character $ in "{{ $ }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-hash
+  error: 'Liquid syntax error: Unexpected character # in "{{ # }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-semicolon
+  error: 'Liquid syntax error: Unexpected character ; in "{{ ; }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-tilde
+  error: 'Liquid syntax error: Unexpected character ~ in "{{ ~ }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-unclosed_double_quote
+  error: 'Liquid syntax error: Unexpected character " in "{{ "hello }}"'
+  type: SyntaxError
+- id: variable-mut-value-lexerr-unclosed_single_quote
+  error: 'Liquid syntax error: Unexpected character '' in "{{ ''hello }}"'
+  type: SyntaxError
+- id: variable-mut-value-lookup-bracket_wrong_content
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x[,]
+    }}"'
+  type: SyntaxError
+- id: variable-mut-value-lookup-dot_number
+  error: 'Liquid syntax error: Expected id but found number in "{{ x.123 }}"'
+  type: SyntaxError
+- id: variable-mut-value-lookup-dot_string
+  error: 'Liquid syntax error: Expected id but found string in "{{ x."y" }}"'
+  type: SyntaxError
+- id: variable-mut-value-lookup-range_bad_separator
+  error: 'Liquid syntax error: Expected dotdot but found comma in "{{ (1, 5) }}"'
+  type: SyntaxError
+- id: variable-mut-value-lookup-range_missing_end
+  error: 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{
+    (1..) }}"'
+  type: SyntaxError
+- id: variable-mut-value-lookup-trailing_dot
+  error: 'Liquid syntax error: Expected id but found end_of_string in "{{ x. }}"'
+  type: SyntaxError
+- id: variable-mut-value-lookup-unclosed_bracket
+  error: 'Liquid syntax error: Expected close_square but found end_of_string in "{{
+    x[0 }}"'
+  type: SyntaxError
+- id: variable-mut-value-lookup-unclosed_range
+  error: 'Liquid syntax error: Expected close_round but found end_of_string in "{{
+    (1..5 }}"'
+  type: SyntaxError
+- id: variable-mut-value-pipe-000
+  error: 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "{{ | }}"'
+  type: SyntaxError
+- id: variable-mut-value-question-005
+  error: 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{ ?
+    }}"'
+  type: SyntaxError
+- id: variable-themecheck-filter-separator-adjacent-colon
+  error: 'Liquid syntax error: Expected end_of_string but found colon in "{{ n | pluralize:
+    ''comment'': ''comments'' }}"'
+  type: SyntaxError
+- id: variable-themecheck-filter-separator-leading-comma
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ n |
+    f1: , }}"'
+  type: SyntaxError
+- id: variable-themecheck-filter-separator-leading-comma-before-pipe
+  error: 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ n |
+    f1: , | f2 }}"'
+  type: SyntaxError
+- id: variable-themecheck-filter-separator-missing-comma
+  error: 'Liquid syntax error: Expected end_of_string but found number in "{{ n |
+    filter: 1 2, 3 }}"'
+  type: SyntaxError
+- id: variable-themecheck-filter-separator-mixed-positional-keyword
+  error:
+  type:
+- id: variable-themecheck-filter-separator-trailing-comma-before-pipe
+  error:
+  type:
+- id: variable-themecheck-malformed-empty-filter-prefix
+  error: 'Liquid syntax error: Expected end_of_string but found id in "{{ x y | append:
+    }}"'
+  type: SyntaxError

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       '@vitest/expect':
         specifier: 4.1.0
         version: 4.1.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
   packages/theme-check-docs-updater:
     dependencies:


### PR DESCRIPTION
### What are you trying to accomplish?

Migrate the Liquid parity test suite for LiquidSyntaxError to the public theme-check-common

### What approach did you use?

Copies like-for-like, and ensures the test run in their new location

