### PR TITLE
Parse empty filter argument lists

### DIFF
--- a/.changeset/empty-filter-arguments.md
+++ b/.changeset/empty-filter-arguments.md
@@ -1,0 +1,5 @@
+---
+'@shopify/liquid-html-parser': patch
+---
+
+Parse empty filter argument lists such as `{{ 'key' | t: }}`.

--- a/packages/liquid-html-parser/src/document/liquid-variable-output.test.ts
+++ b/packages/liquid-html-parser/src/document/liquid-variable-output.test.ts
@@ -40,6 +40,50 @@ describe('Unit: liquid-variable-output', () => {
     expectPath(ast, 'children.0.markup.filters.0.name').to.eql('upcase');
   });
 
+  it.each(["{{ 'key' | t:}}", "{{ 'key' | t:  }}", "{{- 'key' | t:\n-}}"])(
+    'should parse an empty filter argument list in strict mode: %s',
+    (source) => {
+      for (const parse of [toLiquidHtmlAST, toLiquidAST]) {
+        const ast = parse(source, { mode: 'strict', allowUnclosedDocumentNode: false });
+        expectPath(ast, 'children.0.markup.type').to.eql('LiquidVariable');
+        expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(1);
+        expectPath(ast, 'children.0.markup.filters.0.name').to.eql('t');
+        expectPath(ast, 'children.0.markup.filters.0.args').to.eql([]);
+        expectPath(ast, 'children.0.markup.rawSource').to.eql("'key' | t:");
+        expectPosition(ast, 'children.0.markup.filters.0').to.eql(' | t:');
+      }
+    },
+  );
+
+  it('should parse another filter after an empty argument list', () => {
+    const ast = toLiquidHtmlAST("{{ 'key' | t: | escape }}", {
+      mode: 'strict',
+      allowUnclosedDocumentNode: false,
+    });
+    expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(2);
+    expectPath(ast, 'children.0.markup.filters.0.name').to.eql('t');
+    expectPath(ast, 'children.0.markup.filters.0.args').to.eql([]);
+    expectPosition(ast, 'children.0.markup.filters.0').to.eql(' | t:');
+    expectPath(ast, 'children.0.markup.filters.1.name').to.eql('escape');
+    expectPosition(ast, 'children.0.markup.filters.1').to.eql(' | escape');
+  });
+
+  it.each([
+    "'key' | t: title:",
+    "'key' | t: title: | escape",
+    "'key' | t: ,",
+    "'key' | t: title: product.title,",
+    "'key' | t: @",
+  ])('should keep malformed filter arguments as string markup: %s', (markup) => {
+    for (const parse of [toLiquidHtmlAST, toLiquidAST]) {
+      const ast = parse(`{{ ${markup} }}`, {
+        mode: 'strict',
+        allowUnclosedDocumentNode: false,
+      });
+      expectPath(ast, 'children.0.markup').to.eql(markup);
+    }
+  });
+
   it('should parse multiple filters', () => {
     const ast = toLiquidHtmlAST('{{ product | upcase | strip }}');
     expectPath(ast, 'children.0.markup.filters').to.have.lengthOf(2);

--- a/packages/liquid-html-parser/src/markup/parser.test.ts
+++ b/packages/liquid-html-parser/src/markup/parser.test.ts
@@ -902,6 +902,19 @@ describe('Unit: MarkupParser structured primitives', () => {
   });
 
   describe('filters()', () => {
+    it.each(['x | t:', 'x | upcase:  '])(
+      'includes the empty argument colon in the filter position: %s',
+      (source) => {
+        const p = parser(source);
+        p.expression();
+        const result = p.filters(1);
+        expect(result).toHaveLength(1);
+        expect(result[0].args).toEqual([]);
+        expect(result[0].position).toEqual({ start: 1, end: source.trimEnd().length });
+        expect(p.isAtEnd()).toBe(true);
+      },
+    );
+
     it('parses filter with no args', () => {
       const p = parser('x | upcase');
       p.expression(); // consume the expression first

--- a/packages/liquid-html-parser/src/markup/parser.ts
+++ b/packages/liquid-html-parser/src/markup/parser.ts
@@ -1215,15 +1215,22 @@ export class MarkupParser {
     return result;
   }
 
-  // filter := id (":" arguments)?
+  // filter := id (":" arguments?)?
   filter(previousEnd: number): LiquidFilter {
     const nameToken = this.consume(MarkupTokenType.Id);
     let args: LiquidArgument[] = [];
     let end = nameToken.end;
-    if (this.consumeOptional(MarkupTokenType.Colon)) {
-      // Lax: a colon with no following argument (`upcase:`) is tolerated; only
-      // parse arguments when something argument-like actually follows.
-      if (!(this.lax || this.tolerant) || this.atArgumentStart()) {
+    const colon = this.consumeOptional(MarkupTokenType.Colon);
+    if (colon) {
+      end = colon.end;
+      const atFilterBoundary = this.isAtEnd() || this.look(MarkupTokenType.Pipe);
+      const hasOnlyWhitespaceBeforeBoundary = !/\S/.test(
+        this.source.slice(colon.end, this.peek().start),
+      );
+      const emptyArguments = atFilterBoundary && hasOnlyWhitespaceBeforeBoundary;
+      // Strict mode accepts an empty list at a clean filter boundary. Recovery
+      // modes also skip malformed fragments that cannot start an argument.
+      if (!emptyArguments && (!(this.lax || this.tolerant) || this.atArgumentStart())) {
         args = this.arguments();
       }
       if (args.length > 0) {

--- a/packages/liquid-html-parser/src/tags/echo.test.ts
+++ b/packages/liquid-html-parser/src/tags/echo.test.ts
@@ -44,6 +44,23 @@ describe('echoTag', () => {
     });
   });
 
+  it("parses 'key' | t: with no arguments", () => {
+    const markup = "'key' | t:  ";
+    const result = echoTag.parse('echo', parser(markup), stubParser);
+    expect(result).toMatchObject({
+      type: NodeTypes.LiquidVariable,
+      rawSource: "'key' | t:",
+      filters: [
+        {
+          type: NodeTypes.LiquidFilter,
+          name: 't',
+          args: [],
+          position: { start: OFFSET + 5, end: OFFSET + 10 },
+        },
+      ],
+    });
+  });
+
   it("parses 'hello' | append: ' world'", () => {
     const result = echoTag.parse('echo', parser("'hello' | append: ' world'"), stubParser);
     expect(result).toMatchObject({

--- a/packages/liquid-html-parser/src/tolerant.test.ts
+++ b/packages/liquid-html-parser/src/tolerant.test.ts
@@ -44,6 +44,8 @@ describe('tolerant mode is inert on clean input', () => {
     '',
     'plain text only',
     '{{ product.title }}',
+    "{{ 'key' | t: }}",
+    "{{ 'key' | t: | escape }}",
     '{% assign x = 1 %}',
     '{% if x %}a{% else %}b{% endif %}',
     '{% for item in collection %}{{ item.title }}{% endfor %}',


### PR DESCRIPTION
## What are you adding in this PR?

Parse a filter colon followed by the end of markup or another filter as an empty argument list.

These forms now produce a structured `LiquidVariable` with an empty `args` array, and the filter range includes the colon:

```liquid
{{ 'key' | t: }}
{{ 'key' | t: | escape }}
```

Malformed arguments such as `{{ 'key' | t: @ }}` continue to use string markup. Tests cover strict Liquid and LiquidHTML parsing, tolerant parsing, filter ranges, and `echo` tags.

## What's next? Any followup issues?

None.

## Tophatting

Run `CI=1 pnpm test` from the repository root.

- [x] Screenshots are not applicable to parser-only changes.

## Before you deploy

- [x] I included a patch bump `changeset`.
