### PR TITLE
feat(language-server): link {% block %} names to blocks/<name>.liquid

### DIFF
--- a/.changeset/document-link-block-tag.md
+++ b/.changeset/document-link-block-tag.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-language-server-common': patch
+---
+
+Add a document link for the `{% block 'name' %}` tag so cmd+click on the block
+name navigates to `blocks/<name>.liquid`.

--- a/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.spec.ts
+++ b/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.spec.ts
@@ -43,6 +43,9 @@ describe('DocumentLinksProvider', () => {
       {% assign x = 'assign.css' | asset_url %}
       {{ 'asset.js' | asset_url }}
       {% content_for 'block', type: 'block_name' %}
+      {% block 'container' %}{% endblock %}
+      {% block '_private' %}{% endblock %}
+      {% block 'with_args', block.settings.alignment: 'center' %}{% endblock %}
     `;
 
     documentManager.open(uriString, liquidHtmlContent, 1);
@@ -56,11 +59,24 @@ describe('DocumentLinksProvider', () => {
       'file:///path/to/project/assets/assign.css',
       'file:///path/to/project/assets/asset.js',
       'file:///path/to/project/blocks/block_name.liquid',
+      'file:///path/to/project/blocks/container.liquid',
+      'file:///path/to/project/blocks/_private.liquid',
+      'file:///path/to/project/blocks/with_args.liquid',
     ];
 
     expect(result.length).toBe(expectedUrls.length);
     for (let i = 0; i < expectedUrls.length; i++) {
       expect(result[i].target).toBe(expectedUrls[i]);
     }
+  });
+
+  it('should not create a link for the {% partial %} tag', async () => {
+    uriString = 'file:///path/to/liquid-html-document.liquid';
+    rootUri = 'file:///path/to/project';
+
+    documentManager.open(uriString, `{% partial 'x' %}{% endpartial %}`, 1);
+
+    const result = await documentLinksProvider.documentLinks(uriString);
+    expect(result).toEqual([]);
   });
 });

--- a/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.ts
+++ b/packages/theme-language-server-common/src/documentLinks/DocumentLinksProvider.ts
@@ -63,6 +63,15 @@ function documentLinksVisitor(
         );
       }
 
+      // {% block 'name' %}
+      if (node.name === NamedTags.block && typeof node.markup !== 'string') {
+        const blockName = node.markup.name;
+        return DocumentLink.create(
+          range(textDocument, blockName),
+          Utils.resolvePath(root, 'blocks', blockName.value + '.liquid').toString(),
+        );
+      }
+
       // {% content_for 'block', type: 'block_name' %}
       if (node.name === NamedTags.content_for && typeof node.markup !== 'string') {
         const typeArg = node.markup.args.find((arg) => arg.name === 'type');


### PR DESCRIPTION
## What are you adding in this PR?

You can click into a render tag today and navigate to the render such as `{% render 'css-variables' %}` taking you to the `css-variables` file. This doesn't work for blocks.

I'm adding the same logic to block tags so you can navigate to the file such as `{% block 'container'.. %}`

**Before**:
<img width="857" height="459" alt="Screenshot 2026-09-02 at 2 47 55 PM" src="https://github.com/user-attachments/assets/ac7a6e2c-db8e-4314-af26-0c85f689edad" />

**After**:
<img width="873" height="480" alt="Screenshot 2026-09-02 at 2 50 23 PM" src="https://github.com/user-attachments/assets/0c026f45-2fca-41ce-9877-86a83305cd91" />


## Tophatting

- Pull down the branch
- Run the dev server (`F5`)
- Create a block tag and make sure you can navigate to the actual block file.

- [X] I added screenshots of the changes (before and after the changes if applicable)

## Before you deploy

<!-- Public API changes, new features -->
- [x] My feature is backward compatible <!-- purely additive: one new branch, no existing branch modified -->

<!-- Bug fixes -->
- [x] I included a patch bump `changeset` <!-- .changeset/document-link-block-tag.md — patch, @shopify/theme-language-server-common -->
