### PR TITLE
Require other in pluralized default translations

### DIFF
--- a/.changeset/plural-translations-require-other.md
+++ b/.changeset/plural-translations-require-other.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme-check-common': minor
+'@shopify/theme-check-node': minor
+---
+
+Require `other` in pluralized storefront default locale entries with `MatchingTranslations`. The new `requireOther` option defaults to `true`; set it to `false` to disable this requirement while keeping missing and extra translation diagnostics. Schema locales and plural categories in other languages are unchanged. Reports the offending entry without inventing a translation or offering an automatic fix.

--- a/packages/theme-check-common/src/checks/matching-translations/index.spec.ts
+++ b/packages/theme-check-common/src/checks/matching-translations/index.spec.ts
@@ -5,6 +5,130 @@ import { MatchingTranslations } from '../../checks/matching-translations/index';
 const prettyJSON = (json: any) => JSON.stringify(json, null, 2);
 
 describe('Module: MatchingTranslations', async () => {
+  it('should require other in a pluralized default translation', async () => {
+    const theme = {
+      'locales/en.default.json': JSON.stringify({ items: { one: 'One item' } }),
+    };
+
+    const offenses = await check(theme, [MatchingTranslations]);
+
+    expect(offenses).to.have.length(1);
+    expect(offenses).to.containOffense({
+      message: "The pluralized translation 'items' is missing the 'other' key",
+      uri: 'file:///locales/en.default.json',
+    });
+    expect(highlightedOffenses(theme, offenses)).to.deep.equal(['"items":{"one":"One item"}']);
+    expect(offenses[0].fix).to.be.undefined;
+    expect(offenses[0].suggest).to.be.undefined;
+  });
+
+  it.each(['zero', 'one', 'two', 'few', 'many'])(
+    'should recognize the complete plural category %s',
+    async (category) => {
+      const offenses = await check(
+        { 'locales/en.default.json': JSON.stringify({ items: { [category]: 'Items' } }) },
+        [MatchingTranslations],
+      );
+      expect(offenses).to.have.length(1);
+    },
+  );
+
+  it('should report each nested pluralized entry once with its source range', async () => {
+    const theme = {
+      'locales/en.default.json': prettyJSON({
+        cart: { items: { zero: 'No items', one: 'One item' } },
+        many: { results: { few: 'A few results', many: 'Many results' } },
+      }),
+    };
+    const offenses = await check(theme, [MatchingTranslations]);
+
+    expect(offenses).to.have.length(2);
+    for (const path of ['cart.items', 'many.results']) {
+      expect(offenses).to.containOffense({
+        message: `The pluralized translation '${path}' is missing the 'other' key`,
+        uri: 'file:///locales/en.default.json',
+      });
+    }
+    expect(highlightedOffenses(theme, offenses)).to.deep.equal([
+      '"items": {\n      "zero": "No items",\n      "one": "One item"\n    }',
+      '"results": {\n      "few": "A few results",\n      "many": "Many results"\n    }',
+    ]);
+  });
+
+  it.each([
+    ['other alone', { items: { other: '{{ count }} items' } }],
+    ['other with singular', { items: { one: 'One item', other: '{{ count }} items' } }],
+    ['ordinary strings', { title: 'Items' }],
+    ['empty objects', { items: {} }],
+    ['ordinary namespaces', { items: { title: 'Items', description: 'Your items' } }],
+    [
+      'category-like suffixes',
+      { items: { phone: 'Phone', someone: 'Someone', another: 'Another' } },
+    ],
+    ['mixed category and ordinary keys', { items: { one: 'One', title: 'Items' } }],
+    ['category ancestors', { one: { many: { title: 'Items' } } }],
+    ['category keys with object values', { items: { one: { title: 'One' } } }],
+    ['nonstring values', { items: { one: 1, few: null, many: true } }],
+    ['arrays', { items: [{ count: { one: 'One' } }] }],
+    [
+      'external namespaces',
+      { shopify: { items: { one: 'One' } }, customer_accounts: { one: 'One' } },
+    ],
+  ])('should not infer a missing other for %s', async (_name, translations) => {
+    const offenses = await check({ 'locales/en.default.json': JSON.stringify(translations) }, [
+      MatchingTranslations,
+    ]);
+    expect(offenses).to.have.length(0);
+  });
+
+  it.each([
+    'locales/fr.json',
+    'locales/en.default.schema.json',
+    'locales/fr.schema.json',
+    'assets/en.default.json',
+    'config/settings_data.json',
+  ])('should not require other in %s', async (file) => {
+    const offenses = await check({ [file]: JSON.stringify({ items: { one: 'One item' } }) }, [
+      MatchingTranslations,
+    ]);
+    expect(offenses).to.have.length(0);
+  });
+
+  it.each(['}', '{"items":{"one":"One item"}', '[]', 'null', '"Items"'])(
+    'should ignore malformed or non-object default translations: %s',
+    async (source) => {
+      const offenses = await check({ 'locales/en.default.json': source }, [MatchingTranslations]);
+      expect(offenses).to.have.length(0);
+    },
+  );
+
+  it.each([true, false])(
+    'should preserve missing and extra diagnostics with requireOther: %s',
+    async (requireOther) => {
+      const offenses = await check(
+        {
+          'locales/en.default.json': JSON.stringify({ items: { one: 'One item' }, title: 'Items' }),
+          'locales/fr.json': JSON.stringify({
+            items: { few: 'Quelques articles' },
+            extra: 'Extra',
+          }),
+        },
+        [MatchingTranslations],
+        {},
+        { MatchingTranslations: { enabled: true, requireOther } },
+      );
+      expect(offenses).to.have.length(requireOther ? 3 : 2);
+      expect(offenses).to.containOffense({
+        message: "The translation for 'title' is missing",
+        uri: 'file:///locales/fr.json',
+      });
+      expect(offenses).to.containOffense({
+        message: "A default translation for 'extra' does not exist",
+        uri: 'file:///locales/fr.json',
+      });
+    },
+  );
+
   it('should report offenses when the translation file is missing a key', async () => {
     for (const prefix of ['', '.schema']) {
       const theme = {

--- a/packages/theme-check-common/src/checks/matching-translations/index.ts
+++ b/packages/theme-check-common/src/checks/matching-translations/index.ts
@@ -5,11 +5,16 @@ import {
   Severity,
   SourceCodeType,
   PropertyNode,
+  SchemaProp,
 } from '../../types';
 
 const PLURALIZATION_KEYS = new Set(['zero', 'one', 'two', 'few', 'many', 'other']);
 
-export const MatchingTranslations: JSONCheckDefinition = {
+const schema = {
+  requireOther: SchemaProp.boolean(true),
+};
+
+export const MatchingTranslations: JSONCheckDefinition<typeof schema> = {
   meta: {
     code: 'MatchingTranslations',
     name: 'Translation files should have the same keys',
@@ -20,7 +25,7 @@ export const MatchingTranslations: JSONCheckDefinition = {
     },
     type: SourceCodeType.JSON,
     severity: Severity.ERROR,
-    schema: {},
+    schema,
     targets: [],
   },
 
@@ -38,7 +43,7 @@ export const MatchingTranslations: JSONCheckDefinition = {
       fileUri.endsWith('.default.json') || fileUri.endsWith('.default.schema.json');
     const isSchemaTranslationFile = fileUri.endsWith('.schema.json');
 
-    if (!isLocaleFile || isDefaultTranslationsFile || ast instanceof Error) {
+    if (!isLocaleFile || ast instanceof Error) {
       // No need to lint a file that isn't a translation file, we return an
       // empty object as the check for those.
       return {};
@@ -78,6 +83,39 @@ export const MatchingTranslations: JSONCheckDefinition = {
         .reduce((acc: string[], val) => acc.concat(val.key.value), [])
         .join('.');
     };
+
+    if (isDefaultTranslationsFile) {
+      if (isSchemaTranslationFile || !context.settings.requireOther) return {};
+
+      // Validate pluralized entries locally, without comparing the default locale to itself.
+      return {
+        async Property(node, ancestors) {
+          const value = node.value;
+          if (value.type !== 'Object' || value.children.length === 0) return;
+          if (ancestors.some((ancestor) => ancestor.type === 'Array')) return;
+          if (
+            !value.children.every(
+              (child) =>
+                isPluralizationNode(child) &&
+                child.value.type === 'Literal' &&
+                typeof child.value.value === 'string',
+            )
+          ) {
+            return;
+          }
+          if (value.children.some((child) => child.key.value === 'other')) return;
+
+          const path = objectPath(ancestors.concat(node));
+          if (isExternalPath(path) || path === 'shopify' || path === 'customer_accounts') return;
+
+          context.report({
+            message: `The pluralized translation '${path}' is missing the 'other' key`,
+            startIndex: node.loc.start.offset,
+            endIndex: node.loc.end.offset,
+          });
+        },
+      };
+    }
 
     const countCommonParts = (arrayA: string[], arrayB: string[]): number => {
       const minLength = Math.min(arrayA.length, arrayB.length);

--- a/packages/theme-check-node/configs/all.yml
+++ b/packages/theme-check-node/configs/all.yml
@@ -118,6 +118,7 @@ LiquidSyntaxError:
 MatchingTranslations:
   enabled: true
   severity: 0
+  requireOther: true
 MaxFileSize:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/configs/recommended.yml
+++ b/packages/theme-check-node/configs/recommended.yml
@@ -96,6 +96,7 @@ LiquidSyntaxError:
 MatchingTranslations:
   enabled: true
   severity: 0
+  requireOther: true
 MaxFileSize:
   enabled: true
   severity: 0

--- a/packages/theme-check-node/src/config/load-config.spec.ts
+++ b/packages/theme-check-node/src/config/load-config.spec.ts
@@ -9,7 +9,10 @@ import {
   recommended,
   Severity,
   SourceCodeType,
+  check as runChecks,
+  toSourceCode,
 } from '@shopify/theme-check-common';
+import { NodeFileSystem } from '../NodeFileSystem';
 import {
   createMockConfigFile,
   createMockNodeModule,
@@ -36,7 +39,31 @@ describe('Unit: loadConfig', () => {
     const config = await loadConfig(undefined, __dirname);
     expect(config.checks).to.eql(recommended);
     expect(config.context).to.eql('theme');
+    expect(config.settings.MatchingTranslations!.requireOther).to.equal(true);
   });
+
+  it.each([true, false])(
+    'passes requireOther: %s from YAML to MatchingTranslations',
+    async (requireOther) => {
+      const configPath = await createMockConfigFile(
+        tempDir,
+        `extends: nothing\nMatchingTranslations:\n  enabled: true\n  requireOther: ${requireOther}\n`,
+      );
+      const config = await loadConfig(configPath, tempDir);
+      const uri = URI.file(path.join(tempDir, 'locales/en.default.json')).toString();
+      const source = toSourceCode(uri, JSON.stringify({ items: { one: 'One item' } }))!;
+      const offenses = await runChecks([source], config, { fs: NodeFileSystem });
+
+      expect(offenses).to.have.length(requireOther ? 1 : 0);
+      if (requireOther) {
+        expect(offenses[0]).to.include({
+          check: 'MatchingTranslations',
+          uri: source.uri,
+          message: "The pluralized translation 'items' is missing the 'other' key",
+        });
+      }
+    },
+  );
 
   describe.each(['shopify.extension.toml', 'shopify.app.toml'])(
     'when the root contains a %s file',


### PR DESCRIPTION
## What are you adding in this PR?

Add a `requireOther` option to `MatchingTranslations`, enabled by default, to report recognized pluralized entries missing `other` in storefront default locale files.

Fixes #452.

For example, this entry in `locales/en.default.json` now produces a diagnostic:

```json
{
  "items": {
    "one": "One item"
  }
}
```

Reports: `The pluralized translation 'items' is missing the 'other' key`.

Adding an `other` translation resolves that diagnostic. Setting `MatchingTranslations.requireOther: false` disables only the new requirement and preserves the existing missing/extra translation checks:

```yaml
MatchingTranslations:
  requireOther: false
```

Detection is intentionally conservative: it recognizes non-empty objects whose immediate members are exact plural-category names with string values. Mixed namespaces and non-string structures are not treated as pluralization objects.

The change leaves schema locales and plural-category differences in other languages unchanged. It preserves external namespace exemptions and reports the affected property without inventing translation content or offering an automatic fix.

This intentionally adds a new default-on lint diagnostic. Themes with affected entries may need to add `other` or disable this requirement.

## What's next? Any followup issues?

A Shopify maintainer may need to update the internal shopify.dev documentation for `MatchingTranslations` to describe `requireOther`, its default, and its storefront-only scope. That internal documentation update has not been performed in this PR.

## Tophatting

For manual verification, use a storefront default locale containing `{"items":{"one":"One item"}}`. The rule should report the missing `other` entry. Adding `other` or setting `requireOther: false` should remove only that new diagnostic; existing missing/extra translation checks should remain active.

### Automated validation

Recorded on Windows with Node 24.19.0 and the checkout's pnpm 10.16.1:

| Command | Result |
| --- | --- |
| `pnpm exec vitest run packages/theme-check-common/src/checks/matching-translations/index.spec.ts` on the baseline with the new regression test | 18 existing tests passed; regression failed as expected: one diagnostic expected, zero received. The patched rule reports the missing `other` with the correct file, message and property range. |
| `pnpm exec vitest run packages/theme-check-common/src/checks/matching-translations/index.spec.ts packages/theme-check-node/src/config/load-config.spec.ts` | 74 tests passed, including 49 rule tests and real YAML-to-production configuration execution. |
| `pnpm exec vitest run packages/theme-check-common packages/theme-check-node` | 4,994 tests passed across 125 files. This includes the focused tests above; the counts are not additive. |
| `pnpm build` | Full workspace build passed, including factory configuration generation and the VS Code extension build. |
| `pnpm type-check` | Workspace type checks passed. |
| `pnpm format:check` | Source formatting passed. |
| `pnpm exec prettier --check .changeset/plural-translations-require-other.md packages/theme-check-node/configs/all.yml packages/theme-check-node/configs/recommended.yml` | Changeset and generated YAML formatting passed. |
| `git diff --check` and `git diff --check 65fd7743556a6fcb554f08fa58ee13a080a65b07 HEAD` | Patch integrity passed. |

The full monorepo unit suite, complete platform matrix, browser E2E and live-store integration were not run. Successful local validation was not repeated solely for publication.

## Before you deploy

- [x] This PR changes the configuration of a check.
  - [x] Included a minor changeset for `@shopify/theme-check-common` and `@shopify/theme-check-node`.
  - [x] Ran `pnpm build` and committed generated `all.yml` and `recommended.yml` updates with `requireOther: true`.
  - `theme-app-extension.yml` inherits the recommended configuration; no override is needed.
  - [ ] [Shopifolk] Update the internal shopify.dev Theme Check documentation.

## AI assistance

OpenAI Codex assisted with implementation and validation. The contributor personally reviewed the diff and diagnostic examples before submission.
