### PR TITLE
Honor the `white-space: pre` comment hint for plain text nodes

### DIFF
--- a/.changeset/text-node-white-space-pre-comment.md
+++ b/.changeset/text-node-white-space-pre-comment.md
@@ -1,0 +1,5 @@
+---
+'@shopify/prettier-plugin-liquid': patch
+---
+
+Fix `{% # white-space: pre %}` comment hint being ignored for plain text nodes, which caused files with meaningful line breaks but no HTML tags (e.g. a `robots.txt.liquid` template) to have their lines incorrectly joined together

--- a/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
+++ b/packages/prettier-plugin-liquid/src/printer/printer-liquid-html.ts
@@ -55,10 +55,23 @@ import {
   printLiquidDocPrompt,
 } from './print/liquid';
 import { printClosingTagSuffix, printOpeningTagPrefix } from './print/tag';
-import { bodyLines, hasLineBreakInRange, isEmpty, isTextLikeNode, reindent } from './utils';
+import {
+  bodyLines,
+  hasLineBreakInRange,
+  isEmpty,
+  isPreLikeNode,
+  isTextLikeNode,
+  reindent,
+} from './utils';
 
 const { builders, utils } = doc;
 const { fill, group, hardline, dedentToRoot, indent, join, line, softline } = builders;
+
+// `replaceEndOfLine` exists at runtime on both prettier 2 and prettier 3's
+// `doc.utils`, but is missing from prettier 2's type definitions.
+const { replaceEndOfLine } = utils as typeof utils & {
+  replaceEndOfLine: (doc: Doc, replacement?: Doc) => Doc;
+};
 
 const oppositeQuotes = {
   '"': "'",
@@ -160,6 +173,14 @@ function printTextNode(
 
   if (node.value.match(/^\s*$/)) return '';
   const text = node.value;
+
+  if (isPreLikeNode(node)) {
+    return [
+      printOpeningTagPrefix(node, options),
+      replaceEndOfLine(text),
+      printClosingTagSuffix(node, options),
+    ];
+  }
 
   const paragraphs = text
     .split(/(\r?\n){2,}/)

--- a/packages/prettier-plugin-liquid/src/test/text-node-whitespace-pre-comment/fixed.liquid
+++ b/packages/prettier-plugin-liquid/src/test/text-node-whitespace-pre-comment/fixed.liquid
@@ -1,0 +1,5 @@
+It should not reflow plain text preceded by a `{% # white-space: pre %}` comment
+{% # white-space: pre %}
+User-agent: GPTBot
+User-agent: ClaudeBot
+Allow: /

--- a/packages/prettier-plugin-liquid/src/test/text-node-whitespace-pre-comment/index.liquid
+++ b/packages/prettier-plugin-liquid/src/test/text-node-whitespace-pre-comment/index.liquid
@@ -1,0 +1,5 @@
+It should not reflow plain text preceded by a `{% # white-space: pre %}` comment
+{% # white-space: pre %}
+User-agent: GPTBot
+User-agent: ClaudeBot
+Allow: /

--- a/packages/prettier-plugin-liquid/src/test/text-node-whitespace-pre-comment/index.spec.ts
+++ b/packages/prettier-plugin-liquid/src/test/text-node-whitespace-pre-comment/index.spec.ts
@@ -1,0 +1,6 @@
+import { test } from 'vitest';
+import { assertFormattedEqualsFixed } from '../test-helpers';
+
+test('Unit: text-node-whitespace-pre-comment', async () => {
+  await assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
## Summary
- `printTextNode` in `prettier-plugin-liquid` always reflowed text nodes like an HTML paragraph (splitting on blank lines, collapsing single newlines into spaces via `fill`). That's correct for real HTML text, but it never checked the documented `{% # white-space: pre %}` comment hint, so there was no way to opt a bare text node out of it.
- This broke files that have meaningful line breaks but no HTML tags — e.g. a `templates/robots.txt.liquid` override with one `User-agent:`/`Allow:`/`Content-Signal:` directive per line — since every line got joined onto one.
- Fix: `printTextNode` now checks `isPreLikeNode(node)` (already correctly computed, respecting the comment hint) and, when true, prints the raw text preserving line breaks instead of reflowing it via `fill`. Default reflow behavior for ordinary HTML text is unchanged.

With the fix, adding the hint above the content prevents the mangling:
```liquid
{% # white-space: pre %}
User-agent: GPTBot
User-agent: ClaudeBot
Allow: /
```

## Test plan
- [x] Added `src/test/text-node-whitespace-pre-comment` fixture confirming the hint is honored (verified it fails without the fix, passes with it)
- [x] Full `prettier-plugin-liquid` test suite passes (143 tests)
- [x] Added a changeset

https://claude.ai/code/session_01F9pHQHyQvE1bP26XUkfmSj