### PR TITLE
chore(vscode-extension): add webpack size budget to catch bundle regressions

### DIFF
--- a/packages/vscode-extension/webpack.config.js
+++ b/packages/vscode-extension/webpack.config.js
@@ -52,6 +52,26 @@ const baseConfig = {
   },
 }
 
+/**
+ * @param {WebpackConfig | (() => Promise<WebpackConfig>)} config
+ * @param {number} maxBytes
+ * @returns {(env: any, argv: any) => Promise<WebpackConfig>}
+ */
+function withBudget(config, maxBytes) {
+  return async (_env, argv) => {
+    const resolved = typeof config === 'function' ? await config() : config;
+    if (argv?.mode !== 'production') return resolved;
+    return {
+      ...resolved,
+      performance: {
+        hints: 'error',
+        maxAssetSize: maxBytes,
+        maxEntrypointSize: maxBytes,
+      },
+    };
+  };
+}
+
 /** @type WebpackConfig */
 const desktopConfig = {
   ...baseConfig,
@@ -175,4 +195,8 @@ const browserServerConfig = async () => {
   };
 };
 
-module.exports = [desktopConfig, browserClientConfig, browserServerConfig];
+module.exports = [
+  withBudget(desktopConfig, 8_000_000),
+  withBudget(browserClientConfig, 2_600_000),
+  withBudget(browserServerConfig, 8_000_000),
+];


### PR DESCRIPTION
> Stacked on #1275, which cut the client bundles by removing the language server. The budgets below are derived from those post-fix sizes — against the current unfixed 6.4 MB client, a 2.6 MB budget would fail on contact.

## What are you adding in this PR?

`webpack.config.js` gains a `withBudget()` wrapper applied at the export site. One file, no changes to any of the three config bodies. The wrapper handles `browserServerConfig` already being async.

| config | budget |
|---|---:|
| browser client | 2,600,000 |
| browser server | 8,000,000 |
| desktop | 8,000,000 |

Each is roughly 25% over the measured post-fix size (2,103,405 / 6,346,716 / 6,213,426). The desktop config emits both node assets, so its number is governed by `server.js`, not the much smaller `extension.js`.

**Why `hints: 'error'` and not `'warning'`.** CI prints six size warnings today and exits 0. A warning in this repo is invisible — that is exactly how 4.6 MB of language server rode into a client bundle unnoticed. An error turns an invisible regression into a reviewed decision. If a future feature legitimately needs the room, someone raises the number on purpose and says why.

**Why production-only.** `dev:build`, `dev:watch`, and `pretest` run the same configs in development mode, where bundles are larger by design. An unconditional budget would break `pnpm dev`.

Two things worth knowing. Setting an explicit `performance` object re-arms the check on the `target: 'node'` config, which webpack otherwise exempts automatically. And it replaces webpack's default 244 KiB limit — which is what finally silences the six size warnings that #1275 leaves in place.

## Tophatting

- `pnpm build:ci` — exit 0
- Budget proven to fail, not just to pass: client tightened to 1,000,000 → exit 1, `webpack 5.94.0 compiled with 3 errors`. A genuine compile-then-fail, not a config parse error. Restored.
- CI — 7/7 green

The chain that makes it bite: `.github/workflows/ci.yml:39` → root `pnpm -r build:ci` → package `build:extension` → `webpack --mode production`. `pnpm -r` propagates the failure via `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`.

Two jobs enforce it — code-quality and e2e. The test matrix does not: it runs `build:ts`, which is defined as the literal string `"true"` and never invokes webpack.

## Before you deploy

No changeset. Every build-config-only commit in this repo's history ships without one, including the four prior commits to this exact file (#1112, #1208, #142, and `30f5004`), and nothing in CI enforces it. Nothing published changes here.
