### PR TITLE
Require VS Code consent for custom theme checks

### DIFF
--- a/.changeset/bright-themes-ask.md
+++ b/.changeset/bright-themes-ask.md
@@ -1,0 +1,8 @@
+---
+'@shopify/theme-check-node': minor
+'@shopify/theme-language-server-common': minor
+'@shopify/theme-language-server-node': minor
+'theme-check-vscode': minor
+---
+
+Ask for explicit VS Code consent before executing custom Theme Check code selected by a theme configuration.

--- a/packages/theme-check-node/src/config/load-config-description.ts
+++ b/packages/theme-check-node/src/config/load-config-description.ts
@@ -10,7 +10,7 @@ import { fileExists } from '../file-utils';
 import { AbsolutePath } from '../temp';
 import { thisNodeModuleRoot } from './installation-location';
 import { findThirdPartyChecks, loadThirdPartyChecks } from './load-third-party-checks';
-import { ConfigDescription } from './types';
+import { ConfigDescription, CustomCheckCandidate, LoadConfigOptions } from './types';
 import { URI, Utils } from 'vscode-uri';
 
 const flatten = <T>(arrs: T[][]): T[] => arrs.flat();
@@ -24,16 +24,27 @@ const flatten = <T>(arrs: T[][]): T[] => arrs.flat();
 export async function loadConfigDescription(
   configDescription: ConfigDescription,
   root: AbsolutePath,
+  options: LoadConfigOptions = {},
 ): Promise<Config> {
   const nodeModuleRoot = await findNodeModuleRoot(root);
-  const thirdPartyChecksPaths = await Promise.all([
+  const [globalThirdPartyChecksPaths, workspaceThirdPartyChecksPaths] = await Promise.all([
     findThirdPartyChecks(thisNodeModuleRoot()), // global checks
     findThirdPartyChecks(nodeModuleRoot),
-  ]).then(flatten);
-  const thirdPartyChecks = loadThirdPartyChecks([
-    ...configDescription.require,
-    ...thirdPartyChecksPaths,
   ]);
+  const customCheckCandidates = uniqueCandidates([
+    ...configDescription.require.map((path) => ({ source: 'require' as const, path })),
+    ...flatten([globalThirdPartyChecksPaths, workspaceThirdPartyChecksPaths]).map((path) => ({
+      source: 'discovery' as const,
+      path,
+    })),
+  ]);
+  const customChecksAuthorized =
+    customCheckCandidates.length === 0 ||
+    !options.authorizeCustomChecks ||
+    (await options.authorizeCustomChecks({ root, candidates: customCheckCandidates }));
+  const thirdPartyChecks = customChecksAuthorized
+    ? loadThirdPartyChecks(customCheckCandidates.map(({ path }) => path))
+    : [];
   const checks: CheckDefinition<SourceCodeType>[] = allChecks
     .concat(thirdPartyChecks)
     .filter(isEnabledBy(configDescription));
@@ -46,6 +57,15 @@ export async function loadConfigDescription(
     ignore: configDescription.ignore,
     rootUri: resolveRoot(rootUri, configDescription.root),
   };
+}
+
+function uniqueCandidates(candidates: CustomCheckCandidate[]): CustomCheckCandidate[] {
+  const seen = new Set<string>();
+  return candidates.filter(({ path }) => {
+    if (seen.has(path)) return false;
+    seen.add(path);
+    return true;
+  });
 }
 
 /**

--- a/packages/theme-check-node/src/config/load-config.spec.ts
+++ b/packages/theme-check-node/src/config/load-config.spec.ts
@@ -67,6 +67,15 @@ describe('Unit: loadConfig', () => {
     expect(config.ignore).to.include('src/**');
   });
 
+  it('does not request authorization when there are no custom checks', async () => {
+    const configPath = await createMockConfigFile(tempDir, `extends: theme-check:recommended`);
+    const authorizeCustomChecks = vi.fn().mockResolvedValue(false);
+
+    await loadConfig(configPath, tempDir, { authorizeCustomChecks });
+
+    expect(authorizeCustomChecks).not.toHaveBeenCalled();
+  });
+
   it('has no checks if it extends nothing', async () => {
     const configPath = await createMockConfigFile(tempDir, `extends: nothing`);
     const config = await loadConfig(configPath, tempDir);
@@ -215,6 +224,90 @@ NodeModuleCheck:
     const config = await loadConfig(configPath, tempDir);
     const nodeModuleCheck = config.checks.find((check) => check.meta.code === 'NodeModuleCheck');
     expect(nodeModuleCheck).to.exist;
+  });
+
+  it('does not execute a required extension before it is authorized', async () => {
+    const configPath = await createMockConfigFile(
+      tempDir,
+      `
+extends: nothing
+require: './checks.js'
+NodeModuleCheck:
+  enabled: true
+      `,
+    );
+    const markerPath = path.join(tempDir, 'executed');
+    await fs.writeFile(
+      path.join(tempDir, 'checks.js'),
+      `require('node:fs').writeFileSync(${JSON.stringify(markerPath)}, 'yes');\n${mockNodeModuleCheck}`,
+    );
+    const authorizeCustomChecks = vi.fn().mockResolvedValue(false);
+
+    const config = await loadConfig(configPath, tempDir, { authorizeCustomChecks });
+
+    expect(authorizeCustomChecks).toHaveBeenCalledWith({
+      root: tempDir,
+      candidates: [{ source: 'require', path: path.join(tempDir, 'checks.js') }],
+    });
+    expect(config.checks.find((check) => check.meta.code === 'NodeModuleCheck')).not.to.exist;
+    await expect(fs.stat(markerPath)).rejects.toThrow();
+  });
+
+  it('asks for authorization for extensions inherited through extends', async () => {
+    await fs.writeFile(
+      path.join(tempDir, 'base.yml'),
+      `
+extends: nothing
+require: './checks.js'
+      `,
+    );
+    await fs.writeFile(path.join(tempDir, 'checks.js'), mockNodeModuleCheck);
+    const configPath = await createMockConfigFile(tempDir, `extends: './base.yml'`);
+    const authorizeCustomChecks = vi.fn().mockResolvedValue(false);
+
+    await loadConfig(configPath, tempDir, { authorizeCustomChecks });
+
+    expect(authorizeCustomChecks).toHaveBeenCalledWith({
+      root: tempDir,
+      candidates: [{ source: 'require', path: path.join(tempDir, 'checks.js') }],
+    });
+  });
+
+  it('asks for authorization before loading automatically discovered extensions', async () => {
+    const configPath = path.resolve(__dirname, 'fixtures/node-module-rec.yml');
+    const modulePath = await createMockNodeModule(
+      tempDir,
+      'theme-check-node-example',
+      mockNodeModuleCheck,
+    );
+    const authorizeCustomChecks = vi.fn().mockResolvedValue(false);
+
+    const config = await loadConfig(configPath, tempDir, { authorizeCustomChecks });
+
+    expect(authorizeCustomChecks).toHaveBeenCalledWith({
+      root: tempDir,
+      candidates: [{ source: 'discovery', path: modulePath }],
+    });
+    expect(config.checks.find((check) => check.meta.code === 'NodeModuleCheck')).not.to.exist;
+  });
+
+  it('loads custom checks after they are authorized', async () => {
+    const configPath = await createMockConfigFile(
+      tempDir,
+      `
+extends: nothing
+require: './checks.js'
+NodeModuleCheck:
+  enabled: true
+      `,
+    );
+    await fs.writeFile(path.join(tempDir, 'checks.js'), mockNodeModuleCheck);
+
+    const config = await loadConfig(configPath, tempDir, {
+      authorizeCustomChecks: vi.fn().mockResolvedValue(true),
+    });
+
+    expect(config.checks.find((check) => check.meta.code === 'NodeModuleCheck')).to.exist;
   });
 
   it('loads an aliased check properly', async () => {

--- a/packages/theme-check-node/src/config/load-config.ts
+++ b/packages/theme-check-node/src/config/load-config.ts
@@ -2,7 +2,7 @@ import { Config } from '@shopify/theme-check-common';
 import { AbsolutePath } from '../temp';
 import { loadConfigDescription } from './load-config-description';
 import { resolveConfig } from './resolve';
-import { ModernIdentifier } from './types';
+import { LoadConfigOptions, ModernIdentifier } from './types';
 import { validateConfig } from './validation';
 import fs from 'fs/promises';
 
@@ -21,6 +21,7 @@ export async function loadConfig(
   configPath: AbsolutePath | ModernIdentifier | undefined,
   /** The root of the theme */
   root: AbsolutePath,
+  options: LoadConfigOptions = {},
 ): Promise<Config> {
   if (!root) throw new Error('loadConfig cannot be called without a root argument');
   let defaultChecks = 'theme-check:recommended';
@@ -35,7 +36,7 @@ export async function loadConfig(
   }
 
   const configDescription = await resolveConfig(configPath ?? defaultChecks, true);
-  const config = await loadConfigDescription(configDescription, root);
+  const config = await loadConfigDescription(configDescription, root, options);
   validateConfig(config);
   return config;
 }

--- a/packages/theme-check-node/src/config/types.ts
+++ b/packages/theme-check-node/src/config/types.ts
@@ -30,6 +30,25 @@ export type ConfigDescription = Omit<ConfigFragment, 'extends' | 'context'> & {
   context: Mode;
 };
 
+export interface CustomCheckCandidate {
+  source: 'require' | 'discovery';
+  path: string;
+}
+
+export interface CustomCheckAuthorizationRequest {
+  root: string;
+  candidates: CustomCheckCandidate[];
+}
+
+export interface LoadConfigOptions {
+  /**
+   * Called after custom checks have been discovered, but before any of their
+   * JavaScript is loaded. When omitted, custom checks retain their existing
+   * behaviour and are loaded without an additional authorization step.
+   */
+  authorizeCustomChecks?: (request: CustomCheckAuthorizationRequest) => Promise<boolean>;
+}
+
 export const ModernIdentifiers = [
   'theme-check:nothing',
   'theme-check:recommended',

--- a/packages/theme-language-server-common/src/types.ts
+++ b/packages/theme-language-server-common/src/types.ts
@@ -148,6 +148,23 @@ export namespace ThemeGraphDidUpdateNotification {
   }
 }
 
+export namespace CustomCheckPermissionRequest {
+  export const method = 'themeCheck/requestCustomCheckPermission';
+  export const type = new rpc.RequestType<Params, Response, void>(method);
+
+  export interface Candidate {
+    source: 'require' | 'discovery';
+    path: string;
+  }
+
+  export interface Params {
+    root: string;
+    candidates: Candidate[];
+  }
+
+  export type Response = boolean;
+}
+
 export type AugmentedLocationWithExistence = {
   uri: string;
   range: undefined;

--- a/packages/theme-language-server-node/src/dependencies.ts
+++ b/packages/theme-language-server-node/src/dependencies.ts
@@ -1,6 +1,7 @@
 import {
   AbstractFileSystem,
   Config,
+  LoadConfigOptions,
   findRoot,
   loadConfig as nodeLoadConfig,
   makeFileExists,
@@ -28,7 +29,11 @@ const hasThemeAppExtensionConfig = async (rootUri: string, fs: AbstractFileSyste
   return files.length > 0;
 };
 
-export const loadConfig: Dependencies['loadConfig'] = async function loadConfig(uriString, fs) {
+export async function loadConfig(
+  uriString: string,
+  fs: AbstractFileSystem,
+  options: LoadConfigOptions = {},
+): Promise<Config> {
   const fileUri = path.normalize(uriString);
   const fileExists = makeFileExists(fs);
   const rootUriString = await findRoot(fileUri, fileExists);
@@ -47,11 +52,13 @@ export const loadConfig: Dependencies['loadConfig'] = async function loadConfig(
     const configPath = asFsPath(configUri);
     const rootPath = asFsPath(rootUri);
     if (configExists) {
-      return nodeLoadConfig(configPath, rootPath).then(normalizeRoot);
+      return nodeLoadConfig(configPath, rootPath, options).then(normalizeRoot);
     } else if (isDefinitelyThemeAppExtension) {
-      return nodeLoadConfig('theme-check:theme-app-extension', rootPath).then(normalizeRoot);
+      return nodeLoadConfig('theme-check:theme-app-extension', rootPath, options).then(
+        normalizeRoot,
+      );
     } else {
-      return nodeLoadConfig(undefined, rootPath).then(normalizeRoot);
+      return nodeLoadConfig(undefined, rootPath, options).then(normalizeRoot);
     }
   } else {
     // We can't load configs properly in remote environments.
@@ -64,7 +71,7 @@ export const loadConfig: Dependencies['loadConfig'] = async function loadConfig(
       rootUri: path.normalize(rootUri),
     };
   }
-};
+}
 
 function normalizeRoot(config: Config) {
   config.rootUri = path.normalize(config.rootUri);

--- a/packages/theme-language-server-node/src/index.ts
+++ b/packages/theme-language-server-node/src/index.ts
@@ -1,5 +1,9 @@
 import { ThemeLiquidDocsManager } from '@shopify/theme-check-docs-updater';
-import { AbstractFileSystem, NodeFileSystem } from '@shopify/theme-check-node';
+import {
+  AbstractFileSystem,
+  CustomCheckAuthorizationRequest,
+  NodeFileSystem,
+} from '@shopify/theme-check-node';
 import { startServer as startCoreServer } from '@shopify/theme-language-server-common';
 import { stdin, stdout } from 'node:process';
 import { createConnection } from 'vscode-languageserver/node';
@@ -11,7 +15,15 @@ export * from '@shopify/theme-language-server-common';
 
 export const getConnection = () => createConnection(stdin, stdout);
 
-export function startServer(connection = getConnection(), fs: AbstractFileSystem = NodeFileSystem) {
+export interface StartServerOptions {
+  authorizeCustomChecks?: (request: CustomCheckAuthorizationRequest) => Promise<boolean>;
+}
+
+export function startServer(
+  connection = getConnection(),
+  fs: AbstractFileSystem = NodeFileSystem,
+  options: StartServerOptions = {},
+) {
   // Using console.error to not interfere with messages sent on STDIN/OUT
   const log = (message: string) => console.error(message);
   const themeLiquidDocsManager = new ThemeLiquidDocsManager(log);
@@ -19,7 +31,8 @@ export function startServer(connection = getConnection(), fs: AbstractFileSystem
   startCoreServer(connection, {
     fs,
     log,
-    loadConfig,
+    loadConfig: (uri, fs) =>
+      loadConfig(uri, fs, { authorizeCustomChecks: options.authorizeCustomChecks }),
     themeDocset: themeLiquidDocsManager,
     jsonValidationSet: themeLiquidDocsManager,
     fetchMetafieldDefinitionsForURI,

--- a/packages/vscode-extension/src/node/customCheckConsent.spec.ts
+++ b/packages/vscode-extension/src/node/customCheckConsent.spec.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { window, workspace } from 'vscode';
+import { makeCustomCheckPermissionHandler } from './customCheckConsent';
+
+vi.mock('vscode', () => ({
+  window: {
+    showWarningMessage: vi.fn(),
+  },
+  workspace: {
+    isTrusted: true,
+  },
+}));
+
+describe('custom check consent', () => {
+  const params = {
+    root: '/themes/example',
+    candidates: [{ source: 'require' as const, path: '/themes/example/checks/custom.js' }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(workspace, 'isTrusted', { configurable: true, value: true });
+  });
+
+  it('denies custom checks without prompting in an untrusted workspace', async () => {
+    Object.defineProperty(workspace, 'isTrusted', { configurable: true, value: false });
+    const { context } = makeContext();
+
+    const allowed = await makeCustomCheckPermissionHandler(context)(params);
+
+    expect(allowed).toBe(false);
+    expect(window.showWarningMessage).not.toHaveBeenCalled();
+  });
+
+  it('allows custom checks once after explicit consent', async () => {
+    vi.mocked(window.showWarningMessage).mockResolvedValue('Run once' as any);
+    const { context } = makeContext();
+    const handler = makeCustomCheckPermissionHandler(context);
+
+    expect(await handler(params)).toBe(true);
+    expect(await handler(params)).toBe(true);
+    expect(window.showWarningMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps custom checks disabled when consent is declined', async () => {
+    vi.mocked(window.showWarningMessage).mockResolvedValue('Keep disabled' as any);
+    const { context } = makeContext();
+    const handler = makeCustomCheckPermissionHandler(context);
+
+    expect(await handler(params)).toBe(false);
+    expect(await handler(params)).toBe(false);
+    expect(window.showWarningMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists workspace consent', async () => {
+    vi.mocked(window.showWarningMessage).mockResolvedValue(
+      'Always allow for this workspace' as any,
+    );
+    const { context, update } = makeContext();
+
+    expect(await makeCustomCheckPermissionHandler(context)(params)).toBe(true);
+    vi.mocked(window.showWarningMessage).mockClear();
+    expect(await makeCustomCheckPermissionHandler(context)(params)).toBe(true);
+
+    expect(update).toHaveBeenCalledWith(
+      'themeCheck.trustedCustomChecks',
+      expect.arrayContaining([expect.any(String)]),
+    );
+    expect(window.showWarningMessage).not.toHaveBeenCalled();
+  });
+
+  it('prompts again when the requested custom checks change', async () => {
+    vi.mocked(window.showWarningMessage).mockResolvedValue('Run once' as any);
+    const { context } = makeContext();
+    const handler = makeCustomCheckPermissionHandler(context);
+
+    await handler(params);
+    await handler({
+      ...params,
+      candidates: [
+        ...params.candidates,
+        { source: 'require', path: '/themes/example/checks/new.js' },
+      ],
+    });
+
+    expect(window.showWarningMessage).toHaveBeenCalledTimes(2);
+  });
+});
+
+function makeContext() {
+  let state: string[] = [];
+  const update = vi.fn(async (_key: string, value: string[]) => {
+    state = value;
+  });
+  const context = {
+    workspaceState: {
+      get: vi.fn((_key: string, defaultValue: string[]) => state ?? defaultValue),
+      update,
+    },
+  } as any;
+  return { context, update };
+}

--- a/packages/vscode-extension/src/node/customCheckConsent.ts
+++ b/packages/vscode-extension/src/node/customCheckConsent.ts
@@ -1,0 +1,100 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { CustomCheckPermissionRequest } from '@shopify/theme-language-server-common';
+import { ExtensionContext, window, workspace } from 'vscode';
+
+const RUN_ONCE = 'Run once';
+const ALWAYS_ALLOW = 'Always allow for this workspace';
+const KEEP_DISABLED = 'Keep disabled';
+const TRUSTED_CUSTOM_CHECKS_KEY = 'themeCheck.trustedCustomChecks';
+
+export function makeCustomCheckPermissionHandler(context: ExtensionContext) {
+  const sessionDecisions = new Map<string, boolean>();
+  const pendingDecisions = new Map<string, Promise<boolean>>();
+
+  return async function requestCustomCheckPermission(
+    params: CustomCheckPermissionRequest.Params,
+  ): Promise<boolean> {
+    if (!workspace.isTrusted) {
+      return false;
+    }
+
+    const fingerprint = fingerprintRequest(params);
+    const trusted = context.workspaceState.get<string[]>(TRUSTED_CUSTOM_CHECKS_KEY, []);
+    if (trusted.includes(fingerprint)) {
+      return true;
+    }
+
+    const sessionDecision = sessionDecisions.get(fingerprint);
+    if (sessionDecision !== undefined) {
+      return sessionDecision;
+    }
+
+    const pendingDecision = pendingDecisions.get(fingerprint);
+    if (pendingDecision) {
+      return pendingDecision;
+    }
+
+    const decision = promptForPermission(context, params, fingerprint).finally(() => {
+      pendingDecisions.delete(fingerprint);
+    });
+    pendingDecisions.set(fingerprint, decision);
+    const allowed = await decision;
+    sessionDecisions.set(fingerprint, allowed);
+    return allowed;
+  };
+}
+
+async function promptForPermission(
+  context: ExtensionContext,
+  params: CustomCheckPermissionRequest.Params,
+  fingerprint: string,
+): Promise<boolean> {
+  const choice = await window.showWarningMessage(
+    'This theme wants to run custom Theme Check code.',
+    {
+      modal: true,
+      detail: permissionDetail(params),
+    },
+    RUN_ONCE,
+    ALWAYS_ALLOW,
+    KEEP_DISABLED,
+  );
+
+  if (choice === ALWAYS_ALLOW) {
+    const trusted = context.workspaceState.get<string[]>(TRUSTED_CUSTOM_CHECKS_KEY, []);
+    await context.workspaceState.update(
+      TRUSTED_CUSTOM_CHECKS_KEY,
+      Array.from(new Set([...trusted, fingerprint])),
+    );
+    return true;
+  }
+
+  return choice === RUN_ONCE;
+}
+
+function permissionDetail(params: CustomCheckPermissionRequest.Params): string {
+  const candidates = params.candidates.map((candidate) => {
+    const relativePath = path.relative(params.root, candidate.path);
+    const displayPath = relativePath.startsWith('..')
+      ? candidate.path
+      : `.${path.sep}${relativePath}`;
+    return `• ${displayPath}`;
+  });
+
+  return [
+    'Custom checks execute JavaScript with your user permissions:',
+    '',
+    ...candidates,
+    '',
+    'Only allow this if you trust the theme and these checks.',
+  ].join('\n');
+}
+
+function fingerprintRequest(params: CustomCheckPermissionRequest.Params): string {
+  const candidates = params.candidates
+    .map(({ source, path }) => `${source}:${path}`)
+    .sort()
+    .join('\n');
+  return createHash('sha256').update(`${params.root}\n${candidates}`).digest('hex');
+}

--- a/packages/vscode-extension/src/node/extension.ts
+++ b/packages/vscode-extension/src/node/extension.ts
@@ -17,6 +17,8 @@ import {
   watchReferencesTreeViewConfig,
 } from '../common/ReferencesProvider';
 import { makeDeadCode, openLocation } from '../common/commands';
+import { CustomCheckPermissionRequest } from '@shopify/theme-language-server-common';
+import { makeCustomCheckPermissionHandler } from './customCheckConsent';
 
 const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
@@ -88,6 +90,8 @@ async function startServer(context: ExtensionContext) {
   client.onRequest('fs/stat', async (uriString: string): Promise<FileStat> => {
     return workspace.fs.stat(Uri.parse(uriString));
   });
+
+  client.onRequest(CustomCheckPermissionRequest.type, makeCustomCheckPermissionHandler(context));
 
   client.start();
 }

--- a/packages/vscode-extension/src/node/server.ts
+++ b/packages/vscode-extension/src/node/server.ts
@@ -1,5 +1,6 @@
 import type { AbstractFileSystem } from '@shopify/theme-check-common';
 import { getConnection, NodeFileSystem, startServer } from '@shopify/theme-language-server-node';
+import { CustomCheckPermissionRequest } from '@shopify/theme-language-server-common';
 import { VsCodeFileSystem } from '../common/VsCodeFileSystem';
 
 const connection = getConnection();
@@ -9,7 +10,16 @@ const fileSystems: Record<string, AbstractFileSystem> = {
   file: NodeFileSystem,
 };
 
-startServer(connection, new VsCodeFileSystem(connection, fileSystems));
+startServer(connection, new VsCodeFileSystem(connection, fileSystems), {
+  authorizeCustomChecks: async ({ root, candidates }) => {
+    try {
+      return await connection.sendRequest(CustomCheckPermissionRequest.type, { root, candidates });
+    } catch {
+      // The VS Code client should fail closed if it cannot make a trust decision.
+      return false;
+    }
+  },
+});
 
 process.on('uncaughtException', (e) => {
   console.error(e);


### PR DESCRIPTION
## What this changes

Custom Theme Checks remain supported, but the Shopify Liquid VS Code extension now asks for explicit consent before loading JavaScript selected by a theme configuration.

- discover explicit, inherited, and automatically discovered custom checks before calling `require()`
- ask through the language client with **Run once**, **Always allow for this workspace**, and **Keep disabled** choices
- deny without prompting when VS Code marks the workspace untrusted
- persist “always allow” decisions in VS Code workspace state, outside the theme
- fingerprint the theme root and full candidate set so adding or changing a requested path prompts again
- continue running built-in checks when custom checks are denied
- preserve existing behavior for CLI and other language-server clients

## Scope

This PR intentionally covers the VS Code path only. CLI policy and consent for other LSP clients can be considered separately. The browser extension cannot load Node custom checks and is unchanged.

## Validation

- `pnpm build:ts`
- `pnpm exec vitest --run packages/theme-check-node/src packages/theme-language-server-node/src packages/vscode-extension/src/node` (91 tests)
- affected package type checks
- VS Code webpack development bundle
- ESLint on the changed VS Code client files

The repository-wide VS Code lint command still reports existing errors in browser globals and the existing `debugger` statement in `src/node/server.ts`; this change introduces no new lint errors.