### PR TITLE
Limit marketplace publishing tokens to the publish steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  VSCE_PAT: ${{ secrets.VSCE_PAT }}
-  OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   npm_config_registry: "https://registry.npmjs.org"
 
@@ -84,7 +82,11 @@ jobs:
       - name: VS Code Marketplace publish
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.marketplace-version.outputs.version != steps.package-version.outputs.version
         run: pnpm publish:vsce
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Open VSX Registry publish
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.marketplace-version.outputs.version != steps.package-version.outputs.version
         run: pnpm publish:ovsx
+        env:
+          OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -3,8 +3,6 @@ name: VS Code Release Workflow in a pinch
 on: workflow_dispatch
 
 env:
-  VSCE_PAT: ${{ secrets.VSCE_PAT }}
-  OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   npm_config_registry: "https://registry.npmjs.org"
 
@@ -39,6 +37,10 @@ jobs:
 
       - name: VS Code Marketplace publish
         run: pnpm publish:vsce
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Open VSX Registry publish
         run: pnpm publish:ovsx
+        env:
+          OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -5,7 +5,6 @@ on: workflow_dispatch
 env:
   VSCE_PAT: ${{ secrets.VSCE_PAT }}
   OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   npm_config_registry: "https://registry.npmjs.org"
 


### PR DESCRIPTION
The release workflows exposed release credentials more broadly than needed. `VSCE_PAT`, `OVSX_PAT`, and repo credentials were available to install/build steps even though only specific release steps need them.

This PR tightens that up:

- Removes `NPM_TOKEN` from `vscode-release.yml`. That workflow only publishes to the VS Code Marketplace and Open VSX; npm publishing lives in `release.yml` and already runs over OIDC.
- Moves `VSCE_PAT` and `OVSX_PAT` from workflow-level `env:` onto the `vsce publish` and `ovsx publish` steps in both workflows. `vsce show` hits the public gallery API and doesn't need the PAT.
- Removes workflow-level `GITHUB_TOKEN` from both workflows.
- Disables checkout credential persistence so install/build steps do not inherit authenticated git credentials.
- Keeps `GITHUB_TOKEN` scoped to `changesets/action` in `release.yml`, then clears the `.netrc` credentials that action writes before the marketplace publish steps.
- Adds explicit `contents: read` permissions to the manual VS Code release workflow.

Marketplace publishing authentication is unchanged; the required tokens are still available to the publish commands that need them.

## Tophatting

There should be no functional changes. The next `release.yml` run on `main` that ships a VS Code extension version bump should still publish to both marketplaces. If either publish step fails with an auth error, the env didn't make it onto the step.
