### PR TITLE
Add check for standard_event_data

### DIFF
--- a/.changeset/valid-standard-event-data.md
+++ b/.changeset/valid-standard-event-data.md
@@ -1,0 +1,9 @@
+---
+'@shopify/theme-check-common': minor
+---
+
+Add `ValidStandardEventData` check to error on invalid arguments to the `standard_event_data` filter.
+
+The filter's argument values are currently only validated at render time. This check catches invalid literal values statically: `view` is the only supported event type, and `context:` must be one of `page`, `search`, `collection`, `dialog`, or `recommendation`.
+
+Values that aren't string literals are left alone, since the type of the piped input isn't statically knowable.

--- a/packages/theme-check-common/src/checks/index.ts
+++ b/packages/theme-check-common/src/checks/index.ts
@@ -64,6 +64,7 @@ import { ValidSchema } from './valid-schema';
 import { ValidSchemaName } from './valid-schema-name';
 import { ValidSchemaTranslations } from './valid-schema-translations';
 import { ValidSettingsKey } from './valid-settings-key';
+import { ValidStandardEventData } from './valid-standard-event-data';
 import { ValidStaticBlockType } from './valid-static-block-type';
 import { ValidVisibleIf, ValidVisibleIfSettingsSchema } from './valid-visible-if';
 import { VariableName } from './variable-name';
@@ -154,6 +155,7 @@ export const allChecks: (LiquidCheckDefinition | JSONCheckDefinition)[] = [
   ValidRenderSnippetArgumentTypes,
   ValidSchema,
   ValidSettingsKey,
+  ValidStandardEventData,
   ValidStaticBlockType,
   ValidVisibleIf,
   ValidVisibleIfSettingsSchema,

--- a/packages/theme-check-common/src/checks/valid-standard-event-data/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-standard-event-data/index.spec.ts
@@ -3,38 +3,90 @@ import { highlightedOffenses, runLiquidCheck } from '../../test';
 import { ValidStandardEventData } from './index';
 
 describe('Module: ValidStandardEventData', () => {
-  it('reports an offense when the context is not a supported value', async () => {
+  it('reports an offense when the context is not a supported value for products', async () => {
     const sourceCode = `{{ product | standard_event_data: 'view', context: 'homepage' }}`;
     const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
 
     expect(offenses).toHaveLength(1);
     expect(offenses[0].message).toBe(
-      "Unsupported context 'homepage'. Valid values: page, search, collection, dialog, recommendation. The 'context' argument can also be omitted.",
+      "Unsupported context 'homepage' for product. Valid values: page, search, collection, dialog, recommendation. The 'context' argument can also be omitted.",
     );
 
     const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
     expect(highlights[0]).to.eql("'homepage'");
   });
 
-  it('reports an offense when the context is not a supported value on a cart', async () => {
+  it('reports an offense when the context is not a supported value for carts', async () => {
     const sourceCode = `{{ cart | standard_event_data: 'view', context: 'banner' }}`;
     const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
 
     expect(offenses).toHaveLength(1);
     expect(offenses[0].message).toBe(
-      "Unsupported context 'banner'. Valid values: page, search, collection, dialog, recommendation. The 'context' argument can also be omitted.",
+      "Unsupported context 'banner' for cart. Valid values: page, dialog. The 'context' argument can also be omitted.",
     );
   });
 
-  it('does not report an offense on supported context values', async () => {
+  it('reports an offense when the context is valid for products but the input is a cart', async () => {
+    const sourceCode = `{{ cart | standard_event_data: 'view', context: 'recommendation' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe(
+      "Unsupported context 'recommendation' for cart. Valid values: page, dialog. The 'context' argument can also be omitted.",
+    );
+  });
+
+  it('does not report an offense on supported product context values', async () => {
     const contexts = ['page', 'search', 'collection', 'dialog', 'recommendation'];
 
     for (const context of contexts) {
       const sourceCode = `{{ product | standard_event_data: 'view', context: '${context}' }}`;
       const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
 
-      expect(offenses, `expected '${context}' to be a valid context`).toHaveLength(0);
+      expect(offenses, `expected '${context}' to be a valid product context`).toHaveLength(0);
     }
+  });
+
+  it('does not report an offense on supported cart context values', async () => {
+    const contexts = ['page', 'dialog'];
+
+    for (const context of contexts) {
+      const sourceCode = `{{ cart | standard_event_data: 'view', context: '${context}' }}`;
+      const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+      expect(offenses, `expected '${context}' to be a valid cart context`).toHaveLength(0);
+    }
+  });
+
+  it('does not report an offense on collections, whose context is ignored', async () => {
+    const sourceCode = `{{ collection | standard_event_data: 'view', context: 'homepage' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('falls back to the union of contexts when the input is not a known global', async () => {
+    const sourceCode = `{{ line_item.product | standard_event_data: 'view', context: 'recommendation' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('falls back to the union of contexts when the filter input is chained', async () => {
+    const sourceCode = `{{ cart | default: other_cart | standard_event_data: 'view', context: 'recommendation' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports an offense when the context is outside the union for an unknown input', async () => {
+    const sourceCode = `{{ line_item.product | standard_event_data: 'view', context: 'homepage' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe(
+      "Unsupported context 'homepage'. Valid values: page, search, collection, dialog, recommendation. The 'context' argument can also be omitted.",
+    );
   });
 
   it('does not report an offense when the context is a variable', async () => {
@@ -50,7 +102,7 @@ describe('Module: ValidStandardEventData', () => {
 
     expect(offenses).toHaveLength(1);
     expect(offenses[0].message).toBe(
-      "Unsupported context. Valid values: page, search, collection, dialog, recommendation. The 'context' argument can also be omitted.",
+      "Unsupported context for product. Valid values: page, search, collection, dialog, recommendation. The 'context' argument can also be omitted.",
     );
 
     const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
@@ -75,6 +127,16 @@ describe('Module: ValidStandardEventData', () => {
 
     const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
     expect(highlights[0]).to.eql("'click'");
+  });
+
+  it('reports an offense when the event type is not supported on a collection', async () => {
+    const sourceCode = `{{ collection | standard_event_data: 'click' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe(
+      "Unsupported event type 'click'. The only supported event type is 'view'.",
+    );
   });
 
   it('does not report an offense when the event type is a variable', async () => {

--- a/packages/theme-check-common/src/checks/valid-standard-event-data/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-standard-event-data/index.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { highlightedOffenses, runLiquidCheck } from '../../test';
+import { ValidStandardEventData } from './index';
+
+describe('Module: ValidStandardEventData', () => {
+  it('reports an offense when the context is not a supported value', async () => {
+    const sourceCode = `{{ product | standard_event_data: 'view', context: 'homepage' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe(
+      "Unsupported context 'homepage'. Valid values: page, search, collection, dialog, recommendation",
+    );
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights[0]).to.eql("'homepage'");
+  });
+
+  it('reports an offense when the context is not a supported value on a cart', async () => {
+    const sourceCode = `{{ cart | standard_event_data: 'view', context: 'banner' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe(
+      "Unsupported context 'banner'. Valid values: page, search, collection, dialog, recommendation",
+    );
+  });
+
+  it('does not report an offense on supported context values', async () => {
+    const contexts = ['page', 'search', 'collection', 'dialog', 'recommendation'];
+
+    for (const context of contexts) {
+      const sourceCode = `{{ product | standard_event_data: 'view', context: '${context}' }}`;
+      const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+      expect(offenses, `expected '${context}' to be a valid context`).toHaveLength(0);
+    }
+  });
+
+  it('does not report an offense when the context is not a string literal', async () => {
+    const sourceCode = `{{ product | standard_event_data: 'view', context: section.settings.context }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('does not report an offense when the context argument is omitted', async () => {
+    const sourceCode = `{{ collection | standard_event_data: 'view' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports an offense when the event type is not supported', async () => {
+    const sourceCode = `{{ product | standard_event_data: 'click', context: 'page' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe(
+      "Unsupported event type 'click'. The only supported event type is 'view'.",
+    );
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights[0]).to.eql("'click'");
+  });
+
+  it('does not report an offense when the event type is not a string literal', async () => {
+    const sourceCode = `{{ product | standard_event_data: event_type }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+
+  it('reports both offenses when the event type and the context are invalid', async () => {
+    const sourceCode = `{{ product | standard_event_data: 'click', context: 'homepage' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(2);
+  });
+
+  it('does not report an offense on other filters', async () => {
+    const sourceCode = `{{ product | json }}{{ 'homepage' | append: 'view' }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(0);
+  });
+});

--- a/packages/theme-check-common/src/checks/valid-standard-event-data/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-standard-event-data/index.spec.ts
@@ -9,7 +9,7 @@ describe('Module: ValidStandardEventData', () => {
 
     expect(offenses).toHaveLength(1);
     expect(offenses[0].message).toBe(
-      "Unsupported context 'homepage'. Valid values: page, search, collection, dialog, recommendation",
+      "Unsupported context 'homepage'. Valid values: page, search, collection, dialog, recommendation. The 'context' argument can also be omitted.",
     );
 
     const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
@@ -22,7 +22,7 @@ describe('Module: ValidStandardEventData', () => {
 
     expect(offenses).toHaveLength(1);
     expect(offenses[0].message).toBe(
-      "Unsupported context 'banner'. Valid values: page, search, collection, dialog, recommendation",
+      "Unsupported context 'banner'. Valid values: page, search, collection, dialog, recommendation. The 'context' argument can also be omitted.",
     );
   });
 
@@ -37,11 +37,24 @@ describe('Module: ValidStandardEventData', () => {
     }
   });
 
-  it('does not report an offense when the context is not a string literal', async () => {
+  it('does not report an offense when the context is a variable', async () => {
     const sourceCode = `{{ product | standard_event_data: 'view', context: section.settings.context }}`;
     const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
 
     expect(offenses).toHaveLength(0);
+  });
+
+  it('reports an offense when the context is a non-string literal', async () => {
+    const sourceCode = `{{ product | standard_event_data: 'view', context: 123 }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe(
+      "Unsupported context. Valid values: page, search, collection, dialog, recommendation. The 'context' argument can also be omitted.",
+    );
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights[0]).to.eql('123');
   });
 
   it('does not report an offense when the context argument is omitted', async () => {
@@ -64,11 +77,34 @@ describe('Module: ValidStandardEventData', () => {
     expect(highlights[0]).to.eql("'click'");
   });
 
-  it('does not report an offense when the event type is not a string literal', async () => {
+  it('does not report an offense when the event type is a variable', async () => {
     const sourceCode = `{{ product | standard_event_data: event_type }}`;
     const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
 
     expect(offenses).toHaveLength(0);
+  });
+
+  it('reports an offense when the event type is a non-string literal', async () => {
+    const sourceCode = `{{ product | standard_event_data: 123 }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe(
+      "Unsupported event type. The only supported event type is 'view'.",
+    );
+
+    const highlights = highlightedOffenses({ 'file.liquid': sourceCode }, offenses);
+    expect(highlights[0]).to.eql('123');
+  });
+
+  it('reports an offense when the event type is a boolean literal', async () => {
+    const sourceCode = `{{ product | standard_event_data: true }}`;
+    const offenses = await runLiquidCheck(ValidStandardEventData, sourceCode);
+
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0].message).toBe(
+      "Unsupported event type. The only supported event type is 'view'.",
+    );
   });
 
   it('reports both offenses when the event type and the context are invalid', async () => {

--- a/packages/theme-check-common/src/checks/valid-standard-event-data/index.ts
+++ b/packages/theme-check-common/src/checks/valid-standard-event-data/index.ts
@@ -1,4 +1,4 @@
-import { LiquidNamedArgument, NodeTypes } from '@shopify/liquid-html-parser';
+import { LiquidExpression, LiquidNamedArgument, NodeTypes } from '@shopify/liquid-html-parser';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 
 const FILTER_NAME = 'standard_event_data';
@@ -11,6 +11,15 @@ const CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE = [
   'dialog',
   'recommendation',
 ];
+
+function isInvalidStaticValue(value: LiquidExpression, supportedValues: string[]): boolean {
+  if (value.type === NodeTypes.VariableLookup) return false;
+  return value.type !== NodeTypes.String || !supportedValues.includes(value.value);
+}
+
+function describeValue(value: LiquidExpression): string {
+  return value.type === NodeTypes.String ? ` '${value.value}'` : '';
+}
 
 export const ValidStandardEventData: LiquidCheckDefinition = {
   meta: {
@@ -33,11 +42,15 @@ export const ValidStandardEventData: LiquidCheckDefinition = {
       async LiquidFilter(node) {
         if (node.name !== FILTER_NAME) return;
 
-        const eventType = node.args.find((arg) => arg.type !== NodeTypes.NamedArgument);
+        const eventType = node.args.find(
+          (arg): arg is LiquidExpression => arg.type !== NodeTypes.NamedArgument,
+        );
 
-        if (eventType?.type === NodeTypes.String && eventType.value !== SUPPORTED_EVENT_TYPE) {
+        if (eventType && isInvalidStaticValue(eventType, [SUPPORTED_EVENT_TYPE])) {
           context.report({
-            message: `Unsupported event type '${eventType.value}'. The only supported event type is '${SUPPORTED_EVENT_TYPE}'.`,
+            message: `Unsupported event type${describeValue(
+              eventType,
+            )}. The only supported event type is '${SUPPORTED_EVENT_TYPE}'.`,
             startIndex: eventType.position.start,
             endIndex: eventType.position.end,
           });
@@ -50,13 +63,15 @@ export const ValidStandardEventData: LiquidCheckDefinition = {
         const contextValue = contextArgument?.value;
 
         if (
-          contextValue?.type === NodeTypes.String &&
-          !CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE.includes(contextValue.value)
+          contextValue &&
+          isInvalidStaticValue(contextValue, CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE)
         ) {
           context.report({
-            message: `Unsupported context '${
-              contextValue.value
-            }'. Valid values: ${CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE.join(', ')}`,
+            message: `Unsupported context${describeValue(
+              contextValue,
+            )}. Valid values: ${CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE.join(
+              ', ',
+            )}. The '${CONTEXT_ARGUMENT}' argument can also be omitted.`,
             startIndex: contextValue.position.start,
             endIndex: contextValue.position.end,
           });

--- a/packages/theme-check-common/src/checks/valid-standard-event-data/index.ts
+++ b/packages/theme-check-common/src/checks/valid-standard-event-data/index.ts
@@ -1,0 +1,67 @@
+import { LiquidNamedArgument, NodeTypes } from '@shopify/liquid-html-parser';
+import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
+
+const FILTER_NAME = 'standard_event_data';
+const CONTEXT_ARGUMENT = 'context';
+const SUPPORTED_EVENT_TYPE = 'view';
+const CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE = [
+  'page',
+  'search',
+  'collection',
+  'dialog',
+  'recommendation',
+];
+
+export const ValidStandardEventData: LiquidCheckDefinition = {
+  meta: {
+    code: 'ValidStandardEventData',
+    name: 'Prevent the use of invalid arguments to the standard_event_data filter',
+    docs: {
+      description:
+        'This check is aimed at preventing the use of invalid arguments for the standard_event_data filter.',
+      url: 'https://shopify.dev/docs/storefronts/themes/tools/theme-check/checks/valid-standard-event-data',
+      recommended: true,
+    },
+    type: SourceCodeType.LiquidHtml,
+    severity: Severity.ERROR,
+    schema: {},
+    targets: [],
+  },
+
+  create(context) {
+    return {
+      async LiquidFilter(node) {
+        if (node.name !== FILTER_NAME) return;
+
+        const eventType = node.args.find((arg) => arg.type !== NodeTypes.NamedArgument);
+
+        if (eventType?.type === NodeTypes.String && eventType.value !== SUPPORTED_EVENT_TYPE) {
+          context.report({
+            message: `Unsupported event type '${eventType.value}'. The only supported event type is '${SUPPORTED_EVENT_TYPE}'.`,
+            startIndex: eventType.position.start,
+            endIndex: eventType.position.end,
+          });
+        }
+
+        const contextArgument = node.args.find(
+          (arg): arg is LiquidNamedArgument =>
+            arg.type === NodeTypes.NamedArgument && arg.name === CONTEXT_ARGUMENT,
+        );
+        const contextValue = contextArgument?.value;
+
+        if (
+          contextValue?.type === NodeTypes.String &&
+          !CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE.includes(contextValue.value)
+        ) {
+          context.report({
+            message: `Unsupported context '${
+              contextValue.value
+            }'. Valid values: ${CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE.join(', ')}`,
+            startIndex: contextValue.position.start,
+            endIndex: contextValue.position.end,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/theme-check-common/src/checks/valid-standard-event-data/index.ts
+++ b/packages/theme-check-common/src/checks/valid-standard-event-data/index.ts
@@ -1,15 +1,25 @@
-import { LiquidExpression, LiquidNamedArgument, NodeTypes } from '@shopify/liquid-html-parser';
+import {
+  LiquidExpression,
+  LiquidFilter,
+  LiquidHtmlNode,
+  LiquidNamedArgument,
+  NodeTypes,
+} from '@shopify/liquid-html-parser';
 import { LiquidCheckDefinition, Severity, SourceCodeType } from '../../types';
 
 const FILTER_NAME = 'standard_event_data';
 const CONTEXT_ARGUMENT = 'context';
 const SUPPORTED_EVENT_TYPE = 'view';
+
+const SUPPORTED_CONTEXTS_BY_DROP: { [drop: string]: string[] } = {
+  product: ['page', 'search', 'collection', 'dialog', 'recommendation'],
+  cart: ['page', 'dialog'],
+};
+
+const DROPS_THAT_IGNORE_CONTEXT = ['collection'];
+
 const CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE = [
-  'page',
-  'search',
-  'collection',
-  'dialog',
-  'recommendation',
+  ...new Set(Object.values(SUPPORTED_CONTEXTS_BY_DROP).flat()),
 ];
 
 function isInvalidStaticValue(value: LiquidExpression, supportedValues: string[]): boolean {
@@ -19,6 +29,20 @@ function isInvalidStaticValue(value: LiquidExpression, supportedValues: string[]
 
 function describeValue(value: LiquidExpression): string {
   return value.type === NodeTypes.String ? ` '${value.value}'` : '';
+}
+
+function detectInputDrop(
+  node: LiquidFilter,
+  parent: LiquidHtmlNode | undefined,
+): string | undefined {
+  if (parent?.type !== NodeTypes.LiquidVariable) return undefined;
+  if (parent.filters[0] !== node) return undefined;
+
+  const expression = parent.expression;
+  if (expression.type !== NodeTypes.VariableLookup) return undefined;
+  if (expression.lookups.length > 0) return undefined;
+
+  return expression.name ?? undefined;
 }
 
 export const ValidStandardEventData: LiquidCheckDefinition = {
@@ -39,7 +63,7 @@ export const ValidStandardEventData: LiquidCheckDefinition = {
 
   create(context) {
     return {
-      async LiquidFilter(node) {
+      async LiquidFilter(node, ancestors) {
         if (node.name !== FILTER_NAME) return;
 
         const eventType = node.args.find(
@@ -56,20 +80,27 @@ export const ValidStandardEventData: LiquidCheckDefinition = {
           });
         }
 
+        const drop = detectInputDrop(node, ancestors[ancestors.length - 1]);
+
+        if (drop && DROPS_THAT_IGNORE_CONTEXT.includes(drop)) return;
+
         const contextArgument = node.args.find(
           (arg): arg is LiquidNamedArgument =>
             arg.type === NodeTypes.NamedArgument && arg.name === CONTEXT_ARGUMENT,
         );
         const contextValue = contextArgument?.value;
+        if (!contextValue) return;
 
-        if (
-          contextValue &&
-          isInvalidStaticValue(contextValue, CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE)
-        ) {
+        const supportedContexts =
+          (drop && SUPPORTED_CONTEXTS_BY_DROP[drop]) || CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE;
+
+        if (isInvalidStaticValue(contextValue, supportedContexts)) {
+          const dropDescription = drop && SUPPORTED_CONTEXTS_BY_DROP[drop] ? ` for ${drop}` : '';
+
           context.report({
             message: `Unsupported context${describeValue(
               contextValue,
-            )}. Valid values: ${CONTEXTS_SUPPORTED_BY_ANY_INPUT_TYPE.join(
+            )}${dropDescription}. Valid values: ${supportedContexts.join(
               ', ',
             )}. The '${CONTEXT_ARGUMENT}' argument can also be omitted.`,
             startIndex: contextValue.position.start,

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -262,6 +262,9 @@ ValidScopedCSSClass:
 ValidSettingsKey:
   enabled: true
   severity: 0
+ValidStandardEventData:
+  enabled: true
+  severity: 0
 ValidStaticBlockType:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -240,6 +240,9 @@ ValidScopedCSSClass:
 ValidSettingsKey:
   enabled: true
   severity: 0
+ValidStandardEventData:
+  enabled: true
+  severity: 0
 ValidStaticBlockType:
   enabled: true
   severity: 0


### PR DESCRIPTION
### What are you trying to accomplish?

This new filter has parameter values that are only validated on the server side, and it would be helpful to have a dedicated check for them

### What approach did you use?

As the parameter values don't often change, replicate the list of allowed values in a dedicated check