### PR TITLE
docs(theme-check): link LiquidHTMLSyntaxError to its shopify.dev reference

### DIFF
--- a/.changeset/liquid-html-syntax-error-docs-url.md
+++ b/.changeset/liquid-html-syntax-error-docs-url.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Add a `docs.url` to `LiquidHTMLSyntaxError` so editors surface a "learn more" link on the diagnostic.

--- a/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-html-syntax-error/index.ts
@@ -36,6 +36,7 @@ export const LiquidHTMLSyntaxError: LiquidCheckDefinition = {
     docs: {
       description: 'This check exists to inform the user of Liquid HTML syntax errors.',
       recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/liquid-html-syntax-error',
     },
     type: SourceCodeType.LiquidHtml,
     severity: Severity.ERROR,


### PR DESCRIPTION
## What

Adds the missing `docs.url` to the `LiquidHTMLSyntaxError` check so editors surface a "learn more" link on the diagnostic.