### PR TITLE
Fix liquid-html-parser argument edge cases

### DIFF
--- a/.changeset/liquid-parser-parity-fixes.md
+++ b/.changeset/liquid-parser-parity-fixes.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+Fix parser parity for legacy `render` and `include` arguments, trailing `reversed` loop flags, and empty filter argument lists.

--- a/packages/liquid-html-parser/src/ast.test.ts
+++ b/packages/liquid-html-parser/src/ast.test.ts
@@ -688,6 +688,23 @@ describe('Unit: Stage 2 (AST)', () => {
             namedArguments: [],
           },
           {
+            expression: `"card" with product: product as item, show_vendor: true`,
+            snippetType: 'String',
+            alias: {
+              value: 'item',
+            },
+            renderVariableExpression: {
+              kind: 'with',
+              name: {
+                type: 'VariableLookup',
+              },
+            },
+            namedArguments: [
+              { name: 'product', valueType: 'VariableLookup' },
+              { name: 'show_vendor', valueType: 'LiquidLiteral' },
+            ],
+          },
+          {
             expression: `"snippet" for products as product`,
             snippetType: 'String',
             alias: {
@@ -757,6 +774,19 @@ describe('Unit: Stage 2 (AST)', () => {
             }
           },
         );
+      });
+
+      it('should keep late aliases in regular render and include markup unparsed', () => {
+        const markups = [`"snippet", a: 1 as item`, `"snippet" with product, title: "T" as item`];
+
+        for (const { toAST, expectPath } of testCases) {
+          for (const tag of ['render', 'include']) {
+            for (const markup of markups) {
+              ast = toAST(`{% ${tag} ${markup} %}`);
+              expectPath(ast, 'children.0.markup').to.equal(markup);
+            }
+          }
+        }
       });
 
       it('should parse render tags with named args and no comma (Bug 23 regression)', () => {

--- a/packages/liquid-html-parser/src/document/liquid-variable-output.test.ts
+++ b/packages/liquid-html-parser/src/document/liquid-variable-output.test.ts
@@ -40,6 +40,50 @@ describe('Unit: liquid-variable-output', () => {
     expectPath(ast, 'children.0.markup.filters.0.name').to.eql('upcase');
   });
 
+  it.each(["{{ 'key' | t:}}", "{{ 'key' | t:  }}", "{{- 'key' | t:\n-}}"])(
+    'should parse an empty filter argument list in strict mode: %s',
+    (source) => {
+      for (const parse of [toLiquidHtmlAST, toLiquidAST]) {
+        const ast = parse(source, { mode: 'strict', allowUnclosedDocumentNode: false });
+        expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+        expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(1);
+        expectPath(ast, 'children.0.markup.filters.0.name').to.eql('t');
+        expectPath(ast, 'children.0.markup.filters.0.args').to.eql([]);
+        expectPath(ast, 'children.0.markup.rawSource').to.eql("'key' | t:");
+        expectPosition(ast, 'children.0.markup.filters.0').to.eql(' | t:');
+      }
+    },
+  );
+
+  it('should parse another filter after an empty argument list', () => {
+    const ast = toLiquidHtmlAST("{{ 'key' | t: | escape }}", {
+      mode: 'strict',
+      allowUnclosedDocumentNode: false,
+    });
+    expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(2);
+    expectPath(ast, 'children.0.markup.filters.0.name').to.eql('t');
+    expectPath(ast, 'children.0.markup.filters.0.args').to.eql([]);
+    expectPosition(ast, 'children.0.markup.filters.0').to.eql(' | t:');
+    expectPath(ast, 'children.0.markup.filters.1.name').to.eql('escape');
+    expectPosition(ast, 'children.0.markup.filters.1').to.eql(' | escape');
+  });
+
+  it.each([
+    "'key' | t: title:",
+    "'key' | t: title: | escape",
+    "'key' | t: ,",
+    "'key' | t: title: product.title,",
+    "'key' | t: @",
+  ])('should keep malformed filter arguments as string markup: %s', (markup) => {
+    for (const parse of [toLiquidHtmlAST, toLiquidAST]) {
+      const ast = parse(`{{ ${markup} }}`, {
+        mode: 'strict',
+        allowUnclosedDocumentNode: false,
+      });
+      expectPath(ast, 'children.0.markup').to.eql(markup);
+    }
+  });
+
   it('should parse multiple filters', () => {
     const ast = toLiquidHtmlAST('{{ product | upcase | strip }}');
     expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(2);

--- a/packages/liquid-html-parser/src/markup/parser.test.ts
+++ b/packages/liquid-html-parser/src/markup/parser.test.ts
@@ -902,6 +902,19 @@ describe('Unit: MarkupParser structured primitives', () => {
   });
 
   describe('filters()', () => {
+    it.each(['x | t:', 'x | upcase:  '])(
+      'includes the empty argument colon in the filter position: %s',
+      (source) => {
+        const p = parser(source);
+        p.expression();
+        const result = p.filters(1);
+        expect(result).toHaveLength(1);
+        expect(result[0].args).toEqual([]);
+        expect(result[0].position).toEqual({ start: 1, end: source.trimEnd().length });
+        expect(p.isAtEnd()).toBe(true);
+      },
+    );
+
     it('parses filter with no args', () => {
       const p = parser('x | upcase');
       p.expression(); // consume the expression first

--- a/packages/liquid-html-parser/src/markup/parser.ts
+++ b/packages/liquid-html-parser/src/markup/parser.ts
@@ -1215,15 +1215,22 @@ export class MarkupParser {
     return result;
   }
 
-  // filter := id (":" arguments)?
+  // filter := id (":" arguments?)?
   filter(previousEnd: number): LiquidFilter {
     const nameToken = this.consume(MarkupTokenType.Id);
     let args: LiquidArgument[] = [];
     let end = nameToken.end;
-    if (this.consumeOptional(MarkupTokenType.Colon)) {
-      // Lax: a colon with no following argument (`upcase:`) is tolerated; only
-      // parse arguments when something argument-like actually follows.
-      if (!(this.lax || this.tolerant) || this.atArgumentStart()) {
+    const colon = this.consumeOptional(MarkupTokenType.Colon);
+    if (colon) {
+      end = colon.end;
+      const atFilterBoundary = this.isAtEnd() || this.look(MarkupTokenType.Pipe);
+      const hasOnlyWhitespaceBeforeBoundary = !/\S/.test(
+        this.source.slice(colon.end, this.peek().start),
+      );
+      const emptyArguments = atFilterBoundary && hasOnlyWhitespaceBeforeBoundary;
+      // Strict mode accepts an empty list at a clean filter boundary. Recovery
+      // modes also skip malformed fragments that cannot start an argument.
+      if (!emptyArguments && (!(this.lax || this.tolerant) || this.atArgumentStart())) {
         args = this.arguments();
       }
       if (args.length > 0) {

--- a/packages/liquid-html-parser/src/tags/echo.test.ts
+++ b/packages/liquid-html-parser/src/tags/echo.test.ts
@@ -44,6 +44,23 @@ describe('echoTag', () => {
     });
   });
 
+  it("parses 'key' | t: with no arguments", () => {
+    const markup = "'key' | t:  ";
+    const result = echoTag.parse('echo', parser(markup), stubParser);
+    expect(result).toMatchObject({
+      type: NodeTypes.LiquidVariable,
+      rawSource: "'key' | t:",
+      filters: [
+        {
+          type: NodeTypes.LiquidFilter,
+          name: 't',
+          args: [],
+          position: { start: OFFSET + 5, end: OFFSET + 10 },
+        },
+      ],
+    });
+  });
+
   it("parses 'hello' | append: ' world'", () => {
     const result = echoTag.parse('echo', parser("'hello' | append: ' world'"), stubParser);
     expect(result).toMatchObject({

--- a/packages/liquid-html-parser/src/tags/for.test.ts
+++ b/packages/liquid-html-parser/src/tags/for.test.ts
@@ -85,6 +85,40 @@ describe('forTag', () => {
     expect(result.args).toHaveLength(2);
   });
 
+  it('parses for loop with reversed after named args', () => {
+    const result = forTag.parse('for', parser('item in collection limit:5 reversed'), stubParser);
+
+    expect(result).toMatchObject({
+      type: NodeTypes.ForMarkup,
+      variableName: 'item',
+      collection: { type: NodeTypes.VariableLookup, name: 'collection' },
+      reversed: true,
+    });
+    expect(result.args).toHaveLength(1);
+    expect(result.args[0]).toMatchObject({
+      type: NodeTypes.NamedArgument,
+      name: 'limit',
+      value: { type: NodeTypes.Number, value: '5' },
+    });
+  });
+
+  it.each([
+    ['for', forTag],
+    ['tablerow', tablerowTag],
+  ] as const)('parses reversed between named args for %s', (name, tag) => {
+    const markup = parser('item in collection limit:5 reversed offset:2');
+    const result = tag.parse(name, markup, stubParser);
+
+    expect(result).toMatchObject({
+      reversed: true,
+      args: [
+        { type: NodeTypes.NamedArgument, name: 'limit' },
+        { type: NodeTypes.NamedArgument, name: 'offset' },
+      ],
+    });
+    expect(markup.isAtEnd()).toBe(true);
+  });
+
   it('parses for loop with comma-separated named args', () => {
     const result = forTag.parse('for', parser('item in collection limit:5, offset:2'), stubParser);
     expect(result).toMatchObject({

--- a/packages/liquid-html-parser/src/tags/for.ts
+++ b/packages/liquid-html-parser/src/tags/for.ts
@@ -10,13 +10,17 @@ function parseForMarkup(_name: string, markup: MarkupParser, _parser: Parser): F
     throw new Error("Expected 'in'");
   }
   const collection = markup.valueExpression();
-  const reversed = markup.id('reversed');
+  let reversed = false;
 
   // Named args in for/tablerow accept optional commas between args
   // (matching Ruby's `p.consume?(:comma)` behavior).
   const args: LiquidNamedArgument[] = [];
   while (!markup.isAtEnd()) {
     markup.consumeOptional(MarkupTokenType.Comma);
+    if (markup.id('reversed')) {
+      reversed = true;
+      continue;
+    }
     if (markup.isLax()) {
       // Lax recovery (render-tree only; `toLiquidHtmlAST` parses strict, so this
       // branch never runs there): Ruby's lax `tablerow`/`for` parse stops at the

--- a/packages/liquid-html-parser/src/tags/render.test.ts
+++ b/packages/liquid-html-parser/src/tags/render.test.ts
@@ -115,6 +115,43 @@ describe('renderTag', () => {
     });
   });
 
+  it('parses legacy with-prefixed named arguments as an implicit variable and argument', () => {
+    const mp = parser("'font' with multiplier: 1.5");
+    const result = renderTag.parse('render', mp, stubParser);
+
+    expect(result).toMatchObject({
+      snippet: { type: NodeTypes.String, value: 'font' },
+      variable: {
+        type: NodeTypes.RenderVariableExpression,
+        kind: 'with',
+        name: { type: NodeTypes.VariableLookup, name: 'multiplier' },
+      },
+      alias: null,
+      args: [{ type: NodeTypes.NamedArgument, name: 'multiplier' }],
+    });
+    expect(mp.isAtEnd()).toBe(true);
+  });
+
+  it('parses an alias and named arguments after legacy with-prefixed arguments', () => {
+    const mp = parser(`"card" with product: product as item, show_vendor: true`);
+    const result = renderTag.parse('render', mp, stubParser);
+
+    expect(result).toMatchObject({
+      snippet: { type: NodeTypes.String, value: 'card' },
+      variable: {
+        type: NodeTypes.RenderVariableExpression,
+        kind: 'with',
+        name: { type: NodeTypes.VariableLookup, name: 'product' },
+      },
+      alias: { type: NodeTypes.RenderAliasExpression, value: 'item' },
+      args: [
+        { type: NodeTypes.NamedArgument, name: 'product' },
+        { type: NodeTypes.NamedArgument, name: 'show_vendor' },
+      ],
+    });
+    expect(mp.isAtEnd()).toBe(true);
+  });
+
   it('parses named arguments with trailing comma', () => {
     const markup =
       "'slideshow-slide', index: forloop.index0, children: children, media_fit: block_settings.media_fit,";
@@ -166,6 +203,31 @@ describe('renderTag', () => {
     expect(mp.isAtEnd()).toBe(true);
   });
 
+  it('does not parse an alias after regular named arguments', () => {
+    const mp = parser(`"snippet", a: 1 as item`);
+    const result = renderTag.parse('render', mp, stubParser);
+
+    expect(result.alias).toBeNull();
+    expect(result.args).toMatchObject([{ type: NodeTypes.NamedArgument, name: 'a' }]);
+    expect(mp.isAtEnd()).toBe(false);
+  });
+
+  it('does not parse a late alias after a regular with variable', () => {
+    const mp = parser(`"snippet" with product, title: "T" as item`);
+    const result = renderTag.parse('render', mp, stubParser);
+
+    expect(result).toMatchObject({
+      variable: {
+        type: NodeTypes.RenderVariableExpression,
+        kind: 'with',
+        name: { type: NodeTypes.VariableLookup, name: 'product' },
+      },
+      alias: null,
+      args: [{ type: NodeTypes.NamedArgument, name: 'title' }],
+    });
+    expect(mp.isAtEnd()).toBe(false);
+  });
+
   // Ruby render/include strict2_parse keys are a bare `id` immediately followed
   // by a colon (`key = p.consume; p.consume(:colon)`), NOT a dotted path. A
   // dotted key is not consumed as a named arg, leaving trailing tokens that fail
@@ -209,6 +271,79 @@ describe('includeTag', () => {
     expect(result.snippet).toMatchObject({ type: NodeTypes.String, value: 'snippet' });
     expect(result.args).toHaveLength(2);
     expect(mp.isAtEnd()).toBe(true);
+  });
+
+  it('parses legacy with-prefixed named arguments', () => {
+    const mp = parser(
+      "'image-style' with image: product.featured_image, width: max_height, small_style: true",
+    );
+    const result = includeTag.parse('include', mp, stubParser);
+
+    expect(result).toMatchObject({
+      snippet: { type: NodeTypes.String, value: 'image-style' },
+      variable: {
+        type: NodeTypes.RenderVariableExpression,
+        kind: 'with',
+        name: { type: NodeTypes.VariableLookup, name: 'image' },
+      },
+      alias: null,
+      args: [
+        { type: NodeTypes.NamedArgument, name: 'image' },
+        { type: NodeTypes.NamedArgument, name: 'width' },
+        { type: NodeTypes.NamedArgument, name: 'small_style' },
+      ],
+    });
+    expect(mp.isAtEnd()).toBe(true);
+  });
+
+  it('parses an alias and named arguments after legacy with-prefixed arguments', () => {
+    const mp = parser(`"card" with product: product as item, show_vendor: true`);
+    const result = includeTag.parse('include', mp, stubParser);
+
+    expect(result).toMatchObject({
+      variable: {
+        type: NodeTypes.RenderVariableExpression,
+        kind: 'with',
+        name: { type: NodeTypes.VariableLookup, name: 'product' },
+      },
+      alias: { type: NodeTypes.RenderAliasExpression, value: 'item' },
+      args: [
+        { type: NodeTypes.NamedArgument, name: 'product' },
+        { type: NodeTypes.NamedArgument, name: 'show_vendor' },
+      ],
+    });
+    expect(mp.isAtEnd()).toBe(true);
+  });
+
+  it('still parses include with a context variable', () => {
+    const mp = parser("'snippet' with product, title: 'Card'");
+    const result = includeTag.parse('include', mp, stubParser);
+
+    expect(result).toMatchObject({
+      variable: {
+        type: NodeTypes.RenderVariableExpression,
+        kind: 'with',
+        name: { type: NodeTypes.VariableLookup, name: 'product' },
+      },
+      args: [{ type: NodeTypes.NamedArgument, name: 'title' }],
+    });
+    expect(mp.isAtEnd()).toBe(true);
+  });
+
+  it('does not parse a late alias after a regular with variable', () => {
+    const mp = parser(`"snippet" with product, title: "T" as item`);
+    const result = includeTag.parse('include', mp, stubParser);
+
+    expect(result).toMatchObject({
+      variable: {
+        type: NodeTypes.RenderVariableExpression,
+        kind: 'with',
+        name: { type: NodeTypes.VariableLookup, name: 'product' },
+      },
+      alias: null,
+      args: [{ type: NodeTypes.NamedArgument, name: 'title' }],
+    });
+    expect(mp.isAtEnd()).toBe(false);
   });
 
   it('rejects a non-string template name for render (stricter parse)', () => {

--- a/packages/liquid-html-parser/src/tags/render.ts
+++ b/packages/liquid-html-parser/src/tags/render.ts
@@ -3,6 +3,7 @@ import type {
   RenderVariableExpression,
   RenderAliasExpression,
   LiquidNamedArgument,
+  LiquidVariableLookup,
 } from '../ast';
 import type { MarkupParser } from '../markup/parser';
 import { MarkupTokenType } from '../markup/tokenizer';
@@ -19,11 +20,46 @@ function looksLikeNamedArgument(markup: MarkupParser): boolean {
   return markup.look(MarkupTokenType.Id) && markup.look(MarkupTokenType.Colon, 1);
 }
 
+function looksLikeLegacyWithNamedArgumentPrefix(
+  markup: MarkupParser,
+  allowWithNamedArgumentPrefix: boolean,
+): boolean {
+  return (
+    allowWithNamedArgumentPrefix &&
+    markup.peek().type === MarkupTokenType.Id &&
+    markup.peek().value === 'with' &&
+    markup.look(MarkupTokenType.Id, 1) &&
+    markup.look(MarkupTokenType.Colon, 2)
+  );
+}
+
+function parseAlias(markup: MarkupParser, source: string): RenderAliasExpression | null {
+  const asStart = markup.peek().start;
+  if (!markup.id('as')) return null;
+  const aliasToken = markup.consume(MarkupTokenType.Id);
+  return {
+    type: NodeTypes.RenderAliasExpression,
+    value: aliasToken.value,
+    position: { start: asStart, end: aliasToken.end },
+    source,
+  };
+}
+
+function parseRenderNamedArguments(markup: MarkupParser, args: LiquidNamedArgument[]): void {
+  // Commas between named args are optional in Ruby `render` and `include`.
+  markup.consumeOptional(MarkupTokenType.Comma);
+  while (looksLikeNamedArgument(markup)) {
+    args.push(markup.namedArgument());
+    markup.consumeOptional(MarkupTokenType.Comma);
+  }
+}
+
 function parseRenderMarkup(
   _name: string,
   markup: MarkupParser,
   _parser: Parser,
   allowAnyTemplateName = false,
+  allowWithNamedArgumentPrefix = false,
 ): RenderMarkup {
   const snippet = markup.valueExpression();
   // Ruby `render` requires a quoted string template name at parse time
@@ -45,8 +81,32 @@ function parseRenderMarkup(
 
   let kind: 'for' | 'with' | null = null;
   const kwStart = markup.peek().start;
+  const hasWithNamedArgumentPrefix = looksLikeLegacyWithNamedArgumentPrefix(
+    markup,
+    allowWithNamedArgumentPrefix,
+  );
+
   if (markup.id('for')) {
     kind = 'for';
+  } else if (hasWithNamedArgumentPrefix) {
+    // Shopify Liquid treats `with key: value` as both `with key` and a named argument.
+    // Leave `key:` on the cursor so the named argument loop consumes it.
+    const withToken = markup.consume(MarkupTokenType.Id);
+    const nameToken = markup.peek();
+    const name: LiquidVariableLookup = {
+      type: NodeTypes.VariableLookup,
+      name: nameToken.value,
+      lookups: [],
+      position: { start: nameToken.start, end: nameToken.end },
+      source: snippet.source,
+    };
+    variable = {
+      type: NodeTypes.RenderVariableExpression,
+      kind: 'with',
+      name,
+      position: { start: withToken.start, end: nameToken.end },
+      source: snippet.source,
+    };
   } else if (markup.id('with')) {
     kind = 'with';
   }
@@ -62,29 +122,18 @@ function parseRenderMarkup(
     };
   }
 
-  // Handle 'as alias' — may appear after 'with expr' / 'for expr' or standalone
-  const asStart = markup.peek().start;
-  if (markup.id('as')) {
-    const aliasToken = markup.consume(MarkupTokenType.Id);
-    alias = {
-      type: NodeTypes.RenderAliasExpression,
-      value: aliasToken.value,
-      position: { start: asStart, end: aliasToken.end },
-      source: snippet.source,
-    };
-  }
+  // An alias can follow a regular `with` or `for` expression.
+  alias = parseAlias(markup, snippet.source);
 
   const args: LiquidNamedArgument[] = [];
-  // Commas between named args are optional in Ruby `render`/`include`
-  // (render.rb / include.rb strict2_parse: `p.consume?(:comma)` after each
-  // attribute). Both `{% render 'x', a: 1, b: 2 %}` and the space-separated
-  // `{% render 'x' a: 1 b: 2 %}` are valid. This is a render/include-local loop
-  // (NOT a change to the shared `namedArguments()`), so the strict AST for every
-  // other tag — and theme-check-common's parse-error detection — is unaffected.
-  markup.consumeOptional(MarkupTokenType.Comma);
-  while (looksLikeNamedArgument(markup)) {
-    args.push(markup.namedArgument());
-    markup.consumeOptional(MarkupTokenType.Comma);
+  parseRenderNamedArguments(markup, args);
+
+  if (alias === null && hasWithNamedArgumentPrefix) {
+    const lateAlias = parseAlias(markup, snippet.source);
+    if (lateAlias !== null) {
+      alias = lateAlias;
+      parseRenderNamedArguments(markup, args);
+    }
   }
 
   const end = markup.peek().start;
@@ -102,10 +151,10 @@ function parseRenderMarkup(
 
 export const renderTag: TagDefinitionTag<RenderMarkup> = {
   kind: TagKind.Tag,
-  parse: parseRenderMarkup,
+  parse: (name, markup, parser) => parseRenderMarkup(name, markup, parser, false, true),
 };
 
 export const includeTag: TagDefinitionTag<RenderMarkup> = {
   kind: TagKind.Tag,
-  parse: (name, markup, parser) => parseRenderMarkup(name, markup, parser, true),
+  parse: (name, markup, parser) => parseRenderMarkup(name, markup, parser, true, true),
 };

--- a/packages/liquid-html-parser/src/tolerant.test.ts
+++ b/packages/liquid-html-parser/src/tolerant.test.ts
@@ -44,6 +44,8 @@ describe('tolerant mode is inert on clean input', () => {
     '',
     'plain text only',
     '{{ product.title }}',
+    "{{ 'key' | t: }}",
+    "{{ 'key' | t: | escape }}",
     '{% assign x = 1 %}',
     '{% if x %}a{% else %}b{% endif %}',
     '{% for item in collection %}{{ item.title }}{% endfor %}',


### PR DESCRIPTION
## What are you adding in this PR?

Fix three `liquid-html-parser` argument edge cases:

- Parse legacy `render` and `include` forms such as `with product: product as item`.
- Accept `reversed` before, between, or after `for` and `tablerow` named arguments.
- Parse an empty filter argument list such as `{{ 'key' | t: }}` while preserving string-markup fallback for malformed arguments.

The parser, strict AST, tolerant AST, and tag-level tests cover these cases. This includes a patch changeset for `@shopify/liquid-html-parser`.

## What's next? Any followup issues?

None.

## Tophatting

Run `CI=1 pnpm test` from the repository root.

- [x] Screenshots are not applicable to parser-only changes.

## Before you deploy

- [x] I included a patch bump `changeset`.
