### PR TITLE
Fix local block validation in presets and defaults

### DIFF
--- a/.changeset/calm-blocks-validate.md
+++ b/.changeset/calm-blocks-validate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme-check-common': patch
+---
+
+Validate local section block references in presets and default configurations.

--- a/packages/theme-check-common/src/checks/valid-block-target/index.spec.ts
+++ b/packages/theme-check-common/src/checks/valid-block-target/index.spec.ts
@@ -258,6 +258,109 @@ describe('Module: ValidBlockTarget', () => {
       const offenses = await check(theme, [ValidBlockTarget]);
       expect(offenses).to.be.empty;
     });
+
+    it('should report an unknown locally scoped block in a preset', async () => {
+      const theme: MockTheme = {
+        'sections/local-blocks.liquid': `
+          {% schema %}
+          {
+            "name": "Section name",
+            "blocks": [
+              {
+                "type": "local_block",
+                "name": "Local block"
+              }
+            ],
+            "presets": [
+              {
+                "name": "Default preset",
+                "blocks": [
+                  {
+                    "type": "missing_block"
+                  }
+                ]
+              }
+            ]
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [ValidBlockTarget]);
+      expect(offenses).to.have.length(1);
+      expect(offenses).to.containOffense(
+        'Section block type "missing_block" must be defined in "blocks" at the root of this schema.',
+      );
+    });
+
+    it('should report an unknown locally scoped block in a default', async () => {
+      const theme: MockTheme = {
+        'sections/local-blocks.liquid': `
+          {% schema %}
+          {
+            "name": "Section name",
+            "blocks": [
+              {
+                "type": "local_block",
+                "name": "Local block"
+              }
+            ],
+            "default": {
+              "blocks": [
+                {
+                  "type": "missing_block"
+                }
+              ]
+            }
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [ValidBlockTarget]);
+      expect(offenses).to.have.length(1);
+      expect(offenses).to.containOffense(
+        'Section block type "missing_block" must be defined in "blocks" at the root of this schema.',
+      );
+    });
+
+    it('should allow locally scoped blocks declared for presets and defaults', async () => {
+      const theme: MockTheme = {
+        'sections/local-blocks.liquid': `
+          {% schema %}
+          {
+            "name": "Section name",
+            "blocks": [
+              {
+                "type": "local_block",
+                "name": "Local block"
+              }
+            ],
+            "presets": [
+              {
+                "name": "Default preset",
+                "blocks": [
+                  {
+                    "type": "local_block"
+                  }
+                ]
+              }
+            ],
+            "default": {
+              "blocks": [
+                {
+                  "type": "local_block"
+                }
+              ]
+            }
+          }
+          {% endschema %}
+        `,
+      };
+
+      const offenses = await check(theme, [ValidBlockTarget]);
+      expect(offenses).to.be.empty;
+    });
   });
 
   describe('Allowed Targeting Tests', () => {

--- a/packages/theme-check-common/src/checks/valid-block-target/index.ts
+++ b/packages/theme-check-common/src/checks/valid-block-target/index.ts
@@ -54,7 +54,23 @@ export const ValidBlockTarget: LiquidCheckDefinition = {
           hasRootBlocksDeclaration,
         } = getBlocks(validSchema);
 
-        if (rootLevelLocalBlocks.length > 0) return;
+        if (rootLevelLocalBlocks.length > 0) {
+          const localBlockTypes = new Set(rootLevelLocalBlocks.map(({ node }) => node.type));
+          const configuredBlocks = [...(presetLevelBlocks[0] ?? []), ...defaultLevelBlocks];
+
+          for (const { node, path } of configuredBlocks) {
+            if (!localBlockTypes.has(node.type)) {
+              const typeNode = nodeAtPath(ast, path)! as LiteralNode;
+              reportWarning(
+                `Section block type "${node.type}" must be defined in "blocks" at the root of this schema.`,
+                offset,
+                typeNode,
+                context,
+              );
+            }
+          }
+          return;
+        }
 
         let errorsInRootLevelBlocks = false;
         await Promise.all(

--- a/packages/theme-check-common/src/utils/block.ts
+++ b/packages/theme-check-common/src/utils/block.ts
@@ -82,14 +82,10 @@ export function getBlocks(validSchema: ThemeBlock.Schema | Section.Schema) {
   }
 
   function categorizeDefaultLevelBlocks(block: Preset.Block, index: number) {
-    const hasName = 'name' in block;
-
-    if (hasName) {
-      defaultLevelBlocks.push({
-        node: block,
-        path: ['default', 'blocks', String(index), 'type'],
-      });
-    }
+    defaultLevelBlocks.push({
+      node: block,
+      path: ['default', 'blocks', String(index), 'type'],
+    });
   }
 
   if (Array.isArray(rootLevelBlocks)) {


### PR DESCRIPTION
Fixes #965

## What changed

- validate section-local block types referenced by presets
- validate section-local block types referenced by `default.blocks`
- preserve valid references to locally declared blocks

## Root cause

`ValidBlockTarget` returned as soon as it found a local block declaration, so preset and default references were never checked. In addition, ordinary default block entries were omitted from the collected default-level blocks unless they happened to have a `name` property.

The check now compares top-level preset and default block types with the section's local declarations before returning. Theme-block validation remains on its existing path.

## Tests

- focused `ValidBlockTarget` suite: 73 passed
- full `theme-check-common` source suite: 4,855 passed
- `tsc -b packages/theme-check-common/tsconfig.build.json`
- `tsc -p packages/theme-check-common/tsconfig.json --noEmit`
- `pnpm format:check`
- `git diff --check`
