### PR TITLE
Preserve element type through sort/sort_natural filters

### DIFF
--- a/packages/theme-language-server-common/src/TypeSystem.spec.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.spec.ts
@@ -143,6 +143,16 @@ describe('Module: TypeSystem', () => {
             name: 'size',
             return_type: [{ type: 'number', name: '' }],
           },
+          {
+            // The docset declares sort as returning untyped[].
+            // See https://github.com/Shopify/theme-tools/issues/1086
+            name: 'sort',
+            return_type: [{ type: 'array', array_value: 'untyped' }],
+          },
+          {
+            name: 'sort_natural',
+            return_type: [{ type: 'array', array_value: 'untyped' }],
+          },
         ],
         systemTranslations: async () => ({}),
       },
@@ -257,6 +267,51 @@ describe('Module: TypeSystem', () => {
     const xVariable = (ast as any).children[0].markup as AssignMarkup;
     const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
     expect(inferredType).to.equal('number');
+  });
+
+  describe('when using the sort filter', () => {
+    // https://github.com/Shopify/theme-tools/issues/1086
+    it('should preserve the array value type', async () => {
+      const ast = toLiquidHtmlAST(`{% assign x = all_products | sort %}`);
+      const xVariable = (ast as any).children[0].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+      expect(inferredType).to.eql({ kind: 'array', valueType: 'product' });
+    });
+
+    it('should wrap a single value type into an array', async () => {
+      const ast = toLiquidHtmlAST(`{% assign x = product | sort %}`);
+      const xVariable = (ast as any).children[0].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+      expect(inferredType).to.eql({ kind: 'array', valueType: 'product' });
+    });
+
+    it('should preserve the array value type for sort_natural', async () => {
+      const ast = toLiquidHtmlAST(`{% assign x = all_products | sort_natural %}`);
+      const xVariable = (ast as any).children[0].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+      expect(inferredType).to.eql({ kind: 'array', valueType: 'product' });
+    });
+
+    it('should preserve the type through a filter chain ending in sort', async () => {
+      const ast = toLiquidHtmlAST(`{% assign x = all_products | sort | sort %}`);
+      const xVariable = (ast as any).children[0].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+      expect(inferredType).to.eql({ kind: 'array', valueType: 'product' });
+    });
+
+    it('should preserve the lookup type for untyped properties', async () => {
+      const ast = toLiquidHtmlAST(`{% assign x = product.metafields | sort %}`);
+      const xVariable = (ast as any).children[0].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+      expect(inferredType).to.eql({ kind: 'array', valueType: 'product_metafields' });
+    });
+
+    it('should fall back to the docset type for unknown input', async () => {
+      const ast = toLiquidHtmlAST(`{% assign x = unknown_variable | sort %}`);
+      const xVariable = (ast as any).children[0].markup as AssignMarkup;
+      const inferredType = await typeSystem.inferType(xVariable, ast, 'file:///file.liquid');
+      expect(inferredType).to.eql({ kind: 'array', valueType: 'untyped' });
+    });
   });
 
   describe('when using string builtin methods', () => {

--- a/packages/theme-language-server-common/src/TypeSystem.ts
+++ b/packages/theme-language-server-common/src/TypeSystem.ts
@@ -660,6 +660,21 @@ function inferType(
             return inferType(lastFilter.args[0], symbolsTable, objectMap, filtersMap);
           }
         }
+        if (lastFilter.name === 'sort' || lastFilter.name === 'sort_natural') {
+          // sort/sort_natural preserve the element type: an array input keeps its
+          // value type and a single value becomes a single-element array of that
+          // type (a common trick to coerce a drop into an array). The docset
+          // declares these filters as returning untyped[], which loses the type.
+          // See https://github.com/Shopify/theme-tools/issues/1086
+          const inputVariable = { ...thing, filters: thing.filters.slice(0, -1) };
+          const inputType = inferType(inputVariable, symbolsTable, objectMap, filtersMap);
+          if (isArrayType(inputType)) {
+            return inputType;
+          }
+          if (inputType !== Untyped && inputType !== Unknown) {
+            return arrayType(inputType);
+          }
+        }
         const filterEntry = filtersMap[lastFilter.name];
         return filterEntry ? filterEntryReturnType(filterEntry) : Untyped;
       } else {


### PR DESCRIPTION
Fixes #1086.

**Problem:** `media | sort` (the single-object-to-array trick) and `images | sort` both inferred as `untyped[]` because the docset declares `sort` as returning an untyped array — the element type was lost.

**Fix** (`TypeSystem.ts`, `LiquidVariable` inference): when the last filter is `sort`/`sort_natural`, infer the input type instead of using the docset return type —
- array input keeps its value type (`product[] | sort` → `product[]`)
- single typed value wraps into an array type (`media | sort` → `media[]`), chain-safe via recursion without the last filter
- `untyped`/`unknown` input falls back to the docset type (no behavior change there)

**Tests:** 6 new cases in `TypeSystem.spec.ts` (array preserve, single-value wrap, `sort_natural`, chained sorts, lookup-type preserve, unknown fallback). Suite: 35 passed, 1 skipped (pre-existing skip).