### PR TITLE
docs(theme-check): link 13 remaining checks to their shopify.dev references

### DIFF
--- a/.changeset/theme-check-docs-urls.md
+++ b/.changeset/theme-check-docs-urls.md
@@ -1,0 +1,9 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Add missing `docs.url` links so editors surface a "learn more" link on these diagnostics:
+`LiquidComplexity`, `LiquidNestingDepth`, `LiquidSyntaxError`, `ExcessiveSettingsCount`,
+`BlockArgumentSettingCollision`, `UnknownBlockSetting`, `MaxFileSize` (Liquid and JSON variants),
+`SchemaSectionOrBlockOnly`, `SchemaOncePerFile`, `JavascriptTagInWrongFile`, `JavascriptOncePerFile`,
+`StylesheetTagInWrongFile`, and `StylesheetOncePerFile`.

--- a/packages/theme-check-common/src/checks/block-argument-setting-collision/index.ts
+++ b/packages/theme-check-common/src/checks/block-argument-setting-collision/index.ts
@@ -11,6 +11,7 @@ export const BlockArgumentSettingCollision: LiquidCheckDefinition = {
       description:
         "Reports a plain block tag argument whose name matches a setting id in the target block's schema. The author likely intended block.settings.<name>. May overlap with UnrecognizedBlockArguments, which reports the same argument as undeclared.",
       recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/block-argument-setting-collision',
     },
     type: SourceCodeType.LiquidHtml,
     severity: Severity.WARNING,

--- a/packages/theme-check-common/src/checks/excessive-settings-count/index.ts
+++ b/packages/theme-check-common/src/checks/excessive-settings-count/index.ts
@@ -42,6 +42,7 @@ export const ExcessiveSettingsCount: LiquidCheckDefinition<typeof schema> = {
       description:
         'Reports section or block schemas that declare more top-level settings than the configured maximum.',
       recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/excessive-settings-count',
     },
     type: SourceCodeType.LiquidHtml,
     severity: Severity.WARNING,

--- a/packages/theme-check-common/src/checks/liquid-complexity/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-complexity/index.ts
@@ -58,6 +58,7 @@ export const LiquidComplexity: LiquidCheckDefinition<typeof schema> = {
     docs: {
       description: 'Reports Liquid files with high cyclomatic complexity.',
       recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/liquid-complexity',
     },
     type: SourceCodeType.LiquidHtml,
     severity: Severity.WARNING,

--- a/packages/theme-check-common/src/checks/liquid-nesting-depth/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-nesting-depth/index.ts
@@ -33,6 +33,7 @@ export const LiquidNestingDepth: LiquidCheckDefinition<typeof schema> = {
     docs: {
       description: 'Reports Liquid files with deeply nested control-flow structures.',
       recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/liquid-nesting-depth',
     },
     type: SourceCodeType.LiquidHtml,
     severity: Severity.WARNING,

--- a/packages/theme-check-common/src/checks/liquid-syntax-error/index.ts
+++ b/packages/theme-check-common/src/checks/liquid-syntax-error/index.ts
@@ -92,6 +92,7 @@ export const LiquidSyntaxError: LiquidCheckDefinition = {
     docs: {
       description: 'Reports Liquid syntax errors.',
       recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/liquid-syntax-error',
     },
     type: SourceCodeType.LiquidHtml,
     severity: Severity.ERROR,

--- a/packages/theme-check-common/src/checks/max-file-size/index.ts
+++ b/packages/theme-check-common/src/checks/max-file-size/index.ts
@@ -50,6 +50,7 @@ export const MaxFileSize: LiquidCheckDefinition = {
     docs: {
       description: "Reports theme files that exceed Shopify's maximum file size.",
       recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/max-file-size',
     },
     type: SourceCodeType.LiquidHtml,
     severity: Severity.ERROR,

--- a/packages/theme-check-common/src/checks/raw-tags/index.ts
+++ b/packages/theme-check-common/src/checks/raw-tags/index.ts
@@ -8,13 +8,14 @@ interface RawTagCheckOptions {
   tagName: RawTagName;
   code: string;
   message: string;
+  url: string;
 }
 
 function capitalize(tagName: RawTagName): string {
   return tagName[0].toUpperCase() + tagName.slice(1);
 }
 
-function rawTagCheck({ tagName, code, message }: RawTagCheckOptions): LiquidCheckDefinition {
+function rawTagCheck({ tagName, code, message, url }: RawTagCheckOptions): LiquidCheckDefinition {
   return {
     meta: {
       code,
@@ -22,6 +23,7 @@ function rawTagCheck({ tagName, code, message }: RawTagCheckOptions): LiquidChec
       docs: {
         description: message,
         recommended: true,
+        url,
       },
       type: SourceCodeType.LiquidHtml,
       severity: Severity.ERROR,
@@ -46,7 +48,7 @@ function rawTagCheck({ tagName, code, message }: RawTagCheckOptions): LiquidChec
 
 function sectionOrBlockOnlyCheck(
   tagName: RawTagName,
-  { allowSnippets }: { allowSnippets: boolean },
+  { allowSnippets, url }: { allowSnippets: boolean; url: string },
 ): LiquidCheckDefinition {
   const locations = allowSnippets ? 'section, block, or snippet' : 'section or block';
 
@@ -60,10 +62,11 @@ function sectionOrBlockOnlyCheck(
     tagName,
     code,
     message: `{% ${tagName} %} is only valid in ${locations} files.`,
+    url,
   });
 }
 
-function oncePerFileCheck(tagName: RawTagName): LiquidCheckDefinition {
+function oncePerFileCheck(tagName: RawTagName, { url }: { url: string }): LiquidCheckDefinition {
   const code = `${capitalize(tagName)}OncePerFile`;
   const message = `{% ${tagName} %} can only appear once per file.`;
 
@@ -74,6 +77,7 @@ function oncePerFileCheck(tagName: RawTagName): LiquidCheckDefinition {
       docs: {
         description: message,
         recommended: true,
+        url,
       },
       type: SourceCodeType.LiquidHtml,
       severity: Severity.ERROR,
@@ -103,9 +107,9 @@ function oncePerFileCheck(tagName: RawTagName): LiquidCheckDefinition {
 
 function sectionOrBlockOnlyUnlessAllowed(
   tagName: RawTagName,
-  { allowSnippets }: { allowSnippets: boolean },
+  { allowSnippets, url }: { allowSnippets: boolean; url: string },
 ): LiquidCheckDefinition {
-  const check = sectionOrBlockOnlyCheck(tagName, { allowSnippets });
+  const check = sectionOrBlockOnlyCheck(tagName, { allowSnippets, url });
 
   return {
     ...check,
@@ -121,13 +125,22 @@ function sectionOrBlockOnlyUnlessAllowed(
 
 export const SchemaSectionOrBlockOnly = sectionOrBlockOnlyUnlessAllowed('schema', {
   allowSnippets: false,
+  url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/schema-section-or-block-only',
 });
-export const SchemaOncePerFile = oncePerFileCheck('schema');
+export const SchemaOncePerFile = oncePerFileCheck('schema', {
+  url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/schema-once-per-file',
+});
 export const JavascriptTagInWrongFile = sectionOrBlockOnlyUnlessAllowed('javascript', {
   allowSnippets: true,
+  url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/javascript-tag-in-wrong-file',
 });
-export const JavascriptOncePerFile = oncePerFileCheck('javascript');
+export const JavascriptOncePerFile = oncePerFileCheck('javascript', {
+  url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/javascript-once-per-file',
+});
 export const StylesheetTagInWrongFile = sectionOrBlockOnlyUnlessAllowed('stylesheet', {
   allowSnippets: true,
+  url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/stylesheet-tag-in-wrong-file',
 });
-export const StylesheetOncePerFile = oncePerFileCheck('stylesheet');
+export const StylesheetOncePerFile = oncePerFileCheck('stylesheet', {
+  url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/stylesheet-once-per-file',
+});

--- a/packages/theme-check-common/src/checks/unknown-block-setting/index.ts
+++ b/packages/theme-check-common/src/checks/unknown-block-setting/index.ts
@@ -12,6 +12,7 @@ export const UnknownBlockSetting: LiquidCheckDefinition = {
       description:
         "Reports a block.settings.<name> argument in a block tag where <name> is not a setting id in the target block's schema.",
       recommended: true,
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/unknown-block-setting',
     },
     type: SourceCodeType.LiquidHtml,
     severity: Severity.WARNING,


### PR DESCRIPTION
## What

Adds `docs.url` to the 13 remaining theme-check checks that lack one, so editors surface a "learn more" link on the diagnostic.

Follow-up to #1270

| Check | Slug |
|---|---|
| `LiquidComplexity` | `liquid-complexity` |
| `LiquidNestingDepth` | `liquid-nesting-depth` |
| `LiquidSyntaxError` | `liquid-syntax-error` |
| `ExcessiveSettingsCount` | `excessive-settings-count` |
| `BlockArgumentSettingCollision` | `block-argument-setting-collision` |
| `UnknownBlockSetting` | `unknown-block-setting` |
| `MaxFileSize` (+ `MaxFileSizeJSON`) | `max-file-size` |
| `SchemaSectionOrBlockOnly` | `schema-section-or-block-only` |
| `SchemaOncePerFile` | `schema-once-per-file` |
| `JavascriptTagInWrongFile` | `javascript-tag-in-wrong-file` |
| `JavascriptOncePerFile` | `javascript-once-per-file` |
| `StylesheetTagInWrongFile` | `stylesheet-tag-in-wrong-file` |
| `StylesheetOncePerFile` | `stylesheet-once-per-file` |

`MaxFileSizeJSON` needs no edit — it inherits the url through the existing `...MaxFileSize.meta` spread. The verification below proves that rather than assuming it.
